### PR TITLE
[erc20-payload] pass name and symbol to CreateTokenPool()

### DIFF
--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -69,6 +69,8 @@ type createPool struct {
 	Operator  string             `json:"operator"`
 	Data      string             `json:"data,omitempty"`
 	Config    fftypes.JSONObject `json:"config"`
+	Name      string             `json:"name"`
+	Symbol    string             `json:"symbol"`
 }
 
 type activatePool struct {
@@ -379,6 +381,8 @@ func (ft *FFTokens) CreateTokenPool(ctx context.Context, opID *fftypes.UUID, poo
 			Operator:  pool.Key,
 			Data:      string(data),
 			Config:    pool.Config,
+			Name:      pool.Name,
+			Symbol:    pool.Symbol,
 		}).
 		Post("/api/v1/createpool")
 	if err != nil || !res.IsSuccess() {

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -113,6 +113,7 @@ func TestCreateTokenPool(t *testing.T) {
 		Config: fftypes.JSONObject{
 			"foo": "bar",
 		},
+		Symbol: "symbol",
 	}
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/v1/createpool", httpURL),
@@ -127,7 +128,9 @@ func TestCreateTokenPool(t *testing.T) {
 				"config": map[string]interface{}{
 					"foo": "bar",
 				},
-				"data": `{"tx":"` + pool.TX.ID.String() + `"}`,
+				"data":   `{"tx":"` + pool.TX.ID.String() + `"}`,
+				"name":   "new-pool",
+				"symbol": "symbol",
 			}, body)
 
 			res := &http.Response{

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "v0.10.2",
-    "sha": "a677f36b5130f1f9f1e70066762066632aaf72ccd773855f896ebbc681e540d5"
+    "tag": "v0.10.2-20220119-16",
+    "sha": "e4f2dc3a7ec328e56505988bff3d81851832ec55d3e3ff19b7a3a3499af830f0"
   }
 }

--- a/mocks/tokenmocks/callbacks.go
+++ b/mocks/tokenmocks/callbacks.go
@@ -14,13 +14,13 @@ type Callbacks struct {
 	mock.Mock
 }
 
-// TokenOpUpdate provides a mock function with given fields: plugin, opID, txState, errorMessage, opOutput
-func (_m *Callbacks) TokenOpUpdate(plugin tokens.Plugin, opID *fftypes.UUID, txState fftypes.OpStatus, errorMessage string, opOutput fftypes.JSONObject) error {
-	ret := _m.Called(plugin, opID, txState, errorMessage, opOutput)
+// TokenOpUpdate provides a mock function with given fields: plugin, operationID, txState, errorMessage, opOutput
+func (_m *Callbacks) TokenOpUpdate(plugin tokens.Plugin, operationID *fftypes.UUID, txState fftypes.OpStatus, errorMessage string, opOutput fftypes.JSONObject) error {
+	ret := _m.Called(plugin, operationID, txState, errorMessage, opOutput)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(tokens.Plugin, *fftypes.UUID, fftypes.OpStatus, string, fftypes.JSONObject) error); ok {
-		r0 = rf(plugin, opID, txState, errorMessage, opOutput)
+		r0 = rf(plugin, operationID, txState, errorMessage, opOutput)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
The [ERC20 token connector](https://github.com/hyperledger/firefly-tokens-erc20) for Firefly requires that `name` and `symbol` be passed to the ERC20 token factory. This PR allows for firefly to pass these fields down to the token connector.