### PR TITLE
Set fetch-depth to get the full history in GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
This is to fix the linter failing while checking the header copyright date for files that were not changed this year. This change pulls the full git history in the checkout stage, similar to what would happen if a user did a `git clone` on their local machine.

This PR will likely need to be merged without a passing build, due to the fact that all builds are stuck needing this change.