### PR TITLE
Allow null value with blob data, and allow "none" validator to tag datatype on unstructured data

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -665,6 +665,7 @@ paths:
                 validator:
                   enum:
                   - json
+                  - none
                   - definition
                   type: string
                 value:
@@ -1639,6 +1640,7 @@ paths:
                 validator:
                   enum:
                   - json
+                  - none
                   - definition
                   type: string
                 value:

--- a/internal/apiserver/route_post_data.go
+++ b/internal/apiserver/route_post_data.go
@@ -55,6 +55,16 @@ var postData = &oapispec.Route{
 	},
 	FormUploadHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
 		data := &fftypes.DataRefOrValue{}
+		validator := r.FP["validator"]
+		if len(validator) > 0 {
+			data.Validator = fftypes.ValidatorType(validator)
+		}
+		if r.FP["datatype.name"] != "" {
+			data.Datatype = &fftypes.DatatypeRef{
+				Name:    r.FP["datatype.name"],
+				Version: r.FP["datatype.version"],
+			}
+		}
 		metadata := r.FP["metadata"]
 		if len(metadata) > 0 {
 			// The metadata might be JSON, or just a simple string. Try to unmarshal and see
@@ -63,13 +73,6 @@ var postData = &oapispec.Route{
 				metadata = fmt.Sprintf(`"%s"`, metadata)
 			}
 			data.Value = fftypes.Byteable(metadata)
-			data.Validator = fftypes.ValidatorType(r.FP["validator"])
-			if r.FP["datatype.name"] != "" {
-				data.Datatype = &fftypes.DatatypeRef{
-					Name:    r.FP["datatype.name"],
-					Version: r.FP["datatype.version"],
-				}
-			}
 		}
 		output, err = r.Or.Data().UploadBLOB(r.Ctx, r.PP["ns"], data, r.Part, strings.EqualFold(r.FP["autometa"], "true"))
 		return output, err

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -157,7 +157,7 @@ func (dm *dataManager) GetMessageData(ctx context.Context, msg *fftypes.Message,
 
 func (dm *dataManager) ValidateAll(ctx context.Context, data []*fftypes.Data) (valid bool, err error) {
 	for _, d := range data {
-		if d.Datatype != nil {
+		if d.Datatype != nil && d.Validator != fftypes.ValidatorTypeNone {
 			v, err := dm.getValidatorForDatatype(ctx, d.Namespace, d.Validator, d.Datatype)
 			if err != nil {
 				return false, err

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -274,7 +274,9 @@ func TestBadDataExchangeInitFail(t *testing.T) {
 
 func TestBadTokensPlugin(t *testing.T) {
 	or := newTestOrchestrator()
-	tokensConfig.AddKnownKey(tokens.TokensConfigName, "test")
+	tokensConfig = config.NewPluginConfig("tokens").Array()
+	tifactory.InitPrefix(tokensConfig)
+	tokensConfig.AddKnownKey(tokens.TokensConfigName, "text")
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "wrong")
 	config.Set("tokens", []fftypes.JSONObject{{}})
 	or.tokens = nil
@@ -294,6 +296,8 @@ func TestBadTokensPlugin(t *testing.T) {
 
 func TestBadTokensPluginNoName(t *testing.T) {
 	or := newTestOrchestrator()
+	tokensConfig = config.NewPluginConfig("tokens").Array()
+	tifactory.InitPrefix(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName)
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "wrong")
 	config.Set("tokens", []fftypes.JSONObject{{}})
@@ -312,8 +316,31 @@ func TestBadTokensPluginNoName(t *testing.T) {
 	assert.Regexp(t, "FF10273", err)
 }
 
+func TestBadTokensPluginNoType(t *testing.T) {
+	or := newTestOrchestrator()
+	tokensConfig = config.NewPluginConfig("tokens").Array()
+	tifactory.InitPrefix(tokensConfig)
+	tokensConfig.AddKnownKey(tokens.TokensConfigName, "text")
+	tokensConfig.AddKnownKey(tokens.TokensConfigConnector)
+	config.Set("tokens", []fftypes.JSONObject{{}})
+	or.tokens = nil
+	or.mdi.On("GetConfigRecords", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.ConfigRecord{}, nil, nil)
+	or.mdi.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	or.mbi.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	or.mii.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	or.mbi.On("VerifyIdentitySyntax", mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
+	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	err := or.Init(ctx, cancelCtx)
+	assert.Regexp(t, "FF10273", err)
+}
+
 func TestGoodTokensPlugin(t *testing.T) {
 	or := newTestOrchestrator()
+	tokensConfig = config.NewPluginConfig("tokens").Array()
 	tifactory.InitPrefix(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName, "test")
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "https")

--- a/pkg/fftypes/byteable_test.go
+++ b/pkg/fftypes/byteable_test.go
@@ -77,7 +77,7 @@ func TestByteableMarshalNull(t *testing.T) {
 	var pb Byteable
 	b, err := pb.MarshalJSON()
 	assert.NoError(t, err)
-	assert.Equal(t, "null", string(b))
+	assert.Equal(t, nullString, string(b))
 }
 
 func TestByteableUnmarshalFail(t *testing.T) {
@@ -88,4 +88,20 @@ func TestByteableUnmarshalFail(t *testing.T) {
 
 	jo := b.JSONObject()
 	assert.Equal(t, JSONObject{}, jo)
+}
+
+func TestScan(t *testing.T) {
+
+	var h Byteable
+	assert.NoError(t, h.Scan(nil))
+	assert.Equal(t, []byte(nullString), []byte(h))
+
+	assert.NoError(t, h.Scan(`{"some": "stuff"}`))
+	assert.Equal(t, "stuff", h.JSONObject().GetString("some"))
+
+	assert.NoError(t, h.Scan([]byte(`{"some": "stuff"}`)))
+	assert.Equal(t, "stuff", h.JSONObject().GetString("some"))
+
+	assert.Regexp(t, "FF10125", h.Scan(12345))
+
 }

--- a/pkg/fftypes/data_test.go
+++ b/pkg/fftypes/data_test.go
@@ -19,6 +19,7 @@ package fftypes
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ import (
 func TestDatatypeReference(t *testing.T) {
 
 	var dr *DatatypeRef
-	assert.Equal(t, "null", dr.String())
+	assert.Equal(t, nullString, dr.String())
 	dr = &DatatypeRef{
 		Name:    "customer",
 		Version: "0.0.1",
@@ -61,7 +62,7 @@ func TestSealBlobOnly(t *testing.T) {
 	}
 	err := d.Seal(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, d.Hash.String(), "22440fcf4ee9ac8c1a83de36c3a9ef39f838d960971dc79b274718392f1735f9")
+	assert.Equal(t, "22440fcf4ee9ac8c1a83de36c3a9ef39f838d960971dc79b274718392f1735f9", d.Hash.String())
 }
 
 func TestSealBlobAndHashOnly(t *testing.T) {
@@ -76,4 +77,33 @@ func TestSealBlobAndHashOnly(t *testing.T) {
 	err := d.Seal(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, d.Hash[:], h[:])
+}
+
+func TestHashDataNull(t *testing.T) {
+
+	jd := []byte(`{
+		"id": "a64addf8-00e2-4210-9474-477e93b7f8dc",
+		"validator": "none",
+		"namespace": "default",
+		"hash": "3e12f246f0d16ab3fe6d15d15161ca5de8a00991c98fa12cea1b9733ea9832da",
+		"created": "2021-09-25T05:07:53.5847572Z",
+		"datatype": {
+			"name": "myblob"
+		},
+		"value": null,
+		"blob": {
+			"hash": "6014cbaf6bde9f9d755f347cb326db88859475e9d1a215d5dc4ccd8ae9caec7c"
+		}
+	}`)
+	var d Data
+	err := json.Unmarshal(jd, &d)
+	assert.NoError(t, err)
+
+	// Note that the processing of "null" means the value does not contribute to the hash
+	expectedHash, err := ParseBytes32(context.Background(), "6014cbaf6bde9f9d755f347cb326db88859475e9d1a215d5dc4ccd8ae9caec7c")
+	assert.NoError(t, err)
+	hash, err := d.CalcHash(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHash.String(), hash.String())
+
 }

--- a/pkg/fftypes/datatype.go
+++ b/pkg/fftypes/datatype.go
@@ -27,6 +27,8 @@ type ValidatorType = FFEnum
 var (
 	// ValidatorTypeJSON is the validator type for JSON Schema validation
 	ValidatorTypeJSON ValidatorType = ffEnum("validatortype", "json")
+	// ValidatorTypeNone explicitly disables validation, even when a datatype is set. Allowing cateogration of datatype without validation.
+	ValidatorTypeNone ValidatorType = ffEnum("validatortype", "none")
 	// ValidatorTypeSystemDefinition is the validator type for system definitions
 	ValidatorTypeSystemDefinition ValidatorType = ffEnum("validatortype", "definition")
 )

--- a/pkg/fftypes/datatype.go
+++ b/pkg/fftypes/datatype.go
@@ -27,7 +27,7 @@ type ValidatorType = FFEnum
 var (
 	// ValidatorTypeJSON is the validator type for JSON Schema validation
 	ValidatorTypeJSON ValidatorType = ffEnum("validatortype", "json")
-	// ValidatorTypeNone explicitly disables validation, even when a datatype is set. Allowing cateogration of datatype without validation.
+	// ValidatorTypeNone explicitly disables validation, even when a datatype is set. Allowing categorization of datatype without validation.
 	ValidatorTypeNone ValidatorType = ffEnum("validatortype", "none")
 	// ValidatorTypeSystemDefinition is the validator type for system definitions
 	ValidatorTypeSystemDefinition ValidatorType = ffEnum("validatortype", "definition")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -328,7 +328,7 @@ func TestE2EBroadcastBlob(t *testing.T) {
 
 }
 
-func TestE2EPrivateBlob(t *testing.T) {
+func TestE2EPrivateBlobDatatypeTagged(t *testing.T) {
 
 	ts := beforeE2ETest(t)
 	defer ts.done()
@@ -338,7 +338,7 @@ func TestE2EPrivateBlob(t *testing.T) {
 
 	var resp *resty.Response
 
-	resp, err := PrivateBlobMessage(t, ts.client1, []string{
+	resp, err := PrivateBlobMessageDatatypeTagged(t, ts.client1, []string{
 		ts.org1.Name,
 		ts.org2.Name,
 	})
@@ -346,12 +346,10 @@ func TestE2EPrivateBlob(t *testing.T) {
 	assert.Equal(t, 202, resp.StatusCode())
 
 	<-received1
-	val1 := validateReceivedMessages(ts, ts.client1, fftypes.MessageTypePrivate, fftypes.TransactionTypeBatchPin, 1, 0)
-	assert.Regexp(t, "myfile.txt", string(val1))
+	_ = validateReceivedMessages(ts, ts.client1, fftypes.MessageTypePrivate, fftypes.TransactionTypeBatchPin, 1, 0)
 
 	<-received2
-	val2 := validateReceivedMessages(ts, ts.client2, fftypes.MessageTypePrivate, fftypes.TransactionTypeBatchPin, 1, 0)
-	assert.Regexp(t, "myfile.txt", string(val2))
+	_ = validateReceivedMessages(ts, ts.client2, fftypes.MessageTypePrivate, fftypes.TransactionTypeBatchPin, 1, 0)
 }
 
 func TestE2ETokenPool(t *testing.T) {


### PR DESCRIPTION
Fix for #198 

- Fixes handling of `null` on `data.value` - including as part of a FORM post upload
  - Stored as the bytes `null` in the database (as today)
  - Does not contribute to the hash, when there is a blob
  - Returned as `null` in the JSON payload on `GET`
- Adds a new `validator` of `none`
  - Must be set explicitly - `json` remains the default
  - Disabled any checking of the `datatype.name`/`datatype.value` when set
  - Allows you to just use the `datatype` for tagging purposes, without validating the `value` JSON payload itself