### PR TITLE
Leverage new token transfer id from plugin

### DIFF
--- a/internal/events/tokens_transferred_test.go
+++ b/internal/events/tokens_transferred_test.go
@@ -153,6 +153,117 @@ func TestTokensTransferredWithTransactionRetries(t *testing.T) {
 	mti.AssertExpectations(t)
 }
 
+func TestTokensTransferredWithTransactionLoadLocalID(t *testing.T) {
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mti := &tokenmocks.Plugin{}
+
+	transfer := &fftypes.TokenTransfer{
+		Type:       fftypes.TokenTransferTypeTransfer,
+		TokenIndex: "0",
+		Connector:  "erc1155",
+		Key:        "0x12345",
+		From:       "0x1",
+		To:         "0x2",
+		ProtocolID: "123",
+		Amount:     *fftypes.NewBigInt(1),
+		TX: fftypes.TransactionRef{
+			ID:   fftypes.NewUUID(),
+			Type: fftypes.TransactionTypeTokenTransfer,
+		},
+	}
+	pool := &fftypes.TokenPool{
+		Namespace: "ns1",
+	}
+	localID := fftypes.NewUUID()
+	operations := []*fftypes.Operation{{
+		Input: fftypes.JSONObject{
+			"id": localID.String(),
+		},
+	}}
+
+	mdi.On("GetTokenTransferByProtocolID", em.ctx, "erc1155", "123").Return(nil, nil).Times(2)
+	mdi.On("GetTokenPoolByProtocolID", em.ctx, "erc1155", "F1").Return(pool, nil).Times(2)
+	mdi.On("GetOperations", em.ctx, mock.Anything).Return(operations, nil, nil).Times(2)
+	mdi.On("GetTransactionByID", em.ctx, transfer.TX.ID).Return(nil, nil).Times(2)
+	mdi.On("UpsertTransaction", em.ctx, mock.MatchedBy(func(t *fftypes.Transaction) bool {
+		return *t.ID == *transfer.TX.ID && t.Subject.Type == fftypes.TransactionTypeTokenTransfer && t.ProtocolID == "tx1"
+	}), false).Return(nil).Times(2)
+	mdi.On("GetTokenTransfer", em.ctx, localID).Return(nil, fmt.Errorf("pop")).Once()
+	mdi.On("GetTokenTransfer", em.ctx, localID).Return(nil, nil).Once()
+	mdi.On("UpsertTokenTransfer", em.ctx, transfer).Return(nil).Once()
+	mdi.On("UpdateTokenBalances", em.ctx, transfer).Return(nil).Once()
+	mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *fftypes.Event) bool {
+		return ev.Type == fftypes.EventTypeTransferConfirmed && ev.Reference == transfer.LocalID && ev.Namespace == pool.Namespace
+	})).Return(nil).Once()
+
+	info := fftypes.JSONObject{"some": "info"}
+	err := em.TokensTransferred(mti, "F1", transfer, "tx1", info)
+	assert.NoError(t, err)
+
+	assert.Equal(t, *localID, *transfer.LocalID)
+
+	mdi.AssertExpectations(t)
+	mti.AssertExpectations(t)
+}
+
+func TestTokensTransferredWithTransactionRegenerateLocalID(t *testing.T) {
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mti := &tokenmocks.Plugin{}
+
+	transfer := &fftypes.TokenTransfer{
+		Type:       fftypes.TokenTransferTypeTransfer,
+		TokenIndex: "0",
+		Connector:  "erc1155",
+		Key:        "0x12345",
+		From:       "0x1",
+		To:         "0x2",
+		ProtocolID: "123",
+		Amount:     *fftypes.NewBigInt(1),
+		TX: fftypes.TransactionRef{
+			ID:   fftypes.NewUUID(),
+			Type: fftypes.TransactionTypeTokenTransfer,
+		},
+	}
+	pool := &fftypes.TokenPool{
+		Namespace: "ns1",
+	}
+	localID := fftypes.NewUUID()
+	operations := []*fftypes.Operation{{
+		Input: fftypes.JSONObject{
+			"id": localID.String(),
+		},
+	}}
+
+	mdi.On("GetTokenTransferByProtocolID", em.ctx, "erc1155", "123").Return(nil, nil).Once()
+	mdi.On("GetTokenPoolByProtocolID", em.ctx, "erc1155", "F1").Return(pool, nil).Once()
+	mdi.On("GetOperations", em.ctx, mock.Anything).Return(operations, nil, nil).Once()
+	mdi.On("GetTransactionByID", em.ctx, transfer.TX.ID).Return(nil, nil).Once()
+	mdi.On("UpsertTransaction", em.ctx, mock.MatchedBy(func(t *fftypes.Transaction) bool {
+		return *t.ID == *transfer.TX.ID && t.Subject.Type == fftypes.TransactionTypeTokenTransfer && t.ProtocolID == "tx1"
+	}), false).Return(nil).Once()
+	mdi.On("GetTokenTransfer", em.ctx, localID).Return(&fftypes.TokenTransfer{}, nil).Once()
+	mdi.On("UpsertTokenTransfer", em.ctx, transfer).Return(nil).Once()
+	mdi.On("UpdateTokenBalances", em.ctx, transfer).Return(nil).Once()
+	mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *fftypes.Event) bool {
+		return ev.Type == fftypes.EventTypeTransferConfirmed && ev.Reference == transfer.LocalID && ev.Namespace == pool.Namespace
+	})).Return(nil).Once()
+
+	info := fftypes.JSONObject{"some": "info"}
+	err := em.TokensTransferred(mti, "F1", transfer, "tx1", info)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, *localID, *transfer.LocalID)
+
+	mdi.AssertExpectations(t)
+	mti.AssertExpectations(t)
+}
+
 func TestTokensTransferredBadPool(t *testing.T) {
 	em, cancel := newTestEventManager(t)
 	defer cancel()

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -208,8 +208,7 @@ func (ft *FFTokens) handleTokenPoolCreate(ctx context.Context, data fftypes.JSON
 }
 
 func (ft *FFTokens) handleTokenTransfer(ctx context.Context, t fftypes.TokenTransferType, data fftypes.JSONObject) (err error) {
-	tokenIndex := data.GetString("tokenIndex")
-	uri := data.GetString("uri")
+	protocolID := data.GetString("id")
 	poolProtocolID := data.GetString("poolId")
 	operatorAddress := data.GetString("operator")
 	fromAddress := data.GetString("from")
@@ -217,6 +216,8 @@ func (ft *FFTokens) handleTokenTransfer(ctx context.Context, t fftypes.TokenTran
 	value := data.GetString("amount")
 	tx := data.GetObject("transaction")
 	txHash := tx.GetString("transactionHash")
+	tokenIndex := data.GetString("tokenIndex") // optional
+	uri := data.GetString("uri")               // optional
 
 	var eventName string
 	switch t {
@@ -228,7 +229,8 @@ func (ft *FFTokens) handleTokenTransfer(ctx context.Context, t fftypes.TokenTran
 		eventName = "Transfer"
 	}
 
-	if poolProtocolID == "" ||
+	if protocolID == "" ||
+		poolProtocolID == "" ||
 		operatorAddress == "" ||
 		value == "" ||
 		txHash == "" ||
@@ -254,7 +256,7 @@ func (ft *FFTokens) handleTokenTransfer(ctx context.Context, t fftypes.TokenTran
 		Connector:   ft.configuredName,
 		From:        fromAddress,
 		To:          toAddress,
-		ProtocolID:  txHash,
+		ProtocolID:  protocolID,
 		Key:         operatorAddress,
 		Message:     transferData.Message,
 		MessageHash: transferData.MessageHash,

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -512,6 +512,7 @@ func TestEvents(t *testing.T) {
 		"id":    "10",
 		"event": "token-mint",
 		"data": fftypes.JSONObject{
+			"id":         "1.0.0",
 			"poolId":     "F1",
 			"tokenIndex": "0",
 			"operator":   "0x0",
@@ -534,6 +535,7 @@ func TestEvents(t *testing.T) {
 		"id":    "11",
 		"event": "token-mint",
 		"data": fftypes.JSONObject{
+			"id":       "1.0.0",
 			"poolId":   "F1",
 			"operator": "0x0",
 			"to":       "0x0",
@@ -555,6 +557,7 @@ func TestEvents(t *testing.T) {
 		"id":    "12",
 		"event": "token-mint",
 		"data": fftypes.JSONObject{
+			"id":         "1.0.0",
 			"poolId":     "N1",
 			"tokenIndex": "1",
 			"operator":   "0x0",
@@ -574,6 +577,7 @@ func TestEvents(t *testing.T) {
 		"id":    "13",
 		"event": "token-transfer",
 		"data": fftypes.JSONObject{
+			"id":         "1.0.0",
 			"poolId":     "F1",
 			"tokenIndex": "0",
 			"operator":   "0x0",
@@ -596,6 +600,7 @@ func TestEvents(t *testing.T) {
 		"id":    "14",
 		"event": "token-transfer",
 		"data": fftypes.JSONObject{
+			"id":       "1.0.0",
 			"poolId":   "F1",
 			"operator": "0x0",
 			"from":     "0x0",
@@ -619,6 +624,7 @@ func TestEvents(t *testing.T) {
 		"id":    "15",
 		"event": "token-transfer",
 		"data": fftypes.JSONObject{
+			"id":       "1.0.0",
 			"poolId":   "F1",
 			"operator": "0x0",
 			"from":     "0x0",
@@ -641,6 +647,7 @@ func TestEvents(t *testing.T) {
 		"id":    "16",
 		"event": "token-burn",
 		"data": fftypes.JSONObject{
+			"id":         "1.0.0",
 			"poolId":     "F1",
 			"tokenIndex": "0",
 			"operator":   "0x0",

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "v0.10.0-20211123-8",
-    "sha": "ee9e8b0d9112dfae70dbb35a18de8da9863632cbd56f275c3048f0d257e4a6b7"
+    "tag": "v0.10.0-20211124-9",
+    "sha": "5c7055d26b6713b9945d7e6859af79828ccd102ca8d645bbd710706e1a5dfe7e"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/hyperledger/firefly-tokens-erc1155/pull/45 (E2E tests will fail without this)