### PR TITLE
Replace UpsertOperation with InsertOperation

### DIFF
--- a/internal/assets/token_pool.go
+++ b/internal/assets/token_pool.go
@@ -111,7 +111,7 @@ func (am *assetManager) createTokenPoolInternal(ctx context.Context, pool *fftyp
 	err = am.database.RunAsGroup(ctx, func(ctx context.Context) (err error) {
 		err = am.database.UpsertTransaction(ctx, tx, false /* should be new, or idempotent replay */)
 		if err == nil {
-			err = am.database.UpsertOperation(ctx, op, false)
+			err = am.database.InsertOperation(ctx, op)
 		}
 		return err
 	})

--- a/internal/assets/token_pool_test.go
+++ b/internal/assets/token_pool_test.go
@@ -94,7 +94,7 @@ func TestCreateTokenPoolFail(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mti.On("CreateTokenPool", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := am.CreateTokenPool(context.Background(), "ns1", pool, false)
@@ -136,7 +136,7 @@ func TestCreateTokenPoolOperationFail(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := am.CreateTokenPool(context.Background(), "ns1", pool, false)
 	assert.Regexp(t, "pop", err)
@@ -160,7 +160,7 @@ func TestCreateTokenPoolSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.CreateTokenPool(context.Background(), "ns1", pool, false)
 	assert.NoError(t, err)
@@ -184,7 +184,7 @@ func TestCreateTokenPoolUnknownConnectorSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.CreateTokenPool(context.Background(), "ns1", pool, false)
 	assert.NoError(t, err)
@@ -244,7 +244,7 @@ func TestCreateTokenPoolConfirm(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil).Times(1)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil).Times(1)
 	msa.On("WaitForTokenPool", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			send := args[3].(syncasync.RequestSender)
@@ -322,7 +322,7 @@ func TestCreateTokenPoolByTypeFail(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mti.On("CreateTokenPool", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := am.CreateTokenPoolByType(context.Background(), "ns1", "magic-tokens", pool, false)
@@ -364,7 +364,7 @@ func TestCreateTokenPoolByTypeOperationFail(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := am.CreateTokenPoolByType(context.Background(), "ns1", "magic-tokens", pool, false)
 	assert.Regexp(t, "pop", err)
@@ -388,7 +388,7 @@ func TestCreateTokenPoolByTypeSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.CreateTokenPoolByType(context.Background(), "ns1", "magic-tokens", pool, false)
 	assert.NoError(t, err)
@@ -413,7 +413,7 @@ func TestCreateTokenPoolByTypeConfirm(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenPool
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil).Times(1)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil).Times(1)
 	msa.On("WaitForTokenPool", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			send := args[3].(syncasync.RequestSender)

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -283,7 +283,7 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) er
 		if err != nil {
 			return err
 		}
-		if err = s.mgr.database.UpsertOperation(ctx, op, false); err != nil {
+		if err = s.mgr.database.InsertOperation(ctx, op); err != nil {
 			return err
 		}
 		if s.transfer.Message != nil {

--- a/internal/assets/token_transfer_test.go
+++ b/internal/assets/token_transfer_test.go
@@ -130,7 +130,7 @@ func TestMintTokensSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
 	assert.NoError(t, err)
@@ -160,7 +160,7 @@ func TestMintTokenUnknownConnectorSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
 	assert.NoError(t, err)
@@ -281,7 +281,7 @@ func TestMintTokenUnknownPoolSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
 	assert.NoError(t, err)
@@ -453,7 +453,7 @@ func TestMintTokensFail(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
 	assert.EqualError(t, err, "pop")
@@ -481,7 +481,7 @@ func TestMintTokensOperationFail(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
 	assert.EqualError(t, err, "pop")
@@ -513,7 +513,7 @@ func TestMintTokensConfirm(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	msa.On("WaitForTokenTransfer", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			send := args[3].(syncasync.RequestSender)
@@ -553,7 +553,7 @@ func TestMintTokensByTypeSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokensByType(context.Background(), "ns1", "magic-tokens", "pool1", mint, false)
 	assert.NoError(t, err)
@@ -583,7 +583,7 @@ func TestBurnTokensSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.BurnTokens(context.Background(), "ns1", burn, false)
 	assert.NoError(t, err)
@@ -637,7 +637,7 @@ func TestBurnTokensConfirm(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	msa.On("WaitForTokenTransfer", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			send := args[3].(syncasync.RequestSender)
@@ -677,7 +677,7 @@ func TestBurnTokensByTypeSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.BurnTokensByType(context.Background(), "ns1", "magic-tokens", "pool1", burn, false)
 	assert.NoError(t, err)
@@ -713,7 +713,7 @@ func TestTransferTokensSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.TransferTokens(context.Background(), "ns1", transfer, false)
 	assert.NoError(t, err)
@@ -812,7 +812,7 @@ func TestTransferTokensInvalidType(t *testing.T) {
 	mdi.On("UpsertTransaction", am.ctx, mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", am.ctx, mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", am.ctx, mock.Anything).Return(nil)
 
 	sender := &transferSender{
 		mgr:       am,
@@ -899,7 +899,7 @@ func TestTransferTokensWithBroadcastMessage(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mbm.On("NewBroadcast", "ns1", transfer.Message).Return(mms)
 	mms.On("Prepare", context.Background()).Return(nil)
 	mdi.On("UpsertMessage", context.Background(), mock.MatchedBy(func(msg *fftypes.Message) bool {
@@ -997,7 +997,7 @@ func TestTransferTokensWithPrivateMessage(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mpm.On("NewMessage", "ns1", transfer.Message).Return(mms)
 	mms.On("Prepare", context.Background()).Return(nil)
 	mdi.On("UpsertMessage", context.Background(), mock.MatchedBy(func(msg *fftypes.Message) bool {
@@ -1078,7 +1078,7 @@ func TestTransferTokensConfirm(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	msa.On("WaitForTokenTransfer", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			send := args[3].(syncasync.RequestSender)
@@ -1136,7 +1136,7 @@ func TestTransferTokensWithBroadcastConfirm(t *testing.T) {
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
@@ -1196,7 +1196,7 @@ func TestTransferTokensByTypeSuccess(t *testing.T) {
 	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
 		return tx.Subject.Type == fftypes.TransactionTypeTokenTransfer
 	}), false).Return(nil)
-	mdi.On("UpsertOperation", context.Background(), mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.TransferTokensByType(context.Background(), "ns1", "magic-tokens", "pool1", transfer, false)
 	assert.NoError(t, err)

--- a/internal/batchpin/batchpin.go
+++ b/internal/batchpin/batchpin.go
@@ -73,7 +73,7 @@ func (bp *batchPinSubmitter) SubmitPinnedBatch(ctx context.Context, batch *fftyp
 		"",
 		fftypes.OpTypeBlockchainBatchPin,
 		fftypes.OpStatusPending)
-	err = bp.database.UpsertOperation(ctx, op, false)
+	err = bp.database.InsertOperation(ctx, op)
 	if err != nil {
 		return err
 	}

--- a/internal/batchpin/batchpin_test.go
+++ b/internal/batchpin/batchpin_test.go
@@ -63,12 +63,12 @@ func TestSubmitPinnedBatchOk(t *testing.T) {
 	contexts := []*fftypes.Bytes32{}
 
 	mdi.On("UpsertTransaction", ctx, mock.Anything, false).Return(nil)
-	mdi.On("UpsertOperation", ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		assert.Equal(t, fftypes.OpTypeBlockchainBatchPin, op.Type)
 		assert.Equal(t, "ut", op.Plugin)
 		assert.Equal(t, *batch.Payload.TX.ID, *op.Transaction)
 		return true
-	}), false).Return(nil)
+	})).Return(nil)
 	mbi.On("SubmitBatchPin", ctx, mock.Anything, (*fftypes.UUID)(nil), "0x12345", mock.Anything).Return(nil)
 
 	err := bp.SubmitPinnedBatch(ctx, batch, contexts)
@@ -99,12 +99,12 @@ func TestSubmitPinnedBatchWithMetricsOk(t *testing.T) {
 	contexts := []*fftypes.Bytes32{}
 
 	mdi.On("UpsertTransaction", ctx, mock.Anything, false).Return(nil)
-	mdi.On("UpsertOperation", ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		assert.Equal(t, fftypes.OpTypeBlockchainBatchPin, op.Type)
 		assert.Equal(t, "ut", op.Plugin)
 		assert.Equal(t, *batch.Payload.TX.ID, *op.Transaction)
 		return true
-	}), false).Return(nil)
+	})).Return(nil)
 	mbi.On("SubmitBatchPin", ctx, mock.Anything, (*fftypes.UUID)(nil), "0x12345", mock.Anything).Return(nil)
 
 	err := bp.SubmitPinnedBatch(ctx, batch, contexts)
@@ -133,7 +133,7 @@ func TestSubmitPinnedBatchOpFail(t *testing.T) {
 	contexts := []*fftypes.Bytes32{}
 
 	mdi.On("UpsertTransaction", ctx, mock.Anything, false).Return(nil)
-	mdi.On("UpsertOperation", ctx, mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", ctx, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := bp.SubmitPinnedBatch(ctx, batch, contexts)
 	assert.Regexp(t, "pop", err)

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -129,7 +129,7 @@ func (bm *broadcastManager) submitTXAndUpdateDB(ctx context.Context, batch *ffty
 		fftypes.OpTypePublicStorageBatchBroadcast,
 		fftypes.OpStatusSucceeded, // Note we performed the action synchronously above
 	)
-	err = bm.database.UpsertOperation(ctx, op, false)
+	err = bm.database.InsertOperation(ctx, op)
 	if err != nil {
 		return err
 	}

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -154,7 +154,7 @@ func TestDispatchBatchSubmitBatchPinSucceed(t *testing.T) {
 	mbp := bm.batchpin.(*batchpinmocks.Submitter)
 	mps.On("PublishData", mock.Anything, mock.Anything).Return("id1", nil)
 	mdi.On("UpdateBatch", mock.Anything, batch.ID, mock.Anything).Return(nil)
-	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", mock.Anything, mock.Anything).Return(nil)
 	mbp.On("SubmitPinnedBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	err := bm.dispatchBatch(context.Background(), batch, []*fftypes.Bytes32{fftypes.NewRandB32()})
@@ -170,7 +170,7 @@ func TestDispatchBatchSubmitBroadcastFail(t *testing.T) {
 	mbp := bm.batchpin.(*batchpinmocks.Submitter)
 	mps.On("PublishData", mock.Anything, mock.Anything).Return("id1", nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", mock.Anything, mock.Anything).Return(nil)
 	mbp.On("SubmitPinnedBatch", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := bm.dispatchBatch(context.Background(), &fftypes.Batch{Identity: fftypes.Identity{Author: "wrong", Key: "wrong"}}, []*fftypes.Bytes32{fftypes.NewRandB32()})
@@ -198,7 +198,7 @@ func TestSubmitTXAndUpdateDBAddOp1Fail(t *testing.T) {
 	mbi := bm.blockchain.(*blockchainmocks.Plugin)
 	mdi.On("UpsertTransaction", mock.Anything, mock.Anything, false).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 	mbi.On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("txid", nil)
 	mbi.On("Name").Return("unittest")
 
@@ -226,7 +226,7 @@ func TestSubmitTXAndUpdateDBSucceed(t *testing.T) {
 	mbp := bm.batchpin.(*batchpinmocks.Submitter)
 	mdi.On("UpsertTransaction", mock.Anything, mock.Anything, false).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mdi.On("UpsertOperation", mock.Anything, mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", mock.Anything, mock.Anything).Return(nil)
 	mbi.On("SubmitBatchPin", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mbp.On("SubmitPinnedBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -132,7 +132,7 @@ func (em *eventManager) shouldAnnounce(ctx context.Context, ti tokens.Plugin, po
 		"",
 		fftypes.OpTypeTokenAnnouncePool,
 		fftypes.OpStatusPending)
-	return announcePool, em.database.UpsertOperation(ctx, nextOp, false)
+	return announcePool, em.database.InsertOperation(ctx, nextOp)
 }
 
 // It is expected that this method might be invoked twice for each pool, depending on the behavior of the connector.

--- a/internal/events/token_pool_created_test.go
+++ b/internal/events/token_pool_created_test.go
@@ -321,9 +321,9 @@ func TestTokenPoolCreatedAnnounce(t *testing.T) {
 	mdi.On("GetTokenPoolByProtocolID", em.ctx, "erc1155", "123").Return(nil, nil).Times(2)
 	mdi.On("GetOperations", em.ctx, mock.Anything).Return(nil, nil, fmt.Errorf("pop")).Once()
 	mdi.On("GetOperations", em.ctx, mock.Anything).Return(operations, nil, nil).Once()
-	mdi.On("UpsertOperation", em.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", em.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		return op.Type == fftypes.OpTypeTokenAnnouncePool
-	}), false).Return(nil)
+	})).Return(nil)
 	mbm.On("BroadcastTokenPool", em.ctx, "test-ns", mock.MatchedBy(func(pool *fftypes.TokenPoolAnnouncement) bool {
 		return pool.Pool.Namespace == "test-ns" && pool.Pool.Name == "my-pool" && *pool.Pool.ID == *poolID
 	}), false).Return(nil, nil)

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -165,7 +165,7 @@ func (pm *privateMessaging) transferBlobs(ctx context.Context, data []*fftypes.D
 					trackingID,
 					fftypes.OpTypeDataExchangeBlobSend,
 					fftypes.OpStatusPending)
-				if err = pm.database.UpsertOperation(ctx, op, false); err != nil {
+				if err = pm.database.InsertOperation(ctx, op); err != nil {
 					return err
 				}
 			}
@@ -211,7 +211,7 @@ func (pm *privateMessaging) sendData(ctx context.Context, mType string, mID *fft
 				trackingID,
 				fftypes.OpTypeDataExchangeBatchSend,
 				fftypes.OpStatusPending)
-			if err = pm.database.UpsertOperation(ctx, op, false); err != nil {
+			if err = pm.database.InsertOperation(ctx, op); err != nil {
 				return err
 			}
 		}

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -130,22 +130,22 @@ func TestDispatchBatchWithBlobs(t *testing.T) {
 		PayloadRef: "/blob/1",
 	}, nil)
 	mdx.On("TransferBLOB", pm.ctx, "node1", "/blob/1").Return("tracking1", nil)
-	mdi.On("UpsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		return op.BackendID == "tracking1" && op.Type == fftypes.OpTypeDataExchangeBlobSend
-	}), false).Return(nil, nil)
+	})).Return(nil, nil)
 	mdx.On("TransferBLOB", pm.ctx, "node2", "/blob/1").Return("tracking2", nil)
-	mdi.On("UpsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		return op.BackendID == "tracking2" && op.Type == fftypes.OpTypeDataExchangeBlobSend
-	}), false).Return(nil, nil)
+	})).Return(nil, nil)
 
 	mdx.On("SendMessage", pm.ctx, mock.Anything, mock.Anything).Return("tracking3", nil).Once()
-	mdi.On("UpsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		return op.BackendID == "tracking3" && op.Type == fftypes.OpTypeDataExchangeBatchSend
-	}), false).Return(nil, nil)
+	})).Return(nil, nil)
 	mdx.On("SendMessage", pm.ctx, mock.Anything, mock.Anything).Return("tracking4", nil).Once()
-	mdi.On("UpsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
+	mdi.On("InsertOperation", pm.ctx, mock.MatchedBy(func(op *fftypes.Operation) bool {
 		return op.BackendID == "tracking4" && op.Type == fftypes.OpTypeDataExchangeBatchSend
-	}), false).Return(nil, nil)
+	})).Return(nil, nil)
 
 	mbp.On("SubmitPinnedBatch", pm.ctx, mock.Anything, mock.Anything).Return(nil)
 
@@ -270,7 +270,7 @@ func TestSendImmediateFail(t *testing.T) {
 	assert.Regexp(t, "pop", err)
 }
 
-func TestSendSubmitUpsertOperationFail(t *testing.T) {
+func TestSendSubmitInsertOperationFail(t *testing.T) {
 	pm, cancel := newTestPrivateMessaging(t)
 	defer cancel()
 
@@ -281,7 +281,7 @@ func TestSendSubmitUpsertOperationFail(t *testing.T) {
 	mdx.On("SendMessage", pm.ctx, mock.Anything, mock.Anything).Return("tracking1", nil)
 
 	mdi := pm.database.(*databasemocks.Plugin)
-	mdi.On("UpsertOperation", pm.ctx, mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", pm.ctx, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := pm.sendAndSubmitBatch(pm.ctx, &fftypes.Batch{
 		Identity: fftypes.Identity{
@@ -339,7 +339,7 @@ func TestWriteTransactionSubmitBatchPinFail(t *testing.T) {
 
 	mdi := pm.database.(*databasemocks.Plugin)
 	mdi.On("UpsertTransaction", pm.ctx, mock.Anything, true, false).Return(nil)
-	mdi.On("UpsertOperation", pm.ctx, mock.Anything, false).Return(nil)
+	mdi.On("InsertOperation", pm.ctx, mock.Anything).Return(nil)
 
 	mbp := pm.batchpin.(*batchpinmocks.Submitter)
 	mbp.On("SubmitPinnedBatch", pm.ctx, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
@@ -388,7 +388,7 @@ func TestTransferBlobsOpInsertFail(t *testing.T) {
 
 	mdi.On("GetBlobMatchingHash", pm.ctx, mock.Anything).Return(&fftypes.Blob{PayloadRef: "blob/1"}, nil)
 	mdx.On("TransferBLOB", pm.ctx, "peer1", "blob/1").Return("tracking1", nil)
-	mdi.On("UpsertOperation", pm.ctx, mock.Anything, false).Return(fmt.Errorf("pop"))
+	mdi.On("InsertOperation", pm.ctx, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := pm.transferBlobs(pm.ctx, []*fftypes.Data{
 		{ID: fftypes.NewUUID(), Hash: fftypes.NewRandB32(), Blob: &fftypes.BlobRef{Hash: fftypes.NewRandB32()}},

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -1707,6 +1707,20 @@ func (_m *Plugin) InsertNextPin(ctx context.Context, nextpin *fftypes.NextPin) e
 	return r0
 }
 
+// InsertOperation provides a mock function with given fields: ctx, operation
+func (_m *Plugin) InsertOperation(ctx context.Context, operation *fftypes.Operation) error {
+	ret := _m.Called(ctx, operation)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Operation) error); ok {
+		r0 = rf(ctx, operation)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Name provides a mock function with given fields:
 func (_m *Plugin) Name() string {
 	ret := _m.Called()
@@ -2092,20 +2106,6 @@ func (_m *Plugin) UpsertOffset(ctx context.Context, data *fftypes.Offset, allowE
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Offset, bool) error); ok {
 		r0 = rf(ctx, data, allowExisting)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpsertOperation provides a mock function with given fields: ctx, operation, allowExisting
-func (_m *Plugin) UpsertOperation(ctx context.Context, operation *fftypes.Operation, allowExisting bool) error {
-	ret := _m.Called(ctx, operation, allowExisting)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Operation, bool) error); ok {
-		r0 = rf(ctx, operation, allowExisting)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -194,8 +194,8 @@ type iPinCollection interface {
 }
 
 type iOperationCollection interface {
-	// UpsertOperation - Upsert an operation
-	UpsertOperation(ctx context.Context, operation *fftypes.Operation, allowExisting bool) (err error)
+	// InsertOperation - Insert an operation
+	InsertOperation(ctx context.Context, operation *fftypes.Operation) (err error)
 
 	// UpdateOperation - Update operation by ID
 	UpdateOperation(ctx context.Context, id *fftypes.UUID, update Update) (err error)


### PR DESCRIPTION
No code path ever passes allowExisting=true, and we already have a separate
UpdateOperation method for updates. Therefore, rename this method to
InsertOperation and remove the unneeded branches.