### PR TITLE
Remove "skipEventstreamInit" parameters

### DIFF
--- a/internal/blockchain/ethereum/config.go
+++ b/internal/blockchain/ethereum/config.go
@@ -41,8 +41,6 @@ const (
 	EthconnectConfigBatchSize = "batchSize"
 	// EthconnectConfigBatchTimeout is the batch timeout to configure on event streams, when auto-defining them
 	EthconnectConfigBatchTimeout = "batchTimeout"
-	// EthconnectConfigSkipEventstreamInit disables auto-configuration of event streams
-	EthconnectConfigSkipEventstreamInit = "skipEventstreamInit"
 	// EthconnectPrefixShort is used in the query string in requests to ethconnect
 	EthconnectPrefixShort = "prefixShort"
 	// EthconnectPrefixLong is used in HTTP headers in requests to ethconnect
@@ -54,7 +52,6 @@ func (e *Ethereum) InitPrefix(prefix config.Prefix) {
 	wsconfig.InitPrefix(ethconnectConf)
 	ethconnectConf.AddKnownKey(EthconnectConfigInstancePath)
 	ethconnectConf.AddKnownKey(EthconnectConfigTopic)
-	ethconnectConf.AddKnownKey(EthconnectConfigSkipEventstreamInit)
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchSize, defaultBatchSize)
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchTimeout, defaultBatchTimeout)
 	ethconnectConf.AddKnownKey(EthconnectPrefixShort, defaultPrefixShort)

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -144,10 +144,8 @@ func (e *Ethereum) Init(ctx context.Context, prefix config.Prefix, callbacks blo
 		return err
 	}
 
-	if !ethconnectConf.GetBool(EthconnectConfigSkipEventstreamInit) {
-		if err = e.ensureEventStreams(ethconnectConf); err != nil {
-			return err
-		}
+	if err = e.ensureEventStreams(ethconnectConf); err != nil {
+		return err
 	}
 
 	e.closed = make(chan struct{})

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -173,7 +173,6 @@ func TestWSInitFail(t *testing.T) {
 	utEthconnectConf.Set(restclient.HTTPConfigURL, "!!!://")
 	utEthconnectConf.Set(EthconnectConfigInstancePath, "/instances/0x12345")
 	utEthconnectConf.Set(EthconnectConfigTopic, "topic1")
-	utEthconnectConf.Set(EthconnectConfigSkipEventstreamInit, true)
 
 	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{})
 	assert.Regexp(t, "FF10162", err)

--- a/internal/blockchain/fabric/config.go
+++ b/internal/blockchain/fabric/config.go
@@ -45,8 +45,6 @@ const (
 	FabconnectConfigBatchSize = "batchSize"
 	// FabconnectConfigBatchTimeout is the batch timeout to configure on event streams, when auto-defining them
 	FabconnectConfigBatchTimeout = "batchTimeout"
-	// FabconnectConfigSkipEventstreamInit disables auto-configuration of event streams
-	FabconnectConfigSkipEventstreamInit = "skipEventstreamInit"
 	// FabconnectPrefixShort is used in the query string in requests to ethconnect
 	FabconnectPrefixShort = "prefixShort"
 	// FabconnectPrefixLong is used in HTTP headers in requests to ethconnect
@@ -60,7 +58,6 @@ func (f *Fabric) InitPrefix(prefix config.Prefix) {
 	fabconnectConf.AddKnownKey(FabconnectConfigChaincode)
 	fabconnectConf.AddKnownKey(FabconnectConfigSigner)
 	fabconnectConf.AddKnownKey(FabconnectConfigTopic)
-	fabconnectConf.AddKnownKey(FabconnectConfigSkipEventstreamInit)
 	fabconnectConf.AddKnownKey(FabconnectConfigBatchSize, defaultBatchSize)
 	fabconnectConf.AddKnownKey(FabconnectConfigBatchTimeout, defaultBatchTimeout)
 	fabconnectConf.AddKnownKey(FabconnectPrefixShort, defaultPrefixShort)

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -199,10 +199,8 @@ func (f *Fabric) Init(ctx context.Context, prefix config.Prefix, callbacks block
 		return err
 	}
 
-	if !fabconnectConf.GetBool(FabconnectConfigSkipEventstreamInit) {
-		if err = f.ensureEventStreams(fabconnectConf); err != nil {
-			return err
-		}
+	if err = f.ensureEventStreams(fabconnectConf); err != nil {
+		return err
 	}
 
 	f.closed = make(chan struct{})

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -179,7 +179,6 @@ func TestWSInitFail(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigChaincode, "firefly")
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
-	utFabconnectConf.Set(FabconnectConfigSkipEventstreamInit, true)
 
 	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{})
 	assert.Regexp(t, "FF10162", err)


### PR DESCRIPTION
This was previously used by the CLI as a temporary way to bring up FireFly
without initializing event streams - but bringup has been streamlined in
other ways now that do not require it.

Signed-off-by: Andrew Richardson <andrew.richardson@kaleido.io>