### PR TITLE
[helm] Adding Storage for DX Blobs and PVC Templating Improvements

### DIFF
--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -67,8 +67,10 @@ spec:
             {{- toYaml .Values.dataexchange.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data/peer-certs
-              name: {{ include "firefly.fullname" . }}-dx-peer-certs
+              subPath: peer-certs
+              name: {{ include "firefly.fullname" . }}-dx-peers
             - mountPath: /data/peers
+              subPath: peers
               name: {{ include "firefly.fullname" . }}-dx-peers
             - mountPath: /data/config.json
               name: config
@@ -83,7 +85,10 @@ spec:
               name: tls
               subPath: ca.crt
             - mountPath: /data/blobs
-              name: blobs
+              {{- if and .Values.dataexchange.persistentVolumes.blobs.enabled .Values.dataexchange.persistentVolumes.blobs.subPath }}
+              subPath: {{ .Values.dataexchange.persistentVolumes.blobs.subPath | quote }}
+              {{- end }}
+              name: {{ include "firefly.fullname" . }}-dx-blobs
       {{- with .Values.dataexchange.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -103,24 +108,49 @@ spec:
         - name: tls
           secret:
             secretName: {{ if and .Values.dataexchange.certificate.enabled (not .Values.dataexchange.tlsSecret.enabled) }}"{{ include "firefly.fullname" . }}-dx-tls"{{ else }}{{ .Values.dataexchange.tlsSecret.name }}{{ end }}
-        - name: blobs
-          emptyDir:
-            sizeLimit: {{  .Values.dataexchange.blobStorageSize }}
+        {{- if not .Values.dataexchange.persistentVolumes.blobs.enabled }}
+        - name: {{ include "firefly.fullname" . }}-dx-blobs
+          emptyDir: {}
+        {{- end }}
+        {{- if not .Values.dataexchange.persistentVolumes.peers.enabled }}
+        - name: {{ include "firefly.fullname" . }}-dx-peers
+          emptyDir: {}
+  {{- end }}
+  {{- if or .Values.dataexchange.persistentVolumes.blobs.enabled .Values.dataexchange.persistentVolumes.peers.enabled }}
   volumeClaimTemplates:
+    {{- if .Values.dataexchange.persistentVolumes.blobs.enabled }}
     - metadata:
-        name: {{ include "firefly.fullname" . }}-dx-peer-certs
+      {{- with .Values.dataexchange.persistentVolumes.blobs }}
+        name: {{ include "firefly.fullname" . }}-dx-blobs
+        {{ with .annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
-          - ReadWriteOnce
+          {{- toYaml .accessModes | nindent 10 }}
+        storageClassName: {{ .storageClass }}
         resources:
           requests:
-            storage: 1Gi
-    - metadata:
+            storage: {{ .size }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.dataexchange.persistentVolumes.peers.enabled }}
+      - metadata:
+        {{- with .Values.dataexchange.persistentVolumes.peers }}
         name: {{ include "firefly.fullname" . }}-dx-peers
+        {{ with .annotations }}
+        annotations:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
       spec:
         accessModes:
-          - ReadWriteOnce
+        {{- toYaml .accessModes | nindent 10 }}
+        storageClassName: {{ .storageClass }}
         resources:
           requests:
-            storage: 1Gi
+            storage: {{ .size }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -82,6 +82,8 @@ spec:
             - mountPath: /data/ca.pem
               name: tls
               subPath: ca.crt
+            - mountPath: /data/blobs
+              name: blobs
       {{- with .Values.dataexchange.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -101,6 +103,9 @@ spec:
         - name: tls
           secret:
             secretName: {{ if and .Values.dataexchange.certificate.enabled (not .Values.dataexchange.tlsSecret.enabled) }}"{{ include "firefly.fullname" . }}-dx-tls"{{ else }}{{ .Values.dataexchange.tlsSecret.name }}{{ end }}
+        - name: blobs
+          emptyDir:
+            sizeLimit: {{  .Values.dataexchange.blobStorageSize }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "firefly.fullname" . }}-dx-peer-certs

--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -115,14 +115,14 @@ spec:
         {{- if not .Values.dataexchange.persistentVolumes.peers.enabled }}
         - name: {{ include "firefly.fullname" . }}-dx-peers
           emptyDir: {}
-  {{- end }}
+        {{- end }}
   {{- if or .Values.dataexchange.persistentVolumes.blobs.enabled .Values.dataexchange.persistentVolumes.peers.enabled }}
   volumeClaimTemplates:
     {{- if .Values.dataexchange.persistentVolumes.blobs.enabled }}
     - metadata:
-      {{- with .Values.dataexchange.persistentVolumes.blobs }}
         name: {{ include "firefly.fullname" . }}-dx-blobs
-        {{ with .annotations }}
+      {{- with .Values.dataexchange.persistentVolumes.blobs }}
+        {{- with .annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -136,13 +136,13 @@ spec:
       {{- end }}
     {{- end }}
     {{- if .Values.dataexchange.persistentVolumes.peers.enabled }}
-      - metadata:
-        {{- with .Values.dataexchange.persistentVolumes.peers }}
+    - metadata:
         name: {{ include "firefly.fullname" . }}-dx-peers
-        {{ with .annotations }}
+      {{- with .Values.dataexchange.persistentVolumes.peers }}
+        {{- with .annotations }}
         annotations:
-        {{- toYaml . | nindent 10 }}
-      {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
         {{- toYaml .accessModes | nindent 10 }}

--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -112,13 +112,8 @@ spec:
         - name: {{ include "firefly.fullname" . }}-dx-blobs
           emptyDir: {}
         {{- end }}
-        {{- if not .Values.dataexchange.persistentVolumes.peers.enabled }}
-        - name: {{ include "firefly.fullname" . }}-dx-peers
-          emptyDir: {}
-        {{- end }}
   {{- if or .Values.dataexchange.persistentVolumes.blobs.enabled .Values.dataexchange.persistentVolumes.peers.enabled }}
   volumeClaimTemplates:
-    {{- if .Values.dataexchange.persistentVolumes.blobs.enabled }}
     - metadata:
         name: {{ include "firefly.fullname" . }}-dx-blobs
       {{- with .Values.dataexchange.persistentVolumes.blobs }}
@@ -135,7 +130,6 @@ spec:
             storage: {{ .size }}
       {{- end }}
     {{- end }}
-    {{- if .Values.dataexchange.persistentVolumes.peers.enabled }}
     - metadata:
         name: {{ include "firefly.fullname" . }}-dx-peers
       {{- with .Values.dataexchange.persistentVolumes.peers }}
@@ -150,7 +144,5 @@ spec:
         resources:
           requests:
             storage: {{ .size }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
+      {{- end }}
 {{- end }}

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -189,8 +189,7 @@ dataexchange:
   image:
     repository: ghcr.io/hyperledger/firefly-dataexchange-https
     pullPolicy: Always
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: v0.9.2
+    tag: v0.9.3
 
   imagePullSecrets: []
   nameOverride: ""

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -247,7 +247,6 @@ dataexchange:
   persistentVolumes:
     # split into two mounts: /data/peers and /data/peer-certs
     peers:
-      enabled: true
       accessModes:
         - ReadWriteOnce
       annotations: {}

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -243,3 +243,5 @@ dataexchange:
   tolerations: []
 
   affinity: {}
+
+  blobStorageSize: 1Gi

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -244,4 +244,20 @@ dataexchange:
 
   affinity: {}
 
-  blobStorageSize: 1Gi
+  persistentVolumes:
+    # split into two mounts: /data/peers and /data/peer-certs
+    peers:
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+      annotations: {}
+      size: 1Gi
+      storageClass: ""
+    blobs:
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+      annotations: {}
+      subPath: ""
+      size: 2Gi
+      storageClass: ""


### PR DESCRIPTION
We aren't ensuring there's some sort of writeable filesystem to the DX pods for blob storage, might as well offer the ability to persist it too. This refactors how we template the DX PVCs to other more customization (size, storage class, etc.) for future users, as well as offers the ability to disable the PVCs and use `emptyDir` instead.

> **NOTE**: This does include a breaking change in the chart for how DX data is handled: `/data/peers` and `/data/peer-certs` are now apart of the same PVC but given subdirs within the volume. However, we have not made an official release of the chart yet.