### PR TITLE
Allow nested RunAsGroup calls

### DIFF
--- a/internal/database/sqlcommon/sqlcommon.go
+++ b/internal/database/sqlcommon/sqlcommon.go
@@ -75,6 +75,11 @@ func (s *SQLCommon) Init(ctx context.Context, provider Provider, prefix config.P
 func (s *SQLCommon) Capabilities() *database.Capabilities { return s.capabilities }
 
 func (s *SQLCommon) RunAsGroup(ctx context.Context, fn func(ctx context.Context) error) error {
+	if tx := getTXFromContext(ctx); tx != nil {
+		// transaction already exists - just continue using it
+		return fn(ctx)
+	}
+
 	ctx, tx, _, err := s.beginOrUseTx(ctx)
 	if err != nil {
 		return err

--- a/internal/database/sqlcommon/sqlcommon_test.go
+++ b/internal/database/sqlcommon/sqlcommon_test.go
@@ -162,6 +162,14 @@ func TestRunAsGroup(t *testing.T) {
 		// Query, not specifying a transaction
 		_, _, err = s.query(ctx, sq.Select("test").From("test"))
 		assert.NoError(t, err)
+
+		// Nested call
+		err = s.RunAsGroup(ctx, func(ctx2 context.Context) error {
+			assert.Equal(t, ctx, ctx2)
+			return nil
+		})
+		assert.NoError(t, err)
+
 		return
 	})
 

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -418,7 +418,10 @@ type PeristenceInterface interface {
 
 	// RunAsGroup instructs the database plugin that all database operations performed within the context
 	// function can be grouped into a single transaction (if supported).
-	// Note, the caller is responsible for passing the context back to all database operations performed within the supplied function.
+	// Requirements:
+	// - Firefly must not depend on this to guarantee ACID properties (it is only a suggestion/optimization)
+	// - The database implementation must support nested RunAsGroup calls (ie by reusing a transaction if one exists)
+	// - The caller is responsible for passing the supplied context to all database operations within the callback function
 	RunAsGroup(ctx context.Context, fn func(ctx context.Context) error) error
 
 	iNamespaceCollection


### PR DESCRIPTION
If a transaction is already started, it is reused.

This allows code to be reused in a fashion where it may need to start a transaction, or may be called from
within an already-started transaction (useful for operations that span multiple packages, such as the
ongoing work on token transfers with associated messages).

It does introduce a new constraint for database implementations (noted in the database plugin definition).