### PR TITLE
Add topic+tag index to messages

### DIFF
--- a/db/migrations/postgres/000037_add_message_topic_tag_index.down.sql
+++ b/db/migrations/postgres/000037_add_message_topic_tag_index.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP INDEX messages_topics_tag;
+COMMIT;

--- a/db/migrations/postgres/000037_add_message_topic_tag_index.up.sql
+++ b/db/migrations/postgres/000037_add_message_topic_tag_index.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+CREATE INDEX messages_topics_tag ON messages(namespace,topics,tag);
+COMMIT;

--- a/db/migrations/sqlite/000037_add_message_topic_tag_index.down.sql
+++ b/db/migrations/sqlite/000037_add_message_topic_tag_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX messages_topics_tag;

--- a/db/migrations/sqlite/000037_add_message_topic_tag_index.up.sql
+++ b/db/migrations/sqlite/000037_add_message_topic_tag_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX messages_topics_tag ON messages(namespace,topics,tag);


### PR DESCRIPTION
The intention of the topics field, is that you can create a stream of data that is grouped on a particular ordered business context, and the tag sub-classifies messages within that.

This means that querying by topic and tag is a primary use case, for which index(es) should exist.

This PR proposes a single combined index, on topic then tag, as I believe that's the most likely combination of filter across use cases.