### PR TITLE
Consistency in JSON/Blob codepaths for validation of "none" datatype

### DIFF
--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -219,7 +219,7 @@ func (dm *dataManager) checkValidation(ctx context.Context, ns string, validator
 		return err
 	}
 	// If a datatype is specified, we need to verify the payload conforms
-	if datatype != nil {
+	if datatype != nil && validator != fftypes.ValidatorTypeNone {
 		if datatype.Name == "" || datatype.Version == "" {
 			return i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatype)
 		}

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -65,11 +65,12 @@ func NewDataManager(ctx context.Context, di database.Plugin, pi publicstorage.Pl
 		publicstorage:     pi,
 		exchange:          dx,
 		validatorCacheTTL: config.GetDuration(config.ValidatorCacheTTL),
-		blobStore: blobStore{
-			database:      di,
-			publicstorage: pi,
-			exchange:      dx,
-		},
+	}
+	dm.blobStore = blobStore{
+		dm:            dm,
+		database:      di,
+		publicstorage: pi,
+		exchange:      dx,
 	}
 	dm.validatorCache = ccache.New(
 		// We use a LRU cache with a size-aware max
@@ -196,15 +197,6 @@ func (dm *dataManager) resolveRef(ctx context.Context, ns string, dataRef *fftyp
 	}
 }
 
-func (dm *dataManager) checkValidatorType(ctx context.Context, validator fftypes.ValidatorType) error {
-	switch validator {
-	case "", fftypes.ValidatorTypeJSON:
-		return nil
-	default:
-		return i18n.NewError(ctx, i18n.MsgUnknownValidatorType, validator)
-	}
-}
-
 func (dm *dataManager) resolveBlob(ctx context.Context, blobRef *fftypes.BlobRef) (*fftypes.Blob, error) {
 	if blobRef != nil && blobRef.Hash != nil {
 		blob, err := dm.database.GetBlobMatchingHash(ctx, blobRef.Hash)
@@ -219,28 +211,39 @@ func (dm *dataManager) resolveBlob(ctx context.Context, blobRef *fftypes.BlobRef
 	return nil, nil
 }
 
-func (dm *dataManager) validateAndStore(ctx context.Context, ns string, validator fftypes.ValidatorType, datatype *fftypes.DatatypeRef, value fftypes.Byteable, blobRef *fftypes.BlobRef) (data *fftypes.Data, blob *fftypes.Blob, err error) {
+func (dm *dataManager) checkValidation(ctx context.Context, ns string, validator fftypes.ValidatorType, datatype *fftypes.DatatypeRef, value fftypes.Byteable) error {
+	if validator == "" {
+		validator = fftypes.ValidatorTypeJSON
+	}
+	if err := fftypes.CheckValidatorType(ctx, validator); err != nil {
+		return err
+	}
 	// If a datatype is specified, we need to verify the payload conforms
 	if datatype != nil {
-		if err := dm.checkValidatorType(ctx, validator); err != nil {
-			return nil, nil, err
+		if datatype.Name == "" || datatype.Version == "" {
+			return i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatype)
 		}
-		if datatype == nil || datatype.Name == "" || datatype.Version == "" {
-			return nil, nil, i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatype)
+		if validator != fftypes.ValidatorTypeNone {
+			v, err := dm.getValidatorForDatatype(ctx, ns, validator, datatype)
+			if err != nil {
+				return err
+			}
+			if v == nil {
+				return i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatype)
+			}
+			err = v.ValidateValue(ctx, value, nil)
+			if err != nil {
+				return err
+			}
 		}
-		v, err := dm.getValidatorForDatatype(ctx, ns, validator, datatype)
-		if err != nil {
-			return nil, nil, err
-		}
-		if v == nil {
-			return nil, nil, i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatype)
-		}
-		err = v.ValidateValue(ctx, value, nil)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		validator = ""
+	}
+	return nil
+}
+
+func (dm *dataManager) validateAndStore(ctx context.Context, ns string, validator fftypes.ValidatorType, datatype *fftypes.DatatypeRef, value fftypes.Byteable, blobRef *fftypes.BlobRef) (data *fftypes.Data, blob *fftypes.Blob, err error) {
+
+	if err := dm.checkValidation(ctx, ns, validator, datatype, value); err != nil {
+		return nil, nil, err
 	}
 
 	if blob, err = dm.resolveBlob(ctx, blobRef); err != nil {

--- a/pkg/fftypes/data.go
+++ b/pkg/fftypes/data.go
@@ -71,6 +71,15 @@ func (d DataRefs) Hash() *Bytes32 {
 	return &b32
 }
 
+func CheckValidatorType(ctx context.Context, validator ValidatorType) error {
+	switch validator {
+	case ValidatorTypeJSON, ValidatorTypeNone, ValidatorTypeSystemDefinition:
+		return nil
+	default:
+		return i18n.NewError(ctx, i18n.MsgUnknownValidatorType, validator)
+	}
+}
+
 func (d *Data) CalcHash(ctx context.Context) (*Bytes32, error) {
 	if d.Value == nil {
 		d.Value = Byteable(nullString)
@@ -96,6 +105,9 @@ func (d *Data) CalcHash(ctx context.Context) (*Bytes32, error) {
 }
 
 func (d *Data) Seal(ctx context.Context) (err error) {
+	if d.Validator == "" {
+		d.Validator = ValidatorTypeJSON
+	}
 	if d.ID == nil {
 		d.ID = NewUUID()
 	}
@@ -103,5 +115,8 @@ func (d *Data) Seal(ctx context.Context) (err error) {
 		d.Created = Now()
 	}
 	d.Hash, err = d.CalcHash(ctx)
+	if err == nil {
+		err = CheckValidatorType(ctx, d.Validator)
+	}
 	return err
 }

--- a/pkg/fftypes/data_test.go
+++ b/pkg/fftypes/data_test.go
@@ -37,6 +37,11 @@ func TestDatatypeReference(t *testing.T) {
 
 }
 
+func TestValidateBadValidator(t *testing.T) {
+	err := CheckValidatorType(context.Background(), "wrong")
+	assert.Regexp(t, "FF10200", err)
+}
+
 func TestSealNoData(t *testing.T) {
 	d := &Data{}
 	err := d.Seal(context.Background())


### PR DESCRIPTION
In testing #207 we found the following error when using `validator: "none"` on a JSON upload of `data`, that was not seen on the BLOB upload.

```
FF10200: Unknown validator type: ‘none’
```

I found a discrepancy in the validation on upload between the two paths. This PR should reconcile that.