### PR TITLE
Fix token account listing on Postgres

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -8371,16 +8371,6 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
-        name: balance
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: connector
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
         name: key
         schema:
           type: string
@@ -8391,22 +8381,7 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
-        name: pool
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: tokenindex
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
         name: updated
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: uri
         schema:
           type: string
       - description: Sort field. For multi-field sort use comma separated values (or
@@ -8482,21 +8457,6 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
-        name: balance
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: connector
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: key
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
         name: namespace
         schema:
           type: string
@@ -8507,17 +8467,7 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
-        name: tokenindex
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
         name: updated
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: uri
         schema:
           type: string
       - description: Sort field. For multi-field sort use comma separated values (or

--- a/internal/apiserver/route_get_token_account_pools.go
+++ b/internal/apiserver/route_get_token_account_pools.go
@@ -35,7 +35,7 @@ var getTokenAccountPools = &oapispec.Route{
 		{Name: "key", Description: i18n.MsgTBD},
 	},
 	QueryParams:     nil,
-	FilterFactory:   database.TokenBalanceQueryFactory,
+	FilterFactory:   database.TokenAccountPoolQueryFactory,
 	Description:     i18n.MsgTBD,
 	JSONInputValue:  nil,
 	JSONOutputValue: func() interface{} { return []*fftypes.TokenAccountPool{} },

--- a/internal/apiserver/route_get_token_accounts.go
+++ b/internal/apiserver/route_get_token_accounts.go
@@ -34,7 +34,7 @@ var getTokenAccounts = &oapispec.Route{
 		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
 	},
 	QueryParams:     nil,
-	FilterFactory:   database.TokenBalanceQueryFactory,
+	FilterFactory:   database.TokenAccountQueryFactory,
 	Description:     i18n.MsgTBD,
 	JSONInputValue:  nil,
 	JSONOutputValue: func() interface{} { return []*fftypes.TokenAccount{} },

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -860,7 +860,7 @@ var TokenPoolQueryFactory = &queryFields{
 	"connector":  &StringField{},
 }
 
-// TokenBalanceQueryFactory filter fields for token accounts
+// TokenBalanceQueryFactory filter fields for token balances
 var TokenBalanceQueryFactory = &queryFields{
 	"pool":       &UUIDField{},
 	"tokenindex": &StringField{},
@@ -870,6 +870,20 @@ var TokenBalanceQueryFactory = &queryFields{
 	"key":        &StringField{},
 	"balance":    &Int64Field{},
 	"updated":    &TimeField{},
+}
+
+// TokenAccountQueryFactory filter fields for token accounts
+var TokenAccountQueryFactory = &queryFields{
+	"key":       &StringField{},
+	"namespace": &StringField{},
+	"updated":   &TimeField{},
+}
+
+// TokenAccountPoolQueryFactory filter fields for token account pools
+var TokenAccountPoolQueryFactory = &queryFields{
+	"pool":      &UUIDField{},
+	"namespace": &StringField{},
+	"updated":   &TimeField{},
 }
 
 // TokenTransferQueryFactory filter fields for token transfers

--- a/test/e2e/restclient.go
+++ b/test/e2e/restclient.go
@@ -49,6 +49,7 @@ var (
 	urlTokenMint             = "/namespaces/default/tokens/mint"
 	urlTokenBurn             = "/namespaces/default/tokens/burn"
 	urlTokenTransfers        = "/namespaces/default/tokens/transfers"
+	urlTokenAccounts         = "/namespaces/default/tokens/accounts"
 	urlTokenBalances         = "/namespaces/default/tokens/balances"
 	urlContractInvoke        = "/namespaces/default/contracts/invoke"
 	urlContractQuery         = "/namespaces/default/contracts/query"
@@ -437,6 +438,27 @@ func GetTokenTransfers(t *testing.T, client *resty.Client, poolID *fftypes.UUID)
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode(), "GET %s [%d]: %s", path, resp.StatusCode(), resp.String())
 	return transfers
+}
+
+func GetTokenAccounts(t *testing.T, client *resty.Client, poolID *fftypes.UUID) (accounts []*fftypes.TokenAccount) {
+	path := urlTokenAccounts
+	resp, err := client.R().
+		SetResult(&accounts).
+		Get(path)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode(), "GET %s [%d]: %s", path, resp.StatusCode(), resp.String())
+	return accounts
+}
+
+func GetTokenAccountPools(t *testing.T, client *resty.Client, identity string) (pools []*fftypes.TokenAccountPool) {
+	path := urlTokenAccounts + "/" + identity + "/pools"
+	resp, err := client.R().
+		SetQueryParam("sort", "-updated").
+		SetResult(&pools).
+		Get(path)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode(), "GET %s [%d]: %s", path, resp.StatusCode(), resp.String())
+	return pools
 }
 
 func GetTokenBalance(t *testing.T, client *resty.Client, poolID *fftypes.UUID, tokenIndex, key string) (account *fftypes.TokenBalance) {

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -165,6 +165,20 @@ func (suite *TokensTestSuite) TestE2EFungibleTokensAsync() {
 		suite.testState.org1.Identity: 0,
 		suite.testState.org2.Identity: 0,
 	})
