### PR TITLE
Updates to handle recursive structures in swagger - depends on kin-openapi change

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -66,6 +66,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -73,6 +80,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -174,6 +187,10 @@ paths:
                     name:
                       type: string
                     type:
+                      enum:
+                      - local
+                      - broadcast
+                      - system
                       type: string
                   type: object
                 type: array
@@ -221,6 +238,10 @@ paths:
                   name:
                     type: string
                   type:
+                    enum:
+                    - local
+                    - broadcast
+                    - system
                     type: string
                 type: object
           description: Success
@@ -237,6 +258,10 @@ paths:
                   name:
                     type: string
                   type:
+                    enum:
+                    - local
+                    - broadcast
+                    - system
                     type: string
                 type: object
           description: Success
@@ -275,6 +300,10 @@ paths:
                   name:
                     type: string
                   type:
+                    enum:
+                    - local
+                    - broadcast
+                    - system
                     type: string
                 type: object
           description: Success
@@ -484,6 +513,13 @@ paths:
                                   txtype:
                                     type: string
                                   type:
+                                    enum:
+                                    - definition
+                                    - broadcast
+                                    - private
+                                    - groupinit
+                                    - transfer_broadcast
+                                    - transfer_private
                                     type: string
                                 type: object
                               pins:
@@ -491,6 +527,12 @@ paths:
                                   type: string
                                 type: array
                               state:
+                                enum:
+                                - staged
+                                - ready
+                                - pending
+                                - confirmed
+                                - rejected
                                 type: string
                             type: object
                           type: array
@@ -620,6 +662,13 @@ paths:
                                 txtype:
                                   type: string
                                 type:
+                                  enum:
+                                  - definition
+                                  - broadcast
+                                  - private
+                                  - groupinit
+                                  - transfer_broadcast
+                                  - transfer_private
                                   type: string
                               type: object
                             pins:
@@ -627,6 +676,12 @@ paths:
                                 type: string
                               type: array
                             state:
+                              enum:
+                              - staged
+                              - ready
+                              - pending
+                              - confirmed
+                              - rejected
                               type: string
                           type: object
                         type: array
@@ -722,6 +777,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -729,6 +791,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -838,6 +906,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -845,6 +920,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -1476,6 +1557,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -1483,6 +1571,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -1592,6 +1686,10 @@ paths:
                     namespace:
                       type: string
                     validator:
+                      enum:
+                      - json
+                      - none
+                      - definition
                       type: string
                     value:
                       format: byte
@@ -1661,6 +1759,10 @@ paths:
                   namespace:
                     type: string
                   validator:
+                    enum:
+                    - json
+                    - none
+                    - definition
                     type: string
                   value:
                     format: byte
@@ -1683,6 +1785,10 @@ paths:
                   namespace:
                     type: string
                   validator:
+                    enum:
+                    - json
+                    - none
+                    - definition
                     type: string
                   value:
                     format: byte
@@ -1734,6 +1840,10 @@ paths:
                   namespace:
                     type: string
                   validator:
+                    enum:
+                    - json
+                    - none
+                    - definition
                     type: string
                   value:
                     format: byte
@@ -1790,6 +1900,10 @@ paths:
                   namespace:
                     type: string
                   validator:
+                    enum:
+                    - json
+                    - none
+                    - definition
                     type: string
                   value:
                     format: byte
@@ -1904,6 +2018,16 @@ paths:
                       format: int64
                       type: integer
                     type:
+                      enum:
+                      - message_confirmed
+                      - message_rejected
+                      - namespace_confirmed
+                      - datatype_confirmed
+                      - group_confirmed
+                      - token_pool_confirmed
+                      - token_pool_rejected
+                      - token_transfer_confirmed
+                      - token_transfer_op_failed
                       type: string
                   type: object
                 type: array
@@ -1950,6 +2074,16 @@ paths:
                     format: int64
                     type: integer
                   type:
+                    enum:
+                    - message_confirmed
+                    - message_rejected
+                    - namespace_confirmed
+                    - datatype_confirmed
+                    - group_confirmed
+                    - token_pool_confirmed
+                    - token_pool_rejected
+                    - token_transfer_confirmed
+                    - token_transfer_op_failed
                     type: string
                 type: object
           description: Success
