### PR TITLE
Ready state changes require a bump to the message to re-sequence it

### DIFF
--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -184,7 +184,7 @@ func (s *SQLCommon) UpsertMessage(ctx context.Context, message *fftypes.Message,
 }
 
 // In SQL update+bump is a delete+insert within a TX
-func (s *SQLCommon) UpdateAndBumpMessage(ctx context.Context, message *fftypes.Message) (err error) {
+func (s *SQLCommon) ReplaceMessage(ctx context.Context, message *fftypes.Message) (err error) {
 	ctx, tx, autoCommit, err := s.beginOrUseTx(ctx)
 	if err != nil {
 		return err

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -61,7 +61,7 @@ func TestUpsertE2EWithDB(t *testing.T) {
 			TxType:    fftypes.TransactionTypeNone,
 		},
 		Hash:      fftypes.NewRandB32(),
-		State:     fftypes.MessageStateReady,
+		State:     fftypes.MessageStateStaged,
 		Confirmed: nil,
 		Data: []*fftypes.DataRef{
 			{ID: dataID1, Hash: rand1},
@@ -69,7 +69,7 @@ func TestUpsertE2EWithDB(t *testing.T) {
 		},
 	}
 
-	s.callbacks.On("OrderedUUIDCollectionNSEvent", database.CollectionMessages, fftypes.ChangeEventTypeCreated, "ns12345", msgID, mock.Anything).Return()
+	s.callbacks.On("OrderedUUIDCollectionNSEvent", database.CollectionMessages, fftypes.ChangeEventTypeCreated, "ns12345", msgID, mock.Anything).Return().Twice()
 	s.callbacks.On("OrderedUUIDCollectionNSEvent", database.CollectionMessages, fftypes.ChangeEventTypeUpdated, "ns12345", msgID, mock.Anything).Return()
 
 	err := s.UpsertMessage(ctx, msg, database.UpsertOptimizationNew)
@@ -196,6 +196,15 @@ func TestUpsertE2EWithDB(t *testing.T) {
 	assert.Equal(t, 1, len(msgs))
 	assert.Equal(t, *bid2, *msgs[0].BatchID)
 
+	// Bump and Update - this is for a ready transition
+	msgUpdated.State = fftypes.MessageStateReady
+	err = s.UpdateAndBumpMessage(context.Background(), msgUpdated)
+	assert.NoError(t, err)
+	msgRead, err = s.GetMessageByID(ctx, msgUpdated.Header.ID)
+	msgJson, _ = json.Marshal(&msgUpdated)
+	msgReadJson, _ = json.Marshal(msgRead)
+	assert.Equal(t, string(msgJson), string(msgReadJson))
+
 	s.callbacks.AssertExpectations(t)
 }
 
@@ -264,6 +273,38 @@ func TestUpsertMessageFailCommit(t *testing.T) {
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}}, database.UpsertOptimizationSkip)
 	assert.Regexp(t, "FF10119", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateAndBumpMessageFailBegin(t *testing.T) {
+	s, mock := newMockProvider().init()
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
+	msgID := fftypes.NewUUID()
+	err := s.UpdateAndBumpMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
+	assert.Regexp(t, "FF10114", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateAndBumpMessageFailDelete(t *testing.T) {
+	s, mock := newMockProvider().init()
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE .*").WillReturnError(fmt.Errorf("pop"))
+	mock.ExpectRollback()
+	msgID := fftypes.NewUUID()
+	err := s.UpdateAndBumpMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
+	assert.Regexp(t, "FF10118", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateAndBumpMessageFailInsert(t *testing.T) {
+	s, mock := newMockProvider().init()
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE .*").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
+	mock.ExpectRollback()
+	msgID := fftypes.NewUUID()
+	err := s.UpdateAndBumpMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -198,7 +198,7 @@ func TestUpsertE2EWithDB(t *testing.T) {
 
 	// Bump and Update - this is for a ready transition
 	msgUpdated.State = fftypes.MessageStateReady
-	err = s.UpdateAndBumpMessage(context.Background(), msgUpdated)
+	err = s.ReplaceMessage(context.Background(), msgUpdated)
 	assert.NoError(t, err)
 	msgRead, err = s.GetMessageByID(ctx, msgUpdated.Header.ID)
 	msgJson, _ = json.Marshal(&msgUpdated)
@@ -276,34 +276,34 @@ func TestUpsertMessageFailCommit(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpdateAndBumpMessageFailBegin(t *testing.T) {
+func TestReplaceMessageFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	msgID := fftypes.NewUUID()
-	err := s.UpdateAndBumpMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
+	err := s.ReplaceMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
 	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpdateAndBumpMessageFailDelete(t *testing.T) {
+func TestReplaceMessageFailDelete(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	msgID := fftypes.NewUUID()
-	err := s.UpdateAndBumpMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
+	err := s.ReplaceMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
 	assert.Regexp(t, "FF10118", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpdateAndBumpMessageFailInsert(t *testing.T) {
+func TestReplaceMessageFailInsert(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	msgID := fftypes.NewUUID()
-	err := s.UpdateAndBumpMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
+	err := s.ReplaceMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}})
 	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/events/tokens_transferred.go
+++ b/internal/events/tokens_transferred.go
@@ -133,7 +133,7 @@ func (em *eventManager) TokensTransferred(ti tokens.Plugin, transfer *tokens.Tok
 					if msg.State == fftypes.MessageStateStaged {
 						// Message can now be sent
 						msg.State = fftypes.MessageStateReady
-						if err := em.database.UpsertMessage(ctx, msg, database.UpsertOptimizationExisting); err != nil {
+						if err := em.database.UpdateAndBumpMessage(ctx, msg); err != nil {
 							return err
 						}
 					} else {

--- a/internal/events/tokens_transferred.go
+++ b/internal/events/tokens_transferred.go
@@ -133,7 +133,7 @@ func (em *eventManager) TokensTransferred(ti tokens.Plugin, transfer *tokens.Tok
 					if msg.State == fftypes.MessageStateStaged {
 						// Message can now be sent
 						msg.State = fftypes.MessageStateReady
-						if err := em.database.UpdateAndBumpMessage(ctx, msg); err != nil {
+						if err := em.database.ReplaceMessage(ctx, msg); err != nil {
 							return err
 						}
 					} else {

--- a/internal/events/tokens_transferred_test.go
+++ b/internal/events/tokens_transferred_test.go
@@ -429,7 +429,7 @@ func TestTokensTransferredWithMessageSend(t *testing.T) {
 	mdi.On("UpsertTokenTransfer", em.ctx, &transfer.TokenTransfer).Return(nil).Times(2)
 	mdi.On("UpdateTokenBalances", em.ctx, &transfer.TokenTransfer).Return(nil).Times(2)
 	mdi.On("GetMessageByID", em.ctx, mock.Anything).Return(message, nil).Times(2)
-	mdi.On("UpdateAndBumpMessage", em.ctx, mock.MatchedBy(func(msg *fftypes.Message) bool {
+	mdi.On("ReplaceMessage", em.ctx, mock.MatchedBy(func(msg *fftypes.Message) bool {
 		return msg.State == fftypes.MessageStateReady
 	})).Return(fmt.Errorf("pop"))
 	mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *fftypes.Event) bool {

--- a/internal/events/tokens_transferred_test.go
+++ b/internal/events/tokens_transferred_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hyperledger/firefly/mocks/databasemocks"
 	"github.com/hyperledger/firefly/mocks/tokenmocks"
 	"github.com/hyperledger/firefly/pkg/blockchain"
-	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/tokens"
 	"github.com/stretchr/testify/assert"
@@ -430,10 +429,9 @@ func TestTokensTransferredWithMessageSend(t *testing.T) {
 	mdi.On("UpsertTokenTransfer", em.ctx, &transfer.TokenTransfer).Return(nil).Times(2)
 	mdi.On("UpdateTokenBalances", em.ctx, &transfer.TokenTransfer).Return(nil).Times(2)
 	mdi.On("GetMessageByID", em.ctx, mock.Anything).Return(message, nil).Times(2)
-	mdi.On("UpsertMessage", em.ctx, mock.Anything, database.UpsertOptimizationExisting).Return(fmt.Errorf("pop"))
-	mdi.On("UpsertMessage", em.ctx, mock.MatchedBy(func(msg *fftypes.Message) bool {
+	mdi.On("UpdateAndBumpMessage", em.ctx, mock.MatchedBy(func(msg *fftypes.Message) bool {
 		return msg.State == fftypes.MessageStateReady
-	}), database.UpsertOptimizationExisting).Return(nil)
+	})).Return(fmt.Errorf("pop"))
 	mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *fftypes.Event) bool {
 		return ev.Type == fftypes.EventTypeTransferConfirmed && ev.Reference == transfer.LocalID && ev.Namespace == pool.Namespace
 	})).Return(nil).Once()

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2227,6 +2227,20 @@ func (_m *Plugin) SetPinDispatched(ctx context.Context, sequence int64) error {
 	return r0
 }
 
+// UpdateAndBumpMessage provides a mock function with given fields: ctx, message
+func (_m *Plugin) UpdateAndBumpMessage(ctx context.Context, message *fftypes.Message) error {
+	ret := _m.Called(ctx, message)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message) error); ok {
+		r0 = rf(ctx, message)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateBatch provides a mock function with given fields: ctx, id, update
 func (_m *Plugin) UpdateBatch(ctx context.Context, id *fftypes.UUID, update database.Update) error {
 	ret := _m.Called(ctx, id, update)

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2199,6 +2199,20 @@ func (_m *Plugin) Name() string {
 	return r0
 }
 
+// ReplaceMessage provides a mock function with given fields: ctx, message
+func (_m *Plugin) ReplaceMessage(ctx context.Context, message *fftypes.Message) error {
+	ret := _m.Called(ctx, message)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message) error); ok {
+		r0 = rf(ctx, message)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RunAsGroup provides a mock function with given fields: ctx, fn
 func (_m *Plugin) RunAsGroup(ctx context.Context, fn func(context.Context) error) error {
 	ret := _m.Called(ctx, fn)
@@ -2220,20 +2234,6 @@ func (_m *Plugin) SetPinDispatched(ctx context.Context, sequence int64) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
 		r0 = rf(ctx, sequence)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateAndBumpMessage provides a mock function with given fields: ctx, message
-func (_m *Plugin) UpdateAndBumpMessage(ctx context.Context, message *fftypes.Message) error {
-	ret := _m.Called(ctx, message)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message) error); ok {
-		r0 = rf(ctx, message)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -80,6 +80,10 @@ type iMessageCollection interface {
 	// UpdateMessage - Update message
 	UpdateMessage(ctx context.Context, id *fftypes.UUID, update Update) (err error)
 
+	// UpdateAndBumpMessage updates the message, and assigns it a new sequence number at the front of the list.
+	// A new event is raised for the message, with the new sequence number - as if it was brand new.
+	UpdateAndBumpMessage(ctx context.Context, message *fftypes.Message) (err error)
+
 	// UpdateMessages - Update messages
 	UpdateMessages(ctx context.Context, filter Filter, update Update) (err error)
 

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -80,9 +80,9 @@ type iMessageCollection interface {
 	// UpdateMessage - Update message
 	UpdateMessage(ctx context.Context, id *fftypes.UUID, update Update) (err error)
 
-	// UpdateAndBumpMessage updates the message, and assigns it a new sequence number at the front of the list.
+	// ReplaceMessage updates the message, and assigns it a new sequence number at the front of the list.
 	// A new event is raised for the message, with the new sequence number - as if it was brand new.
-	UpdateAndBumpMessage(ctx context.Context, message *fftypes.Message) (err error)
+	ReplaceMessage(ctx context.Context, message *fftypes.Message) (err error)
 
 	// UpdateMessages - Update messages
 	UpdateMessages(ctx context.Context, filter Filter, update Update) (err error)


### PR DESCRIPTION
Fixes the core symptom reported in #421 

> Note that this does not implement the full change to batches described in the discussion on that issue.
> However, when that change happens, this fix will still be applicable.