### PR TITLE
Fixing Duplicate Metrics Registration when Unsetting preInit

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -19,9 +19,12 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	muxprom "gitlab.com/hfuss/mux-prometheus/pkg/middleware"
 )
 
 var registry *prometheus.Registry
+var adminInstrumentation *muxprom.Instrumentation
+var restInstrumentation *muxprom.Instrumentation
 var BatchPinCounter prometheus.Counter
 
 // MetricsBatchPin is the prometheus metric for total number of batch pins submitted
@@ -38,6 +41,38 @@ func Registry() *prometheus.Registry {
 	return registry
 }
 
+// GetAdminServerInstrumentation returns the admin server's Prometheus middleware, ensuring its metrics are never
+// registered twice
+func GetAdminServerInstrumentation() *muxprom.Instrumentation {
+	if adminInstrumentation == nil {
+		adminInstrumentation = muxprom.NewCustomInstrumentation(
+			true,
+			"ff_apiserver",
+			"admin",
+			prometheus.DefBuckets,
+			map[string]string{},
+			Registry(),
+		)
+	}
+	return adminInstrumentation
+}
+
+// GetRestServerInstrumentation returns the REST server's Prometheus middleware, ensuring its metrics are never
+// registered twice
+func GetRestServerInstrumentation() *muxprom.Instrumentation {
+	if restInstrumentation == nil {
+		restInstrumentation = muxprom.NewCustomInstrumentation(
+			true,
+			"ff_apiserver",
+			"rest",
+			prometheus.DefBuckets,
+			map[string]string{},
+			Registry(),
+		)
+	}
+	return restInstrumentation
+}
+
 func initMetricsCollectors() {
 	BatchPinCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: MetricsBatchPin,
@@ -51,7 +86,9 @@ func registerMetricsCollectors() {
 	registry.MustRegister(BatchPinCounter)
 }
 
-// Clear will reset the Prometheus metrics registry, useful for testing
+// Clear will reset the Prometheus metrics registry and instrumentations, useful for testing
 func Clear() {
 	registry = nil
+	adminInstrumentation = nil
+	restInstrumentation = nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -45,14 +45,7 @@ func Registry() *prometheus.Registry {
 // registered twice
 func GetAdminServerInstrumentation() *muxprom.Instrumentation {
 	if adminInstrumentation == nil {
-		adminInstrumentation = muxprom.NewCustomInstrumentation(
-			true,
-			"ff_apiserver",
-			"admin",
-			prometheus.DefBuckets,
-			map[string]string{},
-			Registry(),
-		)
+		adminInstrumentation = newInstrumentation("admin")
 	}
 	return adminInstrumentation
 }
@@ -61,16 +54,20 @@ func GetAdminServerInstrumentation() *muxprom.Instrumentation {
 // registered twice
 func GetRestServerInstrumentation() *muxprom.Instrumentation {
 	if restInstrumentation == nil {
-		restInstrumentation = muxprom.NewCustomInstrumentation(
-			true,
-			"ff_apiserver",
-			"rest",
-			prometheus.DefBuckets,
-			map[string]string{},
-			Registry(),
-		)
+		restInstrumentation = newInstrumentation("rest")
 	}
 	return restInstrumentation
+}
+
+func newInstrumentation(subsystem string) *muxprom.Instrumentation {
+	return muxprom.NewCustomInstrumentation(
+		true,
+		"ff_apiserver",
+		subsystem,
+		prometheus.DefBuckets,
+		map[string]string{},
+		Registry(),
+	)
 }
 
 func initMetricsCollectors() {

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -67,7 +67,7 @@ if [ "$BUILD_FIREFLY" == "true" ]; then
 fi
 
 if [ "$DOWNLOAD_CLI" == "true" ]; then
-  go install github.com/hyperledger/firefly-cli/ff@v0.0.40
+  go install github.com/hyperledger/firefly-cli/ff@v0.0.41
   checkOk $?
 fi
 


### PR DESCRIPTION
The Prometheus registry panics when metrics are duplicated twice. With an `ff` bug fix in `v0.0.41`, @nguyer noticed `firefly` starts running with just the admin server, and then when it gets set to run both the admin server and the REST server without restarting the process, the admin middleware metrics would get re-registered causing a panic:
```
panic: duplicate metrics collector registration attempted

goroutine 242 [running]:
github.com/prometheus/client_golang/prometheus.(*wrappingRegisterer).MustRegister(0xc000453ad8, 0xc000453b00, 0x4, 0x4)
/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/wrap.go:104 +0x185
gitlab.com/hfuss/mux-prometheus/pkg/middleware.(*Instrumentation).initMetrics(0xc000012a00)
    /go/pkg/mod/gitlab.com/hfuss/mux-prometheus@v0.0.4/pkg/middleware/middleware.go:112 +0x66a
gitlab.com/hfuss/mux-prometheus/pkg/middleware.NewCustomInstrumentation(0xc0005f6801, 0xf51b74, 0xc, 0xf48b3d, 0x5, 0x157cce0, 0xb, 0xb, 0xc0005f68a0, 0x1086cf8, ...)
    /go/pkg/mod/gitlab.com/hfuss/mux-prometheus@v0.0.4/pkg/middleware/middleware.go:58 +0x13c
github.com/hyperledger/firefly/internal/apiserver.(*apiServer).configurePrometheusInstrumentation(0xc0001adf80, 0xf51b74, 0xc, 0xf48b3d, 0x5, 0xc0002cc600)
```

this refactors the instrumentation creation and middleware registration in the routers so that the original instrumentations are always re-used whenever router are recreated in-process to prevent the duplicate registration.