### PR TITLE
Support plain string as a message value in webhook subscription

### DIFF
--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -277,7 +277,7 @@ func (wh *WebHooks) attemptRequest(sub *fftypes.Subscription, event *fftypes.Eve
 		} else {
 			// Use JSONObjectOk instead of JSONObject
 			// JSONObject fails for datatypes such as array, string, bool, number etc
-			firstData, valid  = allData[0].JSONObjectOk()
+			firstData, valid = allData[0].JSONObjectOk()
 			if !valid {
 				firstData = fftypes.JSONObject{
 					"value": allData[0],

--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -262,10 +262,10 @@ func (wh *WebHooks) ValidateOptions(options *fftypes.SubscriptionOptions) error 
 }
 
 func (wh *WebHooks) attemptRequest(sub *fftypes.Subscription, event *fftypes.EventDelivery, data []*fftypes.Data) (req *whRequest, res *whResponse, err error) {
-
 	withData := sub.Options.WithData != nil && *sub.Options.WithData
 	allData := make([]fftypes.Byteable, 0, len(data))
 	var firstData fftypes.JSONObject
+	var valid bool
 	if withData {
 		for _, d := range data {
 			if d.Value != nil {
@@ -275,7 +275,14 @@ func (wh *WebHooks) attemptRequest(sub *fftypes.Subscription, event *fftypes.Eve
 		if len(allData) == 0 {
 			firstData = fftypes.JSONObject{}
 		} else {
-			firstData = allData[0].JSONObject()
+			// Use JSONObjectOk instead of JSONObject
+			// JSONObject fails for datatypes such as array, string, bool, number etc
+			firstData, valid  = allData[0].JSONObjectOk()
+			if !valid {
+				firstData = fftypes.JSONObject{
+					"value": allData[0],
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Support plain string as a message value in webhook subscription.  

**Observed behavior**
When putting a plain string in the value field of a FireFly message, the HTTP request body on the received webhook is an empty object

**Expected behavior:**
If a message is accepted by a FireFly node, whatever is in the value field should be put in the HTTP request body for a webhook subscription

**Before Changes:**
POST /test HTTP/1.1
Host: ff-meera.requestcatcher.com
Accept: application/json
Accept-Encoding: gzip
Content-Length: 2
Content-Type: application/json
User-Agent: go-resty/2.6.0 (https://github.com/go-resty/resty)

{}

**After Changes.**
POST /test HTTP/1.1
Host: ff-meera.requestcatcher.com
Accept: application/json
Accept-Encoding: gzip
Content-Length: 20
Content-Type: application/json
User-Agent: go-resty/2.6.0 (https://github.com/go-resty/resty)

{"value":"hello456"}