@@ -2137,6 +2271,13 @@ paths:
                         txtype:
                           type: string
                         type:
+                          enum:
+                          - definition
+                          - broadcast
+                          - private
+                          - groupinit
+                          - transfer_broadcast
+                          - transfer_private
                           type: string
                       type: object
                     pins:
@@ -2144,6 +2285,12 @@ paths:
                         type: string
                       type: array
                     state:
+                      enum:
+                      - staged
+                      - ready
+                      - pending
+                      - confirmed
+                      - rejected
                       type: string
                   type: object
                 type: array
@@ -2239,6 +2386,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -2246,6 +2400,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -2421,6 +2581,16 @@ paths:
                       format: int64
                       type: integer
                     type:
+                      enum:
+                      - message_confirmed
+                      - message_rejected
+                      - namespace_confirmed
+                      - datatype_confirmed
+                      - group_confirmed
+                      - token_pool_confirmed
+                      - token_pool_rejected
+                      - token_transfer_confirmed
+                      - token_transfer_op_failed
                       type: string
                   type: object
                 type: array
@@ -2479,6 +2649,14 @@ paths:
                       type: string
                     tx: {}
                     type:
+                      enum:
+                      - blockchain_batch_pin
+                      - publicstorage_batch_broadcast
+                      - dataexchange_batch_send
+                      - dataexchange_blob_send
+                      - token_create_pool
+                      - token_announce_pool
+                      - token_transfer
                       type: string
                     updated: {}
                   type: object
@@ -2535,6 +2713,11 @@ paths:
                       signer:
                         type: string
                       type:
+                        enum:
+                        - none
+                        - batch_pin
+                        - token_pool
+                        - token_transfer
                         type: string
                     type: object
                 type: object
@@ -2649,6 +2832,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -2656,6 +2846,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -2696,6 +2892,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -2703,6 +2906,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -2830,6 +3039,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -2837,6 +3053,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -2877,6 +3099,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -2884,6 +3113,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -3021,6 +3256,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -3028,6 +3270,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -3173,6 +3421,14 @@ paths:
                       type: string
                     tx: {}
                     type:
+                      enum:
+                      - blockchain_batch_pin
+                      - publicstorage_batch_broadcast
+                      - dataexchange_batch_send
+                      - dataexchange_blob_send
+                      - token_create_pool
+                      - token_announce_pool
+                      - token_transfer
                       type: string
                     updated: {}
                   type: object
@@ -3231,6 +3487,14 @@ paths:
                     type: string
                   tx: {}
                   type:
+                    enum:
+                    - blockchain_batch_pin
+                    - publicstorage_batch_broadcast
+                    - dataexchange_batch_send
+                    - dataexchange_blob_send
+                    - token_create_pool
+                    - token_announce_pool
+                    - token_transfer
                     type: string
                   updated: {}
                 type: object
@@ -3370,6 +3634,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -3377,6 +3648,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -3500,6 +3777,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -3507,6 +3791,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -4279,6 +4569,10 @@ paths:
                     standard:
                       type: string
                     state:
+                      enum:
+                      - unknown
+                      - pending
+                      - confirmed
                       type: string
                     symbol:
                       type: string
@@ -4289,6 +4583,9 @@ paths:
                           type: string
                       type: object
                     type:
+                      enum:
+                      - fungible
+                      - nonfungible
                       type: string
                   type: object
                 type: array
@@ -4370,6 +4667,10 @@ paths:
                   standard:
                     type: string
                   state:
+                    enum:
+                    - unknown
+                    - pending
+                    - confirmed
                     type: string
                   symbol:
                     type: string
@@ -4380,6 +4681,9 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - fungible
+                    - nonfungible
                     type: string
                 type: object
           description: Success
@@ -4407,6 +4711,10 @@ paths:
                   standard:
                     type: string
                   state:
+                    enum:
+                    - unknown
+                    - pending
+                    - confirmed
                     type: string
                   symbol:
                     type: string
@@ -4417,6 +4725,9 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - fungible
+                    - nonfungible
                     type: string
                 type: object
           description: Success
