### PR TITLE
Update assertion on unit test to pass on Go 1.17

### DIFF
--- a/internal/blockchain/fabric/certs_test.go
+++ b/internal/blockchain/fabric/certs_test.go
@@ -80,5 +80,5 @@ func TestClient(t *testing.T) {
 
 	certStr = base64.StdEncoding.EncodeToString([]byte(badCert))
 	_, err = getDNFromCertString(certStr)
-	assert.EqualError(err, "asn1: syntax error: data truncated")
+	assert.Contains([]string{"x509: malformed certificate", "asn1: syntax error: data truncated"}, err.Error())
 }


### PR DESCRIPTION
Somehow I missed this one when I fixed the other tests.

Resolves https://github.com/hyperledger/firefly/issues/282