### PR TITLE
[helm] Support for Prometheus Metrics

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -36,6 +36,11 @@ jobs:
           helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager --wait
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
 
+      - name: install prom-operator
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+          helm install --set kubeStateMetrics.enabled=false --set nodeExporter.enabled=false --set grafana.enabled=false kube-prometheus prometheus-community/kube-prometheus-stack
+
       - name: install postgres
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami || true

--- a/deploy/charts/firefly/ci/it-values.yaml
+++ b/deploy/charts/firefly/ci/it-values.yaml
@@ -1,6 +1,7 @@
 config:
   debugEnabled: true
   adminEnabled: true
+  metricsEnabled: true
   preInit: true
 
   organizationName: "firefly-os"
@@ -14,6 +15,11 @@ config:
 
   ipfsApiUrl: "http://ipfs.firefly-os:5001"
   ipfsGatewayUrl: "http://ipfs.firefly-os:8080"
+
+core:
+  metrics:
+    serviceMonitor:
+      enabled: true
 
 dataexchange:
   certificate:

--- a/deploy/charts/firefly/templates/_helpers.tpl
+++ b/deploy/charts/firefly/templates/_helpers.tpl
@@ -97,6 +97,13 @@ admin:
   address: 0.0.0.0
   enabled: {{ .Values.config.adminEnabled }}
   preinit: {{ and .Values.config.adminEnabled .Values.config.preInit }}
+metrics:
+  enabled: {{ .Values.config.metricsEnabled }}
+{{- if .Values.config.metricsEnabled }}
+  path: {{ .Values.config.metricsPath }}
+  address: 0.0.0.0
+  port: {{  .Values.core.service.metricsPort }}
+{{- end }}
 ui:
   path: ./frontend
 org:

--- a/deploy/charts/firefly/templates/core/service.yaml
+++ b/deploy/charts/firefly/templates/core/service.yaml
@@ -23,5 +23,11 @@ spec:
       protocol: TCP
       name: admin
     {{- end }}
+    {{- if .Values.config.metricsEnabled }}
+    - port: {{ .Values.core.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "firefly.coreSelectorLabels" . | nindent 4 }}

--- a/deploy/charts/firefly/templates/core/servicemonitor.yaml
+++ b/deploy/charts/firefly/templates/core/servicemonitor.yaml
@@ -14,7 +14,7 @@ spec:
     - port: metrics
       path: {{ .Values.config.metricsPath }}
       interval: {{ .Values.core.metrics.serviceMonitor.scrapeInterval }}
-      {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
+      {{- if .Values.core.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
       {{- end }}
       {{- if .Values.core.metrics.serviceMonitor.metricRelabelings }}

--- a/deploy/charts/firefly/templates/core/servicemonitor.yaml
+++ b/deploy/charts/firefly/templates/core/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.core.metrics.serviceMonitor.enabled .Values.config.metricsEnabled }}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+# WARNING: prometheus-operator is not installed but serivcemonitor has been enabled, this will fail. Please install
+#          prometheus-operator to resolve this.
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+  {{- include "firefly.coreLabels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: metrics
+      path: {{ .Values.config.metricsPath }}
+      interval: {{ .Values.core.metrics.serviceMonitor.scrapeInterval }}
+      {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- if .Values.core.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.core.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
+  {{- if .Values.core.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.core.metrics.serviceMonitor.jobLabel | quote }}
+  {{- end }}
+  {{- if .Values.core.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml .Values.core.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.core.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- range .Values.core.metrics.serviceMonitor.targetLabels }}
+    - {{ . }}
+      {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+    {{- include "firefly.coreSelectorLabels" . | nindent 6 }}
+{{- end }}
+

--- a/deploy/charts/firefly/templates/core/statefulset.yaml
+++ b/deploy/charts/firefly/templates/core/statefulset.yaml
@@ -56,6 +56,11 @@ spec:
               containerPort: {{ .Values.core.service.adminPort }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.config.metricsEnabled }}
+            - name: metrics
+              containerPort: {{ .Values.core.service.metricsPort }}
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             tcpSocket:
               port: {{ if and .Values.config.adminEnabled .Values.config.preInit }}admin{{ else }}http{{ end }}

--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         - name: dx
           securityContext:
             {{- toYaml .Values.dataexchange.securityContext | nindent 12 }}
-          image: "{{ .Values.dataexchange.image.repository }}:{{ .Values.dataexchange.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.dataexchange.image.repository }}:{{ .Values.dataexchange.image.tag }}"
           imagePullPolicy: {{ .Values.dataexchange.image.pullPolicy }}
           {{- if .Values.dataexchange.extraEnv }}
           env:

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -6,6 +6,10 @@ config:
   # Enables the Admin API port for dynamic configuration
   adminEnabled: true
 
+  # Enables the metrics server / port for Prometheus scraping
+  metricsEnabled: true
+  metricsPath: /metrics
+
   # Puts a fresh FireFly node into the preinit state, allowing an operator to then setup smart contracts, apply database migrations, etc. before re-configuring the node to proceed.
   # It is _not_ recommended to configure FireFly nodes in a preinit state for non-development scenarios.
   preInit: false
@@ -127,6 +131,13 @@ core:
     httpPort: 5000
     adminPort: 5001
     debugPort: 6060
+    metricsPort: 5100
+
+  metrics:
+    serviceMonitor:
+      enabled: false
+      scrapeInterval: 10s
+
 
   # NOTE: The Ingress will only expose the HTTP API and never the Admin or Debug APIs
   ingress:

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -8,6 +8,8 @@ config:
 
   # Enables the metrics server / port for Prometheus scraping
   metricsEnabled: true
+
+  # Configures the path on which Prometheus metrics are served, useful if you need to change it to match existing Prometheus scrape configs
   metricsPath: /metrics
 
   # Puts a fresh FireFly node into the preinit state, allowing an operator to then setup smart contracts, apply database migrations, etc. before re-configuring the node to proceed.
@@ -137,7 +139,6 @@ core:
     serviceMonitor:
       enabled: false
       scrapeInterval: 10s
-
 
   # NOTE: The Ingress will only expose the HTTP API and never the Admin or Debug APIs
   ingress:


### PR DESCRIPTION
Closes #322

## Adds
* Configuring `metrics` section of FireFly core
* Support for an optional `ServiceMonitor` object
* Tests `ServiceMonitor` install via IT test in GH actions
