### PR TITLE
Reduce I/O load of test runs by using memory DB

### DIFF
--- a/internal/database/sqlcommon/provider_sqlitego_test.go
+++ b/internal/database/sqlcommon/provider_sqlitego_test.go
@@ -19,7 +19,6 @@ package sqlcommon
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -57,7 +56,7 @@ func newSQLiteTestProvider(t *testing.T) (*sqliteGoTestProvider, func()) {
 	tp.SQLCommon.InitPrefix(tp, tp.prefix)
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	tp.prefix.Set(SQLConfDatasourceURL, fmt.Sprintf("file:%s/testdb", dir))
+	tp.prefix.Set(SQLConfDatasourceURL, "file::memory:")
 	tp.prefix.Set(SQLConfMigrationsAuto, true)
 	tp.prefix.Set(SQLConfMigrationsDirectory, "../../../db/migrations/sqlite")
 	tp.prefix.Set(SQLConfMaxConnections, 1)


### PR DESCRIPTION
Now we have SQLConfMaxConnections, the previous reasons we needed a real filesystem backing the SQL tests has been removed, and it seems to significantly slow down the test to have a full filesystem on I/O throttled build servers.