### PR TITLE
PostgreSQL updates following merging of onchain-logic branch

### DIFF
--- a/db/migrations/postgres/000054_create_blockchainevents_table.up.sql
+++ b/db/migrations/postgres/000054_create_blockchainevents_table.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 CREATE TABLE blockchainevents (
-  seq              INTEGER         PRIMARY KEY AUTOINCREMENT,
+  seq              SERIAL          PRIMARY KEY,
   id               UUID            NOT NULL,
   source           VARCHAR(256)    NOT NULL,
   namespace        VARCHAR(64)     NOT NULL,

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -201,7 +201,7 @@ func (cm *contractManager) resolveInvokeContractRequest(ctx context.Context, ns 
 
 		method, err = cm.database.GetFFIMethod(ctx, ns, req.Interface, method.Pathname)
 		if err != nil || method == nil {
-			return nil, i18n.NewError(ctx, i18n.MsgContractMethodResolveError)
+			return nil, i18n.NewError(ctx, i18n.MsgContractMethodResolveError, err)
 		}
 	}
 	return method, nil

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -232,7 +232,7 @@ var (
 	MsgContractSubscriptionExists   = ffm("FF10312", "A contract subscription already exists in the namespace: '%s' with name: '%s'", 409)
 	MsgContractMethodNotSet         = ffm("FF10313", "Method not specified on invoke contract request", 400)
 	MsgContractNoMethodSignature    = ffm("FF10314", "Method signature is required if interfaceID is absent", 400)
-	MsgContractMethodResolveError   = ffm("FF10315", "Unable to resolve contract method", 400)
+	MsgContractMethodResolveError   = ffm("FF10315", "Unable to resolve contract method: %s", 400)
 	MsgContractLocationExists       = ffm("FF10316", "The contract location cannot be changed after it is created", 400)
 	MsgSubscriptionNoEvent          = ffm("FF10317", "An eventId or in-line event definition must be supplied when subscribing", 400)
 	MsgSubscriptionEventNotFound    = ffm("FF10318", "No event was found in namespace '%s' with id '%s'", 400)

--- a/pkg/fftypes/batch.go
+++ b/pkg/fftypes/batch.go
@@ -63,11 +63,14 @@ func (ma *BatchPayload) Scan(src interface{}) error {
 	case nil:
 		return nil
 
-	case string, []byte:
+	case []byte:
+		return json.Unmarshal(src, &ma)
+
+	case string:
 		if src == "" {
 			return nil
 		}
-		return json.Unmarshal(src.([]byte), &ma)
+		return json.Unmarshal([]byte(src), &ma)
 
 	default:
 		return i18n.NewError(context.Background(), i18n.MsgScanFailed, src, ma)

--- a/pkg/fftypes/batch_test.go
+++ b/pkg/fftypes/batch_test.go
@@ -51,6 +51,9 @@ func TestSQLSerializedMessageArray(t *testing.T) {
 	err = batchPayloadRead.Scan("")
 	assert.NoError(t, err)
 
+	err = batchPayloadRead.Scan("{}")
+	assert.NoError(t, err)
+
 	err = batchPayloadRead.Scan(nil)
 	assert.NoError(t, err)
 

--- a/pkg/fftypes/contractsubscription.go
+++ b/pkg/fftypes/contractsubscription.go
@@ -50,6 +50,8 @@ func (fse *FFISerializedEvent) Scan(src interface{}) error {
 	case nil:
 		fse = nil
 		return nil
+	case string:
+		return json.Unmarshal([]byte(src), &fse)
 	case []byte:
 		return json.Unmarshal(src, &fse)
 	default:

--- a/pkg/fftypes/contractsubscription_test.go
+++ b/pkg/fftypes/contractsubscription_test.go
@@ -34,9 +34,15 @@ func TestFFISerializedEventScanNil(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestFFISerializedEventScanString(t *testing.T) {
+	params := &FFISerializedEvent{}
+	err := params.Scan(`{"name":"event1","description":"a super event","params":[{"name":"details","type":"integer","details":{"type":"uint256"}}]}`)
+	assert.NoError(t, err)
+}
+
 func TestFFISerializedEventScanError(t *testing.T) {
 	params := &FFISerializedEvent{}
-	err := params.Scan("definitely not FFISerializedEvent")
+	err := params.Scan(map[string]interface{}{"this is": "not a supported serialization of a FFISerializedEvent"})
 	assert.Regexp(t, "FF10125", err)
 }
 

--- a/pkg/fftypes/ffi.go
+++ b/pkg/fftypes/ffi.go
@@ -102,6 +102,8 @@ func (m *FFIParams) Scan(src interface{}) error {
 	case nil:
 		m = nil
 		return nil
+	case string:
+		return json.Unmarshal([]byte(src), &m)
 	case []byte:
 		return json.Unmarshal(src, &m)
 	default:

--- a/pkg/fftypes/ffi_test.go
+++ b/pkg/fftypes/ffi_test.go
@@ -107,6 +107,12 @@ func TestFFIParamsScan(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestFFIParamsScanString(t *testing.T) {
+	params := &FFIParams{}
+	err := params.Scan(`[{"name": "x", "type": "integer", "internalType": "uint256"}]`)
+	assert.NoError(t, err)
+}
+
 func TestFFIParamsScanNil(t *testing.T) {
 	params := &FFIParams{}
 	err := params.Scan(nil)
@@ -115,7 +121,7 @@ func TestFFIParamsScanNil(t *testing.T) {
 
 func TestFFIParamsScanError(t *testing.T) {
 	params := &FFIParams{}
-	err := params.Scan("definitely not FFIParams")
+	err := params.Scan(map[string]interface{}{"type": "not supported for scanning FFIParams"})
 	assert.Regexp(t, "FF10125", err)
 }
 

--- a/pkg/fftypes/jsonobject.go
+++ b/pkg/fftypes/jsonobject.go
@@ -37,11 +37,14 @@ func (jd *JSONObject) Scan(src interface{}) error {
 	case nil:
 		return nil
 
-	case string, []byte:
+	case string:
 		if src == "" {
 			return nil
 		}
-		return json.Unmarshal(src.([]byte), &jd)
+		return json.Unmarshal([]byte(src), &jd)
+
+	case []byte:
+		return json.Unmarshal(src, &jd)
 
 	default:
 		return i18n.NewError(context.Background(), i18n.MsgScanFailed, src, jd)
@@ -167,7 +170,11 @@ func (jd JSONObject) GetStringArrayOk(key string) ([]string, bool) {
 
 // Value implements sql.Valuer
 func (jd JSONObject) Value() (driver.Value, error) {
-	return json.Marshal(&jd)
+	b, err := json.Marshal(&jd)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), err
 }
 
 func (jd JSONObject) String() string {

--- a/pkg/fftypes/jsonobject_test.go
+++ b/pkg/fftypes/jsonobject_test.go
@@ -32,7 +32,7 @@ func TestJSONObject(t *testing.T) {
 
 	b, err := data.Value()
 	assert.NoError(t, err)
-	assert.IsType(t, []byte{}, b)
+	assert.IsType(t, "", b)
 
 	var dataRead JSONObject
 	err = dataRead.Scan(b)
@@ -84,21 +84,27 @@ func TestJSONObject(t *testing.T) {
 	assert.Equal(t, "", v)
 }
 
-func TestJSONObjectBool(t *testing.T) {
+func TestJSONObjectScan(t *testing.T) {
 
-	data := JSONObjectArray{
-		{"some": "data"},
-	}
+	data := JSONObject{"some": "data"}
 
-	b, err := data.Value()
+	sv, err := data.Value()
 	assert.NoError(t, err)
-	assert.Equal(t, "[{\"some\":\"data\"}]", b)
+	assert.Equal(t, "{\"some\":\"data\"}", sv)
 
-	var dataRead JSONObjectArray
-	err = dataRead.Scan(b)
+	var dataRead JSONObject
+	err = dataRead.Scan(sv)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `[{"some":"data"}]`, fmt.Sprintf("%v", dataRead))
+	assert.Equal(t, `{"some":"data"}`, fmt.Sprintf("%v", dataRead))
+
+	sv, err = ((JSONObject)(nil)).Value()
+	assert.NoError(t, err)
+	assert.Equal(t, NullString, sv)
+
+	var badData JSONObject = map[string]interface{}{"bad": map[bool]bool{false: true}}
+	_, err = badData.Value()
+	assert.Error(t, err)
 
 	j1, err := json.Marshal(&data)
 	assert.NoError(t, err)
@@ -110,6 +116,13 @@ func TestJSONObjectBool(t *testing.T) {
 
 	err = dataRead.Scan("")
 	assert.NoError(t, err)
+
+	err = dataRead.Scan([]byte("{}"))
+	assert.NoError(t, err)
+
+	err = dataRead.Scan(`{"test": true}`)
+	assert.NoError(t, err)
+	assert.True(t, dataRead.GetBool("test"))
 
 	err = dataRead.Scan(nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes for #415 

The PostgreSQL driver in Go passes `Scan` a `string` rather than a `[]byte` when reading data from the database, now that we are using `TEXT` columns. However, our custom `Scan()` implementations for these types assumed `[]byte` was being returned (in various spellings of that assumption).

To support environments created before the moved away from `BYTEA` we cannot take the old `Scan()` support for `[]byte`. So we need all the objects to support either.

Through incremental e2e test-fix cycles I found the following needed updates:
1. SQL Migration copy/paste bug from SQLite to PSQL
2. `fftypes.JSONObject`
3. `fftypes.JSONObjectArray`
4. `fftypes.Batch`
5. `fftypes.FFISerializedEvent`
6. `fftypes.FFIParams`