### PR TITLE
[helm] Support Passing Secrets to Migrations Job

### DIFF
--- a/deploy/charts/firefly/README.md
+++ b/deploy/charts/firefly/README.md
@@ -206,7 +206,7 @@ core:
 In the case of PostgreSQL credentials, environment variables will have to be set for FireFly and its [migrations `Job`](#database-migrations):
 
 ```yaml
-# database section of the config still needs to be set to indicate Postgres
+# database section of the config needs to be set to indicate Postgres
 config:
   databaseOverride:
     type: postgres

--- a/deploy/charts/firefly/README.md
+++ b/deploy/charts/firefly/README.md
@@ -206,6 +206,15 @@ core:
 In the case of PostgreSQL credentials, environment variablels will have to be set for FireFly and its [migrations `Job`](#database-migrations):
 
 ```yaml
+# database section of the config still needs to be set to indicate Postgres
+config:
+  databaseOverride:
+    type: postgres
+    postgres:
+      migrations:
+        auto: false
+
+# pass Postgres URL as a secret to both FireFly and the migrations job
 core:
   extraEnv:
     - name: FIREFLY_DATABASE_POSTGRES_URL

--- a/deploy/charts/firefly/README.md
+++ b/deploy/charts/firefly/README.md
@@ -203,7 +203,7 @@ core:
           key: password
 ```
 
-In the case of PostgreSQL credentials, environment variablels will have to be set for FireFly and its [migrations `Job`](#database-migrations):
+In the case of PostgreSQL credentials, environment variables will have to be set for FireFly and its [migrations `Job`](#database-migrations):
 
 ```yaml
 # database section of the config still needs to be set to indicate Postgres

--- a/deploy/charts/firefly/README.md
+++ b/deploy/charts/firefly/README.md
@@ -194,13 +194,35 @@ core:
     - name: FIREFLY_PUBLICSTORAGE_IPFS_API_AUTH_USERNAME
       valueFrom:
         secretKeyRef:
-          name: my-ipfs-basic-auth
+          name: custom-ipfs-basic-auth
           key: username
     - name: FIREFLY_PUBLICSTORAGE_IPFS_API_AUTH_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: my-ipfs-basic-auth
+          name: custom-ipfs-basic-auth
           key: password
+```
+
+In the case of PostgreSQL credentials, environment variablels will have to be set for FireFly and its [migrations `Job`](#database-migrations):
+
+```yaml
+core:
+  extraEnv:
+    - name: FIREFLY_DATABASE_POSTGRES_URL
+      valueFrom:
+      secretKeyRef:
+        name: custom-psql-config
+        key: url    
+
+  jobs:
+    postgresMigrations:
+      enabled: true
+      extraEnv:
+        - name: PSQL_URL
+          valueFrom:
+            secretKeyRef:
+              name: custom-psql-config
+              key: url
 ```
 
 ### Ethereum

--- a/deploy/charts/firefly/templates/core/job-migrations.yaml
+++ b/deploy/charts/firefly/templates/core/job-migrations.yaml
@@ -16,11 +16,18 @@ spec:
         - -ce
         - |
 {{ .Files.Get "scripts/ff-db-migrations.sh" | indent 10 }}
+        {{- if or .Values.config.postgresUrl .Values.core.jobs.postgresMigrations.extraEnv }}
         env:
-        - name: PSQL_URL
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "firefly.fullname" . }}-config
-              key: psql_url
+          {{- if .Values.config.postgresUrl }}
+          - name: PSQL_URL
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "firefly.fullname" . }}-config
+                key: psql_url
+          {{- end }}
+          {{- if .Values.core.jobs.postgresMigrations.extraEnv }}
+            {{- toYaml .Values.core.jobs.postgresMigrations.extraEnv | nindent 12 }}
+          {{- end }}
+        {{- end }}
       restartPolicy: Never
 {{- end }}

--- a/deploy/charts/firefly/templates/core/statefulset.yaml
+++ b/deploy/charts/firefly/templates/core/statefulset.yaml
@@ -39,9 +39,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if .Values.core.extraEnv }}
+            {{- if .Values.core.extraEnv }}
             {{- toYaml .Values.core.extraEnv | nindent 12 }}
-          {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.core.service.httpPort }}

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -199,6 +199,12 @@ core:
     # Whether to create a migration job to perform migrations each time a new tag is pushed for the FireFly image (supports DB creation)
     postgresMigrations:
       enabled: false
+      extraEnv: []
+      #  - name: PSQL_URL
+      #    valueFrom:
+      #      secretKeyRef:
+      #        name: custom-psql-config
+      #        key: psql_url
 
     # Whether to use a Job to perform auto-registration of the FireFly runtime.
     # Note registration will not be successful until the new node has caught up with the head of the chain.


### PR DESCRIPTION
With `core.extraEnv` we're able to provide secrets to FireFly, but in the case of Postgres the secret also has to be passed to the migrations `Job`. So this PR supports and documents how to do that.