### PR TITLE
Factor out "PersistTransaction" as a common database utility

### DIFF
--- a/internal/events/batch_pin_complete.go
+++ b/internal/events/batch_pin_complete.go
@@ -64,57 +64,8 @@ func (em *eventManager) handlePrivatePinComplete(batchPin *blockchain.BatchPin, 
 	})
 }
 
-func subjectMatch(a *fftypes.TransactionSubject, b *fftypes.TransactionSubject) bool {
-	return a.Type == b.Type &&
-		a.Signer == b.Signer &&
-		a.Reference != nil && b.Reference != nil &&
-		*a.Reference == *b.Reference &&
-		a.Namespace == b.Namespace
-}
-
-func (em *eventManager) persistTransaction(ctx context.Context, tx *fftypes.Transaction) (valid bool, err error) {
-	if err := fftypes.ValidateFFNameField(ctx, tx.Subject.Namespace, "namespace"); err != nil {
-		log.L(ctx).Errorf("Invalid transaction ID='%s' Reference='%s' - invalid namespace '%s': %a", tx.ID, tx.Subject.Reference, tx.Subject.Namespace, err)
-		return false, nil // this is not retryable
-	}
-	existing, err := em.database.GetTransactionByID(ctx, tx.ID)
-	if err != nil {
-		return false, err // a peristence failure here is considered retryable (so returned)
-	}
-
-	switch {
-	case existing == nil:
-		// We're the first to write the transaction record on this node
-		tx.Created = fftypes.Now()
-		tx.Hash = tx.Subject.Hash()
-
-	case subjectMatch(&tx.Subject, &existing.Subject):
-		// This is an update to an existing transaction, but the subject is the same
-		tx.Created = existing.Created
-		tx.Hash = existing.Hash
-
-	default:
-		log.L(ctx).Errorf("Invalid transaction ID='%s' Reference='%s' - does not match existing subject", tx.ID, tx.Subject.Reference)
-		return false, nil // this is not retryable
-	}
-
-	// Upsert the transaction, ensuring the hash does not change
-	tx.Status = fftypes.OpStatusSucceeded
-	err = em.database.UpsertTransaction(ctx, tx, false)
-	if err != nil {
-		if err == database.HashMismatch {
-			log.L(ctx).Errorf("Invalid transaction ID='%s' Reference='%s' - hash mismatch with existing record '%s'", tx.ID, tx.Subject.Reference, tx.Hash)
-			return false, nil // this is not retryable
-		}
-		log.L(ctx).Errorf("Failed to insert transaction ID='%s' Reference='%s': %a", tx.ID, tx.Subject.Reference, err)
-		return false, err // a peristence failure here is considered retryable (so returned)
-	}
-
-	return true, nil
-}
-
 func (em *eventManager) persistBatchTransaction(ctx context.Context, batchPin *blockchain.BatchPin, signingIdentity string, protocolTxID string, additionalInfo fftypes.JSONObject) (valid bool, err error) {
-	return em.persistTransaction(ctx, &fftypes.Transaction{
+	return database.PersistTransaction(ctx, em.database, &fftypes.Transaction{
 		ID: batchPin.TransactionID,
 		Subject: fftypes.TransactionSubject{
 			Namespace: batchPin.Namespace,

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -30,7 +30,7 @@ func (em *eventManager) persistTokenPoolTransaction(ctx context.Context, pool *f
 		log.L(ctx).Errorf("Invalid token pool '%s'. Missing ID (%v) or transaction ID (%v)", pool.ID, pool.ID, pool.TX.ID)
 		return false, nil // this is not retryable
 	}
-	return em.persistTransaction(ctx, &fftypes.Transaction{
+	return database.PersistTransaction(ctx, em.database, &fftypes.Transaction{
 		ID: pool.TX.ID,
 		Subject: fftypes.TransactionSubject{
 			Namespace: pool.Namespace,

--- a/pkg/database/common.go
+++ b/pkg/database/common.go
@@ -1,0 +1,73 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/firefly/internal/log"
+	"github.com/hyperledger-labs/firefly/pkg/fftypes"
+)
+
+func subjectMatch(a *fftypes.TransactionSubject, b *fftypes.TransactionSubject) bool {
+	return a.Type == b.Type &&
+		a.Signer == b.Signer &&
+		a.Reference != nil && b.Reference != nil &&
+		*a.Reference == *b.Reference &&
+		a.Namespace == b.Namespace
+}
+
+func PersistTransaction(ctx context.Context, plugin Plugin, tx *fftypes.Transaction) (valid bool, err error) {
+	if err := fftypes.ValidateFFNameField(ctx, tx.Subject.Namespace, "namespace"); err != nil {
+		log.L(ctx).Errorf("Invalid transaction ID='%s' Reference='%s' - invalid namespace '%s': %a", tx.ID, tx.Subject.Reference, tx.Subject.Namespace, err)
+		return false, nil // this is not retryable
+	}
+	existing, err := plugin.GetTransactionByID(ctx, tx.ID)
+	if err != nil {
+		return false, err // a peristence failure here is considered retryable (so returned)
+	}
+
+	switch {
+	case existing == nil:
+		// We're the first to write the transaction record on this node
+		tx.Created = fftypes.Now()
+		tx.Hash = tx.Subject.Hash()
+
+	case subjectMatch(&tx.Subject, &existing.Subject):
+		// This is an update to an existing transaction, but the subject is the same
+		tx.Created = existing.Created
+		tx.Hash = existing.Hash
+
+	default:
+		log.L(ctx).Errorf("Invalid transaction ID='%s' Reference='%s' - does not match existing subject", tx.ID, tx.Subject.Reference)
+		return false, nil // this is not retryable
+	}
+
+	// Upsert the transaction, ensuring the hash does not change
+	tx.Status = fftypes.OpStatusSucceeded
+	err = plugin.UpsertTransaction(ctx, tx, false)
+	if err != nil {
+		if err == HashMismatch {
+			log.L(ctx).Errorf("Invalid transaction ID='%s' Reference='%s' - hash mismatch with existing record '%s'", tx.ID, tx.Subject.Reference, tx.Hash)
+			return false, nil // this is not retryable
+		}
+		log.L(ctx).Errorf("Failed to insert transaction ID='%s' Reference='%s': %a", tx.ID, tx.Subject.Reference, err)
+		return false, err // a peristence failure here is considered retryable (so returned)
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
No idea where would be the appropriate place for this... but this general logic of validating and marking
a transaction complete is going to be needed outside of `events` (specifically, tokens look to be
introducing a new type of transaction that will be marked complete by a call in `syshandler`).

This logic is all transaction- and database-related (not particularly related to events). It's also not
particular to a specific database (ie SQL), although some of the checks could be pushed down into
the SQLCommon handler. Looking for input on whether a common utility like this is a good idea, or
if there's a better way to handle this common logic across packages.