### PR TITLE
Do not use tokenIndex in E2E test for fungible tokens

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "v0.9.0",
-    "sha": "6c5f8a28739ad4c45ee207038e55ec1793b9f42ca2d7548dcf54a02787711f9b"
+    "tag": "v0.10.0",
+    "sha": "086055b97a4d26a66f967702ef5fd2117af50c6d96faea1f010ea240de338a1e"
   }
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -523,9 +523,8 @@ func TestE2ETokenPool(t *testing.T) {
 	transfers := GetTokenTransfers(t, ts.client1, poolName)
 	assert.Equal(t, 1, len(transfers))
 	assert.Equal(t, fftypes.TokenTransferTypeMint, transfers[0].Type)
-	assert.Equal(t, "0", transfers[0].TokenIndex)
 	assert.Equal(t, int64(1), transfers[0].Amount.Int().Int64())
-	validateAccountBalances(t, ts.client1, poolName, "0", map[string]int64{
+	validateAccountBalances(t, ts.client1, poolName, "", map[string]int64{
 		ts.org1.Identity: 1,
 	})
 
@@ -534,13 +533,12 @@ func TestE2ETokenPool(t *testing.T) {
 	assert.Equal(t, 1, len(transfers))
 	assert.Equal(t, fftypes.TokenTransferTypeMint, transfers[0].Type)
 	assert.Equal(t, int64(1), transfers[0].Amount.Int().Int64())
-	validateAccountBalances(t, ts.client2, poolName, "0", map[string]int64{
+	validateAccountBalances(t, ts.client2, poolName, "", map[string]int64{
 		ts.org1.Identity: 1,
 	})
 
 	transfer = &fftypes.TokenTransfer{
-		TokenIndex: "0",
-		To:         ts.org2.Identity,
+		To: ts.org2.Identity,
 	}
 	transfer.Amount.Int().SetInt64(1)
 	TransferTokens(t, ts.client1, poolName, transfer)
@@ -549,9 +547,8 @@ func TestE2ETokenPool(t *testing.T) {
 	transfers = GetTokenTransfers(t, ts.client1, poolName)
 	assert.Equal(t, 2, len(transfers))
 	assert.Equal(t, fftypes.TokenTransferTypeTransfer, transfers[0].Type)
-	assert.Equal(t, "0", transfers[0].TokenIndex)
 	assert.Equal(t, int64(1), transfers[0].Amount.Int().Int64())
-	validateAccountBalances(t, ts.client1, poolName, "0", map[string]int64{
+	validateAccountBalances(t, ts.client1, poolName, "", map[string]int64{
 		ts.org1.Identity: 0,
 		ts.org2.Identity: 1,
 	})
@@ -560,16 +557,13 @@ func TestE2ETokenPool(t *testing.T) {
 	transfers = GetTokenTransfers(t, ts.client2, poolName)
 	assert.Equal(t, 2, len(transfers))
 	assert.Equal(t, fftypes.TokenTransferTypeTransfer, transfers[0].Type)
-	assert.Equal(t, "0", transfers[0].TokenIndex)
 	assert.Equal(t, int64(1), transfers[0].Amount.Int().Int64())
-	validateAccountBalances(t, ts.client2, poolName, "0", map[string]int64{
+	validateAccountBalances(t, ts.client2, poolName, "", map[string]int64{
 		ts.org1.Identity: 0,
 		ts.org2.Identity: 1,
 	})
 
-	transfer = &fftypes.TokenTransfer{
-		TokenIndex: "0",
-	}
+	transfer = &fftypes.TokenTransfer{}
 	transfer.Amount.Int().SetInt64(1)
 	BurnTokens(t, ts.client2, poolName, transfer)
 
@@ -577,9 +571,8 @@ func TestE2ETokenPool(t *testing.T) {
 	transfers = GetTokenTransfers(t, ts.client2, poolName)
 	assert.Equal(t, 3, len(transfers))
 	assert.Equal(t, fftypes.TokenTransferTypeBurn, transfers[0].Type)
-	assert.Equal(t, "0", transfers[0].TokenIndex)
 	assert.Equal(t, int64(1), transfers[0].Amount.Int().Int64())
-	validateAccountBalances(t, ts.client2, poolName, "0", map[string]int64{
+	validateAccountBalances(t, ts.client2, poolName, "", map[string]int64{
 		ts.org1.Identity: 0,
 		ts.org2.Identity: 0,
 	})
@@ -588,9 +581,8 @@ func TestE2ETokenPool(t *testing.T) {
 	transfers = GetTokenTransfers(t, ts.client1, poolName)
 	assert.Equal(t, 3, len(transfers))
 	assert.Equal(t, fftypes.TokenTransferTypeBurn, transfers[0].Type)
-	assert.Equal(t, "0", transfers[0].TokenIndex)
 	assert.Equal(t, int64(1), transfers[0].Amount.Int().Int64())
-	validateAccountBalances(t, ts.client1, poolName, "0", map[string]int64{
+	validateAccountBalances(t, ts.client1, poolName, "", map[string]int64{
 		ts.org1.Identity: 0,
 		ts.org2.Identity: 0,
 	})


### PR DESCRIPTION
Pulls in the behavior from https://github.com/hyperledger/firefly-tokens-erc1155/pull/35 and adjusts E2E test to match.