@@ -4479,6 +4790,10 @@ paths:
                   standard:
                     type: string
                   state:
+                    enum:
+                    - unknown
+                    - pending
+                    - confirmed
                     type: string
                   symbol:
                     type: string
@@ -4489,6 +4804,9 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - fungible
+                    - nonfungible
                     type: string
                 type: object
           description: Success
@@ -4797,6 +5115,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -4832,6 +5154,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -5016,6 +5342,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -5051,6 +5381,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -5221,6 +5555,10 @@ paths:
                           type: string
                       type: object
                     type:
+                      enum:
+                      - mint
+                      - burn
+                      - transfer
                       type: string
                   type: object
                 type: array
@@ -5405,6 +5743,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -5440,6 +5782,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -5931,6 +6277,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -5966,6 +6316,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -6170,6 +6524,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -6205,6 +6563,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -6349,6 +6711,10 @@ paths:
                     standard:
                       type: string
                     state:
+                      enum:
+                      - unknown
+                      - pending
+                      - confirmed
                       type: string
                     symbol:
                       type: string
@@ -6359,6 +6725,9 @@ paths:
                           type: string
                       type: object
                     type:
+                      enum:
+                      - fungible
+                      - nonfungible
                       type: string
                   type: object
                 type: array
@@ -6435,6 +6804,10 @@ paths:
                   standard:
                     type: string
                   state:
+                    enum:
+                    - unknown
+                    - pending
+                    - confirmed
                     type: string
                   symbol:
                     type: string
@@ -6445,6 +6818,9 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - fungible
+                    - nonfungible
                     type: string
                 type: object
           description: Success
@@ -6472,6 +6848,10 @@ paths:
                   standard:
                     type: string
                   state:
+                    enum:
+                    - unknown
+                    - pending
+                    - confirmed
                     type: string
                   symbol:
                     type: string
@@ -6482,6 +6862,9 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - fungible
+                    - nonfungible
                     type: string
                 type: object
           description: Success
@@ -6537,6 +6920,10 @@ paths:
                   standard:
                     type: string
                   state:
+                    enum:
+                    - unknown
+                    - pending
+                    - confirmed
                     type: string
                   symbol:
                     type: string
@@ -6547,6 +6934,9 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - fungible
+                    - nonfungible
                     type: string
                 type: object
           description: Success
@@ -6709,6 +7099,10 @@ paths:
                           type: string
                       type: object
                     type:
+                      enum:
+                      - mint
+                      - burn
+                      - transfer
                       type: string
                   type: object
                 type: array
@@ -6880,6 +7274,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -6915,6 +7313,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -6978,6 +7380,10 @@ paths:
                         type: string
                     type: object
                   type:
+                    enum:
+                    - mint
+                    - burn
+                    - transfer
                     type: string
                 type: object
           description: Success
@@ -7111,6 +7517,11 @@ paths:
                         signer:
                           type: string
                         type:
+                          enum:
+                          - none
+                          - batch_pin
+                          - token_pool
+                          - token_transfer
                           type: string
                       type: object
                   type: object
@@ -7251,6 +7662,11 @@ paths:
                       signer:
                         type: string
                       type:
+                        enum:
+                        - none
+                        - batch_pin
+                        - token_pool
+                        - token_transfer
                         type: string
                     type: object
                 type: object
@@ -7307,6 +7723,11 @@ paths:
                         signer:
                           type: string
                         type:
+                          enum:
+                          - none
+                          - batch_pin
+                          - token_pool
+                          - token_transfer
                           type: string
                       type: object
                   type: object
@@ -7900,6 +8321,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -7907,6 +8335,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -7968,6 +8402,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -7975,6 +8416,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success
@@ -8048,6 +8495,13 @@ paths:
                       txtype:
                         type: string
                       type:
+                        enum:
+                        - definition
+                        - broadcast
+                        - private
+                        - groupinit
+                        - transfer_broadcast
+                        - transfer_private
                         type: string
                     type: object
                   pins:
@@ -8055,6 +8509,12 @@ paths:
                       type: string
                     type: array
                   state:
