### PR TITLE
Fix Hyperledger Image Refs and Migration Job's Postgres URL in Helm Chart

### DIFF
--- a/deploy/charts/firefly/Chart.yaml
+++ b/deploy/charts/firefly/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: firefly
-description: A Helm chart for Kubernetes
+description: A Helm chart for deploying FireFly and FireFly HTTPS Dataexchange onto Kubernetes.
 type: application
-appVersion: "0.11.0"
+appVersion: "0.11.1"
 version: "0.1.0"
 
 maintainers:
@@ -10,3 +10,5 @@ maintainers:
     email: hayden.fuss@kaleido.io
   - name: drewmarshburn
     email: drew.marshburn@kaleido.io
+  - name: peterbroadhurst
+    email: peter.broadhurst@kaleido.io

--- a/deploy/charts/firefly/Chart.yaml
+++ b/deploy/charts/firefly/Chart.yaml
@@ -2,9 +2,8 @@ apiVersion: v2
 name: firefly
 description: A Helm chart for Kubernetes
 type: application
-# TODO appVersion and version might be the same once an official FireFly release is made
-appVersion: "0.0.1"
-version: "0.0.1"
+appVersion: "0.11.0"
+version: "0.1.0"
 
 maintainers:
   - name: hfuss

--- a/deploy/charts/firefly/templates/core/secret.yaml
+++ b/deploy/charts/firefly/templates/core/secret.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "firefly.coreLabels" . | nindent 4 }}
 stringData:
+  {{- if and .Values.config.postgresUrl .Values.config.postgresMigrationJob -}}
+  psql_url: {{ tpl .Values.config.postgresUrl . }}
+  {{- end }}
   firefly.core: |
     {{- if .Values.config.templateOverride }}
     {{- toYaml (tpl .Values.config.templateOverride .) | nindent 4 }}

--- a/deploy/charts/firefly/templates/core/statefulset.yaml
+++ b/deploy/charts/firefly/templates/core/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
         - name: firefly
           securityContext:
             {{- toYaml .Values.core.securityContext | nindent 12 }}
-          image: "{{ .Values.core.image.repository }}:{{ .Values.core.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.core.image.repository }}:{{ .Values.core.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.core.image.pullPolicy }}
           env:
             - name: FIREFLY_NODE_NAME

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -190,7 +190,7 @@ dataexchange:
     repository: ghcr.io/hyperledger/firefly-dataexchange-https
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.1
+    tag: v0.9.2
 
   imagePullSecrets: []
   nameOverride: ""
@@ -215,13 +215,14 @@ dataexchange:
     p2pPort: 5001
 
   # The Ingress templated will only expose the HTTPS DataExchange P2P endpoint, as its API will only need to be accessible to FireFly
-  # NOTE: tls is not templatable for the Ingress since it is provided as part of the mTLS certificate above.
+  # NOTE: TLS is not templatable for the Ingress since it is provided as part of the mTLS certificate above. TLS passthrough
+  #       must be enabled for the Ingress in order for mTLS to work, make sure to set the appropriate annotation for your
+  #       respective Ingress controller. See below for an example of the passthrough annotation for ingress-nginx.
   ingress:
     enabled: false
     className: ""
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+      # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     hosts:
       - host: chart-example.local
 

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -96,10 +96,10 @@ config:
 # Configures the properties of the StatefulSet, Service, and optionally Ingress used to deploy and expose FireFly
 core:
   image:
-    repository: ghcr.io/hyperledger-labs/firefly
+    repository: ghcr.io/hyperledger/firefly
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: latest
+    # tag: latest
 
   extraEnv: []
     # - name: FIREFLY_LOG_LEVEL
@@ -187,10 +187,10 @@ dataexchange:
     #   value: DEBUG
 
   image:
-    repository: ghcr.io/hyperledger-labs/firefly-dataexchange-https
+    repository: ghcr.io/hyperledger/firefly-dataexchange-https
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: latest
+    tag: v0.9.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -133,7 +133,7 @@ var (
 	MsgUnknownDataExchangePlugin   = ffm("FF10213", "Unknown Data Exchange plugin '%s'")
 	MsgParentIdentityNotFound      = ffm("FF10214", "Organization with identity '%s' not found in identity chain for %s '%s'")
 	MsgInvalidSigningIdentity      = ffm("FF10215", "Invalid signing identity")
-	MsgNodeAndOrgIDMustBeSet       = ffm("FF10216", "node.name, org.name and org.identity must be configured first", 409)
+	MsgNodeAndOrgIDMustBeSet       = ffm("FF10216", "node.name, org.name and org.key must be configured first", 409)
 	MsgBlobStreamingFailed         = ffm("FF10217", "Blob streaming terminated with error", 500)
 	MsgMultiPartFormReadError      = ffm("FF10218", "Error reading multi-part form input", 400)
 	MsgGroupMustHaveMembers        = ffm("FF10219", "Group must have at least one member", 400)


### PR DESCRIPTION
Noticed these when trying to deploy FireFly in live environments via the Helm chart

## Fixes

* `psql_url` needs to be a key in the `firefly-config` `Secret` when using the migration job
* uses for `ghcr.io/hyperledger/` for Docker repos
* no longer uses `latest` image tag, and instead uses `v0.9.2` for DX and `.Chart.AppVersion` for FF (which is set to `v0.11.1`)
* error message for when `organization.key` is not set is misleading since it reference the deprecated `organization.identity`