+
+	accounts := GetTokenAccounts(suite.T(), suite.testState.client1, poolID)
+	assert.Equal(suite.T(), 2, len(accounts))
+	assert.Equal(suite.T(), suite.testState.org2.Identity, accounts[0].Key)
+	assert.Equal(suite.T(), suite.testState.org1.Identity, accounts[1].Key)
+	accounts = GetTokenAccounts(suite.T(), suite.testState.client2, poolID)
+	assert.Equal(suite.T(), 2, len(accounts))
+	assert.Equal(suite.T(), suite.testState.org2.Identity, accounts[0].Key)
+	assert.Equal(suite.T(), suite.testState.org1.Identity, accounts[1].Key)
+
+	accountPools := GetTokenAccountPools(suite.T(), suite.testState.client1, suite.testState.org1.Identity)
+	assert.Equal(suite.T(), *poolID, *accountPools[0].Pool)
+	accountPools = GetTokenAccountPools(suite.T(), suite.testState.client2, suite.testState.org2.Identity)
+	assert.Equal(suite.T(), *poolID, *accountPools[0].Pool)
 }
 
 func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
@@ -287,4 +301,18 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 		suite.testState.org1.Identity: 0,
 		suite.testState.org2.Identity: 0,
 	})
+
+	accounts := GetTokenAccounts(suite.T(), suite.testState.client1, poolID)
+	assert.Equal(suite.T(), 2, len(accounts))
+	assert.Equal(suite.T(), suite.testState.org2.Identity, accounts[0].Key)
+	assert.Equal(suite.T(), suite.testState.org1.Identity, accounts[1].Key)
+	accounts = GetTokenAccounts(suite.T(), suite.testState.client2, poolID)
+	assert.Equal(suite.T(), 2, len(accounts))
+	assert.Equal(suite.T(), suite.testState.org2.Identity, accounts[0].Key)
+	assert.Equal(suite.T(), suite.testState.org1.Identity, accounts[1].Key)
+
+	accountPools := GetTokenAccountPools(suite.T(), suite.testState.client1, suite.testState.org1.Identity)
+	assert.Equal(suite.T(), *poolID, *accountPools[0].Pool)
+	accountPools = GetTokenAccountPools(suite.T(), suite.testState.client2, suite.testState.org2.Identity)
+	assert.Equal(suite.T(), *poolID, *accountPools[0].Pool)
 }


### PR DESCRIPTION
Postgres has much stricter constraints on DISTINCT/GROUP BY queries - specifically,
the fields used in ORDER BY must also be part of SELECT, and therefore may need
an aggregate function applied in order to give deterministic results.

Implement ordering by "seq" or "updated", which seem like the most useful.

Resolves #416