### PR TITLE
[fabric] Dockerfile for Compiling firefly-go for Linux

### DIFF
--- a/smart_contracts/fabric/firefly-go/Dockerfile
+++ b/smart_contracts/fabric/firefly-go/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.16
+
+WORKDIR /app
+COPY  firefly.go go.mod go.sum ./
+COPY chaincode/ ./chaincode/
+RUN ls -la ./ \
+    && GO111MODULE=on GOOS=linux CGO_ENABLED=0 go build -o firefly.bin firefly.go
+


### PR DESCRIPTION
When deploying the Fabric chaincode for FireFly to Kaleido, I need to ensure I create a Linux-compatible binary for it but I have a Mac. I did so using this Dockerfile and the following commands:
```
docker build . -t firefly-go
container_id=$(docker create firefly-go)
docker cp ${container_id}:/app/firefly.bin ./
docker rm ${container_id}
```

Using `GOOS` with the build on my Mac did not seem to work. So opening this PR to get feedback on whether this makes sense (or if I'm missing something obvious), if we need docs or additional scripting to streamline this for other folks, etc.