### PR TITLE
Capture logs if startup or earlier steps fail

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -8,16 +8,16 @@ STACK_DIR=~/.firefly/stacks
 STACK_NAME=firefly-e2e
 
 checkOk() {
-  RC=$1
+  local rc=$1
 
   WORKDIR=${GITHUB_WORKSPACE}
   if [ -z "$WORKDIR" ]; then WORKDIR=.; fi
 
   mkdir -p "${WORKDIR}/containerlogs"
   $CLI logs $STACK_NAME > "${WORKDIR}/containerlogs/logs.txt"
-  if [ $RC -eq 0 ]; then RC=$?; fi
+  if [ $rc -eq 0 ]; then rc=$?; fi
 
-  if [ $RC -ne 0 ]; then exit $RC; fi
+  if [ $rc -ne 0 ]; then exit $rc; fi
 }
 
 if [ -z "${DOWNLOAD_CLI}" ]; then


### PR DESCRIPTION
Per https://github.com/hyperledger/firefly/issues/226#issuecomment-938160813, the change in #231 only helps capture container logs during the test running phase.

If the failure happens during startup or registration in the CLI, then logs aren't currently captured.

This change checks the RC after each step, so that the bash code always goes through the log exit