+                    enum:
+                    - staged
+                    - ready
+                    - pending
+                    - confirmed
+                    - rejected
                     type: string
                 type: object
           description: Success

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/docker/go-units v0.4.0
-	github.com/getkin/kin-openapi v0.81.0
+	github.com/getkin/kin-openapi v0.83.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-resty/resty/v2 v2.7.0
@@ -53,3 +53,5 @@ require (
 	gopkg.in/ini.v1 v1.64.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
+
+replace github.com/getkin/kin-openapi => ../kin-openapi

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/docker/go-units v0.4.0
-	github.com/getkin/kin-openapi v0.83.0
+	github.com/getkin/kin-openapi v0.84.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-resty/resty/v2 v2.7.0
@@ -53,5 +53,3 @@ require (
 	gopkg.in/ini.v1 v1.64.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
-
-replace github.com/getkin/kin-openapi => ../kin-openapi

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXt
 github.com/gabriel-vasile/mimetype v1.3.1/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/gabriel-vasile/mimetype v1.4.0/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/getkin/kin-openapi v0.81.0 h1:avwkWFYWMZBvSMzewNA9ZdQiAPmLkRALYKdU6xC6uyw=
-github.com/getkin/kin-openapi v0.81.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
+github.com/getkin/kin-openapi v0.84.0 h1:EBH74SpHJPdOV33fHBVgAxKjWBX2sLCfccalw7xyTOY=
+github.com/getkin/kin-openapi v0.84.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/apiserver/route_post_new_subscription.go
+++ b/internal/apiserver/route_post_new_subscription.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newSubscriptionSchemaGenerator(ctx context.Context) string {
-	baseSchema, _, _ := openapi3gen.NewSchemaRefForValue(&fftypes.Subscription{})
+	baseSchema, _ := openapi3gen.NewSchemaRefForValue(&fftypes.Subscription{}, nil)
 	baseProps := baseSchema.Value.Properties
 	delete(baseProps, "id")
 	delete(baseProps, "namespace")

--- a/internal/oapispec/openapi3.go
+++ b/internal/oapispec/openapi3.go
@@ -101,7 +101,7 @@ func addInput(ctx context.Context, doc *openapi3.T, input interface{}, mask []st
 		}
 	}
 	if schemaRef == nil {
-		schemaRef, _ = openapi3gen.NewSchemaRefAndComponentsForValue(maskFields(input, mask), doc.Components.Schemas, openapi3gen.SchemaCustomizer(ffTagHandler))
+		schemaRef, _ = openapi3gen.NewSchemaRefForValue(maskFields(input, mask), doc.Components.Schemas, openapi3gen.SchemaCustomizer(ffTagHandler))
 	}
 	op.RequestBody.Value.Content["application/json"] = &openapi3.MediaType{
 		Schema: schemaRef,
@@ -137,7 +137,7 @@ func addFormInput(ctx context.Context, op *openapi3.Operation, formParams []*For
 }
 
 func addOutput(ctx context.Context, doc *openapi3.T, route *Route, output interface{}, op *openapi3.Operation) {
-	schemaRef, _ := openapi3gen.NewSchemaRefAndComponentsForValue(output, doc.Components.Schemas, openapi3gen.SchemaCustomizer(ffTagHandler))
+	schemaRef, _ := openapi3gen.NewSchemaRefForValue(output, doc.Components.Schemas, openapi3gen.SchemaCustomizer(ffTagHandler))
 	s := i18n.Expand(ctx, i18n.MsgSuccessResponse)
 	for _, code := range route.JSONOutputCodes {
 		op.Responses[strconv.FormatInt(int64(code), 10)] = &openapi3.ResponseRef{

--- a/internal/oapispec/openapi3.go
+++ b/internal/oapispec/openapi3.go
@@ -46,6 +46,9 @@ func SwaggerGen(ctx context.Context, routes []*Route, url string) *openapi3.T {
 			Version:     "1.0",
 			Description: "Copyright © 2021 Kaleido, Inc.",
 		},
+		Components: openapi3.Components{
+			Schemas: make(openapi3.Schemas),
+		},
 	}
 	opIds := make(map[string]bool)
 	for _, route := range routes {
@@ -89,7 +92,7 @@ func ffTagHandler(name string, t reflect.Type, tag reflect.StructTag, schema *op
 	return nil
 }
 
-func addInput(ctx context.Context, input interface{}, mask []string, schemaDef func(context.Context) string, op *openapi3.Operation) {
+func addInput(ctx context.Context, doc *openapi3.T, input interface{}, mask []string, schemaDef func(context.Context) string, op *openapi3.Operation) {
 	var schemaRef *openapi3.SchemaRef
 	if schemaDef != nil {
 		err := json.Unmarshal([]byte(schemaDef(ctx)), &schemaRef)
@@ -98,7 +101,7 @@ func addInput(ctx context.Context, input interface{}, mask []string, schemaDef f
 		}
 	}
 	if schemaRef == nil {
-		schemaRef, _, _ = openapi3gen.NewSchemaRefForValue(maskFields(input, mask), openapi3gen.SchemaCustomizer(ffTagHandler))
+		schemaRef, _ = openapi3gen.NewSchemaRefAndComponentsForValue(maskFields(input, mask), doc.Components.Schemas, openapi3gen.SchemaCustomizer(ffTagHandler))
 	}
 	op.RequestBody.Value.Content["application/json"] = &openapi3.MediaType{
 		Schema: schemaRef,
@@ -133,8 +136,8 @@ func addFormInput(ctx context.Context, op *openapi3.Operation, formParams []*For
 	}
 }
 
-func addOutput(ctx context.Context, route *Route, output interface{}, op *openapi3.Operation) {
-	schemaRef, _, _ := openapi3gen.NewSchemaRefForValue(output)
+func addOutput(ctx context.Context, doc *openapi3.T, route *Route, output interface{}, op *openapi3.Operation) {
+	schemaRef, _ := openapi3gen.NewSchemaRefAndComponentsForValue(output, doc.Components.Schemas, openapi3gen.SchemaCustomizer(ffTagHandler))
 	s := i18n.Expand(ctx, i18n.MsgSuccessResponse)
 	for _, code := range route.JSONOutputCodes {
 		op.Responses[strconv.FormatInt(int64(code), 10)] = &openapi3.ResponseRef{
@@ -196,7 +199,7 @@ func addRoute(ctx context.Context, doc *openapi3.T, route *Route) {
 		}
 		initInput(op)
 		if input != nil {
-			addInput(ctx, input, route.JSONInputMask, route.JSONInputSchema, op)
+			addInput(ctx, doc, input, route.JSONInputMask, route.JSONInputSchema, op)
 		}
 		if route.FormUploadHandler != nil {
 			addFormInput(ctx, op, route.FormParams)
@@ -207,7 +210,7 @@ func addRoute(ctx context.Context, doc *openapi3.T, route *Route) {
 		output = route.JSONOutputValue()
 	}
 	if output != nil {
-		addOutput(ctx, route, output, op)
+		addOutput(ctx, doc, route, output, op)
 	}
 	for _, p := range route.PathParams {
 		example := p.Example

--- a/internal/oapispec/openapi3_test.go
+++ b/internal/oapispec/openapi3_test.go
@@ -30,6 +30,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type RecursiveType struct {
+	Field1     string           `json:"field1"`
+	Field2     string           `json:"field2"`
+	Field3     string           `json:"field3"`
+	Components []*RecursiveType `json:"children,omitempty"`
+}
+
 var testRoutes = []*Route{
 	{
 		Name:   "op1",
@@ -79,9 +86,8 @@ var testRoutes = []*Route{
 		},
 		FilterFactory:   nil,
 		Description:     i18n.MsgTBD,
-		JSONInputValue:  func() interface{} { return &fftypes.Data{} },
+		JSONInputValue:  func() interface{} { return &RecursiveType{} },
 		JSONOutputValue: func() interface{} { return nil },
-		JSONInputMask:   []string{"id"},
 		JSONOutputCodes: []int{http.StatusNoContent},
 		FormParams: []*FormParam{
 			{Name: "metadata", Description: i18n.MsgTBD},


### PR DESCRIPTION
- Depends on https://github.com/getkin/kin-openapi/pull/451
- Needs the `go.mod` replace stripping out before it can move out of draft
- Corrects a bug where we weren't honouring the `ffenum` etc. tags on outputs (only inputs) 