### PR TITLE
[erc20-manifest] adding erc20 token to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,10 @@
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
     "tag": "v0.10.2-20220119-16",
     "sha": "e4f2dc3a7ec328e56505988bff3d81851832ec55d3e3ff19b7a3a3499af830f0"
+  },
+  "tokens-erc20": {
+    "image": "ghcr.io/hyperledger/firefly-tokens-erc20",
+    "tag": "v0.1.0",
+    "sha": "245869aa5b91d5ba4f501f54140c2a2e7136a73bf558a818a18e3b4163cc5aaf"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -16,12 +16,12 @@
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "v0.10.2-20220119-16",
-    "sha": "e4f2dc3a7ec328e56505988bff3d81851832ec55d3e3ff19b7a3a3499af830f0"
+    "tag": "v0.10.3",
+    "sha": "82da382294df7df60c78c37c20e447d8fefe23b654aba6ae5ab5084d363c3879"
   },
   "tokens-erc20": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc20",
-    "tag": "v0.1.0",
-    "sha": "245869aa5b91d5ba4f501f54140c2a2e7136a73bf558a818a18e3b4163cc5aaf"
+    "tag": "v0.1.1",
+    "sha": "46c733c1d9faa250b43f98f4b31205cb5a0b80221cb447bd7aa3574152a9ad55"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   },
   "tokens-erc20": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc20",
-    "tag": "v0.1.1",
-    "sha": "46c733c1d9faa250b43f98f4b31205cb5a0b80221cb447bd7aa3574152a9ad55"
+    "tag": "v0.1.2",
+    "sha": "149caf9f86433b1c33765c4567b42f858765d3cb30627d0cace5cf08996e0e73"
   }
 }

--- a/manifestgen.sh
+++ b/manifestgen.sh
@@ -38,6 +38,7 @@ SERVICES=(
     "fabconnect"
     "dataexchange-https"
     "tokens-erc1155"
+    "tokens-erc20"
 )
 SERVICE_COUNT=${#SERVICES[@]}
 


### PR DESCRIPTION
Adding support for [Firefly-Tokens-ERC20](https://github.com/hyperledger/firefly-tokens-erc20) in `manifest.json` and `manifestgen.sh`. This is needed for ERC20 support in [Firefly-CLI](https://github.com/hyperledger/firefly-cli)