### PR TITLE
Rename tokens "https" plugin to "fftokens"

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -324,13 +324,28 @@ func (or *orchestrator) initPlugins(ctx context.Context) (err error) {
 		for i := 0; i < tokensConfig.ArraySize(); i++ {
 			prefix := tokensConfig.ArrayEntry(i)
 			name := prefix.GetString(tokens.TokensConfigName)
-			connector := prefix.GetString(tokens.TokensConfigConnector)
-			if name == "" || connector == "" {
+			pluginName := prefix.GetString(tokens.TokensConfigPlugin)
+			if name == "" {
 				return i18n.NewError(ctx, i18n.MsgMissingTokensPluginConfig)
 			}
+			if pluginName == "" {
+				// Migration path for old config key
+				// TODO: eventually make this fatal
+				pluginName = prefix.GetString(tokens.TokensConfigConnector)
+				if pluginName == "" {
+					return i18n.NewError(ctx, i18n.MsgMissingTokensPluginConfig)
+				}
+				log.L(ctx).Warnf("Your tokens config uses the deprecated 'connector' key - please change to 'plugin' instead")
+			}
+			if pluginName == "https" {
+				// Migration path for old plugin name
+				// TODO: eventually make this fatal
+				log.L(ctx).Warnf("Your tokens config uses the old plugin name 'https' - this plugin has been renamed to 'fftokens'")
+				pluginName = "fftokens"
+			}
 
-			log.L(ctx).Infof("Loading tokens plugin name=%s connector=%s", name, connector)
-			plugin, err := tifactory.GetPlugin(ctx, connector)
+			log.L(ctx).Infof("Loading tokens plugin name=%s plugin=%s", name, pluginName)
+			plugin, err := tifactory.GetPlugin(ctx, pluginName)
 			if plugin != nil {
 				err = plugin.Init(ctx, name, prefix, &or.bc)
 			}

--- a/internal/tokens/fftokens/config.go
+++ b/internal/tokens/fftokens/config.go
@@ -14,13 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package https
+package fftokens
 
 import (
 	"github.com/hyperledger/firefly/internal/config"
 	"github.com/hyperledger/firefly/internal/wsclient"
 )
 
-func (h *HTTPS) InitPrefix(prefix config.PrefixArray) {
+func (h *FFTokens) InitPrefix(prefix config.PrefixArray) {
 	wsclient.InitPrefix(prefix)
 }

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package https
+package fftokens
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 	"github.com/hyperledger/firefly/pkg/tokens"
 )
 
-type HTTPS struct {
+type FFTokens struct {
 	ctx            context.Context
 	capabilities   *tokens.Capabilities
 	callbacks      tokens.Callbacks
@@ -65,18 +65,17 @@ type createPoolData struct {
 	TransactionID *fftypes.UUID `json:"transactionId"`
 }
 
-func (h *HTTPS) Name() string {
-	return "https"
+func (h *FFTokens) Name() string {
+	return "fftokens"
 }
 
-func (h *HTTPS) Init(ctx context.Context, name string, prefix config.Prefix, callbacks tokens.Callbacks) (err error) {
-
-	h.ctx = log.WithLogField(ctx, "proto", "https")
+func (h *FFTokens) Init(ctx context.Context, name string, prefix config.Prefix, callbacks tokens.Callbacks) (err error) {
+	h.ctx = log.WithLogField(ctx, "proto", "fftokens")
 	h.callbacks = callbacks
 	h.configuredName = name
 
 	if prefix.GetString(restclient.HTTPConfigURL) == "" {
-		return i18n.NewError(ctx, i18n.MsgMissingPluginConfig, "url", "tokens.https")
+		return i18n.NewError(ctx, i18n.MsgMissingPluginConfig, "url", "tokens.fftokens")
 	}
 
 	h.client = restclient.New(h.ctx, prefix)
@@ -95,15 +94,15 @@ func (h *HTTPS) Init(ctx context.Context, name string, prefix config.Prefix, cal
 	return nil
 }
 
-func (h *HTTPS) Start() error {
+func (h *FFTokens) Start() error {
 	return h.wsconn.Connect()
 }
 
-func (h *HTTPS) Capabilities() *tokens.Capabilities {
+func (h *FFTokens) Capabilities() *tokens.Capabilities {
 	return h.capabilities
 }
 
-func (h *HTTPS) handleReceipt(ctx context.Context, data fftypes.JSONObject) error {
+func (h *FFTokens) handleReceipt(ctx context.Context, data fftypes.JSONObject) error {
 	l := log.L(ctx)
 
 	requestID := data.GetString("id")
@@ -121,7 +120,7 @@ func (h *HTTPS) handleReceipt(ctx context.Context, data fftypes.JSONObject) erro
 	return h.callbacks.TokensTxUpdate(h, requestID, updateType, message, data)
 }
 
-func (h *HTTPS) handleTokenPoolCreate(ctx context.Context, data fftypes.JSONObject) (err error) {
+func (h *FFTokens) handleTokenPoolCreate(ctx context.Context, data fftypes.JSONObject) (err error) {
 	packedData := data.GetString("data")
 	tokenType := data.GetString("type")
 	protocolID := data.GetString("poolId")
@@ -169,7 +168,7 @@ func (h *HTTPS) handleTokenPoolCreate(ctx context.Context, data fftypes.JSONObje
 	return h.callbacks.TokenPoolCreated(h, pool, operatorAddress, txHash, tx)
 }
 
-func (h *HTTPS) eventLoop() {
+func (h *FFTokens) eventLoop() {
 	defer h.wsconn.Close()
 	l := log.L(h.ctx).WithField("role", "event-loop")
 	ctx := log.WithLogger(h.ctx, l)
@@ -219,7 +218,7 @@ func (h *HTTPS) eventLoop() {
 	}
 }
 
-func (h *HTTPS) CreateTokenPool(ctx context.Context, identity *fftypes.Identity, pool *fftypes.TokenPool) error {
+func (h *FFTokens) CreateTokenPool(ctx context.Context, identity *fftypes.Identity, pool *fftypes.TokenPool) error {
 	data := createPoolData{
 		Namespace:     pool.Namespace,
 		Name:          pool.Name,

--- a/internal/tokens/tifactory/factory.go
+++ b/internal/tokens/tifactory/factory.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/hyperledger/firefly/internal/config"
 	"github.com/hyperledger/firefly/internal/i18n"
-	"github.com/hyperledger/firefly/internal/tokens/https"
+	"github.com/hyperledger/firefly/internal/tokens/fftokens"
 	"github.com/hyperledger/firefly/pkg/tokens"
 )
 
 var plugins = []tokens.Plugin{
-	&https.HTTPS{},
+	&fftokens.FFTokens{},
 }
 
 var pluginsByName = make(map[string]tokens.Plugin)
@@ -39,6 +39,7 @@ func init() {
 
 func InitPrefix(prefix config.PrefixArray) {
 	prefix.AddKnownKey(tokens.TokensConfigConnector)
+	prefix.AddKnownKey(tokens.TokensConfigPlugin)
 	prefix.AddKnownKey(tokens.TokensConfigName)
 	for _, plugin := range plugins {
 		// Accept a superset of configs allowed by all plugins

--- a/pkg/tokens/config.go
+++ b/pkg/tokens/config.go
@@ -19,6 +19,8 @@ package tokens
 const (
 	// TokensConfigName is the user-supplied name for this token type
 	TokensConfigName = "name"
-	// TokensConfigConnector is the connector plugin used for this token type
-	TokensConfigConnector = "connector"
+	// TokensConfigConnector is the connector plugin used for this token type (deprecated)
+	TokensConfigConnector = "connector" // TODO: remove
+	// TokensConfigPlugin is the connector plugin used for this token type
+	TokensConfigPlugin = "plugin"
 )


### PR DESCRIPTION
The name "https" is too generic - the plugin represents a way to map token operations
like pool, mint, and transfer into a specific HTTP+websocket protocol. Therefore a
specific, unique name is appropriate.

Also changed the config key from "connector" to "plugin" (since its purpose is to
affect which plugin FireFly loads from the map).

Added migration paths for both changes so that the CLI and any existing stacks can
have time to be updated.