### PR TITLE
Rename /contracts/events to /blockchainevents

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1346,6 +1346,201 @@ paths:
           description: Success
         default:
           description: ""
+  /namespaces/{ns}/blockchainevents:
+    get:
+      description: 'TODO: Description'
+      operationId: getBlockchainEvents
+      parameters:
+      - description: 'TODO: Description'
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: Server-side request timeout (millseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 120s
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: name
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: namespace
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: protocolid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: source
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: subscription
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: timestamp
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: tx.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: tx.type
+        schema:
+          type: string
+      - description: Sort field. For multi-field sort use comma separated values (or
+          multiple query values) with '-' prefix for descending
+        in: query
+        name: sort
+        schema:
+          type: string
+      - description: Ascending sort order (overrides all fields in a multi-field sort)
+        in: query
+        name: ascending
+        schema:
+          type: string
+      - description: Descending sort order (overrides all fields in a multi-field
+          sort)
+        in: query
+        name: descending
+        schema:
+          type: string
+      - description: 'The number of records to skip (max: 1,000). Unsuitable for bulk
+          operations'
+        in: query
+        name: skip
+        schema:
+          type: string
+      - description: 'The maximum number of records to return (max: 1,000)'
+        in: query
+        name: limit
+        schema:
+          example: "25"
+          type: string
+      - description: Return a total count as well as items (adds extra database processing)
+        in: query
+        name: count
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: {}
+                  info:
+                    additionalProperties: {}
+                    type: object
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  output:
+                    additionalProperties: {}
+                    type: object
+                  protocolId:
+                    type: string
+                  sequence:
+                    format: int64
+                    type: integer
+                  source:
+                    type: string
+                  subscription: {}
+                  timestamp: {}
+                  tx:
+                    properties:
+                      id: {}
+                      type:
+                        type: string
+                    type: object
+                type: object
+          description: Success
+        default:
+          description: ""
+  /namespaces/{ns}/blockchainevents/{id}:
+    get:
+      description: 'TODO: Description'
+      operationId: getBlockchainEventByID
+      parameters:
+      - description: 'TODO: Description'
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: 'TODO: Description'
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Server-side request timeout (millseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 120s
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: {}
+                  info:
+                    additionalProperties: {}
+                    type: object
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  output:
+                    additionalProperties: {}
+                    type: object
+                  protocolId:
+                    type: string
+                  sequence:
+                    format: int64
+                    type: integer
+                  source:
+                    type: string
+                  subscription: {}
+                  timestamp: {}
+                  tx:
+                    properties:
+                      id: {}
+                      type:
+                        type: string
+                    type: object
+                type: object
+          description: Success
+        default:
+          description: ""
   /namespaces/{ns}/broadcast/datatype:
     post:
       deprecated: true
@@ -1625,201 +1820,6 @@ paths:
                   count:
                     type: string
                   timestamp: {}
-                type: object
-          description: Success
-        default:
-          description: ""
-  /namespaces/{ns}/contracts/events:
-    get:
-      description: 'TODO: Description'
-      operationId: getContractEvents
-      parameters:
-      - description: 'TODO: Description'
-        in: path
-        name: ns
-        required: true
-        schema:
-          example: default
-          type: string
-      - description: Server-side request timeout (millseconds, or set a custom suffix
-          like 10s)
-        in: header
-        name: Request-Timeout
-        schema:
-          default: 120s
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: id
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: name
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: namespace
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: protocolid
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: source
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: subscription
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: timestamp
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: tx.id
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
-        name: tx.type
-        schema:
-          type: string
-      - description: Sort field. For multi-field sort use comma separated values (or
-          multiple query values) with '-' prefix for descending
-        in: query
-        name: sort
-        schema:
-          type: string
-      - description: Ascending sort order (overrides all fields in a multi-field sort)
-        in: query
-        name: ascending
-        schema:
-          type: string
-      - description: Descending sort order (overrides all fields in a multi-field
-          sort)
-        in: query
-        name: descending
-        schema:
-          type: string
-      - description: 'The number of records to skip (max: 1,000). Unsuitable for bulk
-          operations'
-        in: query
-        name: skip
-        schema:
-          type: string
-      - description: 'The maximum number of records to return (max: 1,000)'
-        in: query
-        name: limit
-        schema:
-          example: "25"
-          type: string
-      - description: Return a total count as well as items (adds extra database processing)
-        in: query
-        name: count
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                properties:
-                  id: {}
-                  info:
-                    additionalProperties: {}
-                    type: object
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  output:
-                    additionalProperties: {}
-                    type: object
-                  protocolId:
-                    type: string
-                  sequence:
-                    format: int64
-                    type: integer
-                  source:
-                    type: string
-                  subscription: {}
-                  timestamp: {}
-                  tx:
-                    properties:
-                      id: {}
-                      type:
-                        type: string
-                    type: object
-                type: object
-          description: Success
-        default:
-          description: ""
-  /namespaces/{ns}/contracts/events/{id}:
-    get:
-      description: 'TODO: Description'
-      operationId: getContractEventByID
-      parameters:
-      - description: 'TODO: Description'
-        in: path
-        name: ns
-        required: true
-        schema:
-          example: default
-          type: string
-      - description: 'TODO: Description'
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: Server-side request timeout (millseconds, or set a custom suffix
-          like 10s)
-        in: header
-        name: Request-Timeout
-        schema:
-          default: 120s
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                properties:
-                  id: {}
-                  info:
-                    additionalProperties: {}
-                    type: object
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  output:
-                    additionalProperties: {}
-                    type: object
-                  protocolId:
-                    type: string
-                  sequence:
-                    format: int64
-                    type: integer
-                  source:
-                    type: string
-                  subscription: {}
-                  timestamp: {}
-                  tx:
-                    properties:
-                      id: {}
-                      type:
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:

--- a/internal/apiserver/route_get_blockchain_event_by_id.go
+++ b/internal/apiserver/route_get_blockchain_event_by_id.go
@@ -25,9 +25,9 @@ import (
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
-var getContractEventByID = &oapispec.Route{
-	Name:   "getContractEventByID",
-	Path:   "namespaces/{ns}/contracts/events/{id}",
+var getBlockchainEventByID = &oapispec.Route{
+	Name:   "getBlockchainEventByID",
+	Path:   "namespaces/{ns}/blockchainevents/{id}",
 	Method: http.MethodGet,
 	PathParams: []*oapispec.PathParam{
 		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
@@ -45,6 +45,6 @@ var getContractEventByID = &oapispec.Route{
 		if err != nil {
 			return nil, err
 		}
-		return getOr(r.Ctx).Contracts().GetContractEventByID(r.Ctx, u)
+		return getOr(r.Ctx).GetBlockchainEventByID(r.Ctx, u)
 	},
 }

--- a/internal/apiserver/route_get_blockchain_event_by_id_test.go
+++ b/internal/apiserver/route_get_blockchain_event_by_id_test.go
@@ -20,23 +20,32 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hyperledger/firefly/mocks/contractmocks"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestGetContractEvents(t *testing.T) {
+func TestGetBlockchainEventByID(t *testing.T) {
 	o, r := newTestAPIServer()
-	mcm := &contractmocks.Manager{}
-	o.On("Contracts").Return(mcm)
-	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/contracts/events", nil)
+	id := fftypes.NewUUID()
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/blockchainevents/"+id.String(), nil)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	mcm.On("GetContractEvents", mock.Anything, "mynamespace", mock.Anything).
-		Return([]*fftypes.BlockchainEvent{}, nil, nil)
+	o.On("GetBlockchainEventByID", mock.Anything, id).
+		Return(&fftypes.BlockchainEvent{}, nil)
 	r.ServeHTTP(res, req)
 
 	assert.Equal(t, 200, res.Result().StatusCode)
+}
+
+func TestGetBlockchainEventBadID(t *testing.T) {
+	_, r := newTestAPIServer()
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/blockchainevents/bad", nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 400, res.Result().StatusCode)
 }

--- a/internal/apiserver/route_get_blockchain_events.go
+++ b/internal/apiserver/route_get_blockchain_events.go
@@ -26,9 +26,9 @@ import (
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
-var getContractEvents = &oapispec.Route{
-	Name:   "getContractEvents",
-	Path:   "namespaces/{ns}/contracts/events",
+var getBlockchainEvents = &oapispec.Route{
+	Name:   "getBlockchainEvents",
+	Path:   "namespaces/{ns}/blockchainevents",
 	Method: http.MethodGet,
 	PathParams: []*oapispec.PathParam{
 		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
@@ -41,6 +41,6 @@ var getContractEvents = &oapispec.Route{
 	JSONOutputValue: func() interface{} { return []*fftypes.BlockchainEvent{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
-		return filterResult(getOr(r.Ctx).Contracts().GetContractEvents(r.Ctx, r.PP["ns"], r.Filter))
+		return filterResult(getOr(r.Ctx).GetBlockchainEvents(r.Ctx, r.PP["ns"], r.Filter))
 	},
 }

--- a/internal/apiserver/route_get_blockchain_events_test.go
+++ b/internal/apiserver/route_get_blockchain_events_test.go
@@ -20,35 +20,20 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hyperledger/firefly/mocks/contractmocks"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestGetContractEventByID(t *testing.T) {
+func TestGetBlockchainEvents(t *testing.T) {
 	o, r := newTestAPIServer()
-	mcm := &contractmocks.Manager{}
-	o.On("Contracts").Return(mcm)
-	id := fftypes.NewUUID()
-	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/contracts/events/"+id.String(), nil)
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/blockchainevents", nil)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	mcm.On("GetContractEventByID", mock.Anything, id).
-		Return(&fftypes.BlockchainEvent{}, nil)
+	o.On("GetBlockchainEvents", mock.Anything, "mynamespace", mock.Anything).
+		Return([]*fftypes.BlockchainEvent{}, nil, nil)
 	r.ServeHTTP(res, req)
 
 	assert.Equal(t, 200, res.Result().StatusCode)
-}
-
-func TestGetContractEventBadID(t *testing.T) {
-	_, r := newTestAPIServer()
-	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/contracts/events/bad", nil)
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	res := httptest.NewRecorder()
-
-	r.ServeHTTP(res, req)
-
-	assert.Equal(t, 400, res.Result().StatusCode)
 }

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -125,6 +125,6 @@ var routes = []*oapispec.Route{
 	getContractSubscriptionByNameOrID,
 	getContractSubscriptions,
 	deleteContractSubscription,
-	getContractEvents,
-	getContractEventByID,
+	getBlockchainEvents,
+	getBlockchainEventByID,
 }

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -52,8 +52,6 @@ type Manager interface {
 	GetContractSubscriptionByNameOrID(ctx context.Context, ns, nameOrID string) (*fftypes.ContractSubscription, error)
 	GetContractSubscriptions(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.ContractSubscription, *database.FilterResult, error)
 	DeleteContractSubscriptionByNameOrID(ctx context.Context, ns, nameOrID string) error
-	GetContractEventByID(ctx context.Context, id *fftypes.UUID) (*fftypes.BlockchainEvent, error)
-	GetContractEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.BlockchainEvent, *database.FilterResult, error)
 }
 
 type contractManager struct {
@@ -544,14 +542,6 @@ func (cm *contractManager) SubscribeContractAPI(ctx context.Context, ns, apiName
 	}
 
 	return cm.SubscribeContract(ctx, ns, eventPath, req)
-}
-
-func (cm *contractManager) GetContractEventByID(ctx context.Context, id *fftypes.UUID) (*fftypes.BlockchainEvent, error) {
-	return cm.database.GetBlockchainEventByID(ctx, id)
-}
-
-func (cm *contractManager) GetContractEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.BlockchainEvent, *database.FilterResult, error) {
-	return cm.database.GetBlockchainEvents(ctx, cm.scopeNS(ns, filter))
 }
 
 func (cm *contractManager) checkParamSchema(ctx context.Context, input interface{}, param *fftypes.FFIParam) error {

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -1274,28 +1274,6 @@ func TestDeleteContractSubscriptionNotFound(t *testing.T) {
 	assert.Regexp(t, "FF10109", err)
 }
 
-func TestGetContractEventByID(t *testing.T) {
-	cm := newTestContractManager()
-	mdi := cm.database.(*databasemocks.Plugin)
-
-	id := fftypes.NewUUID()
-	mdi.On("GetBlockchainEventByID", context.Background(), id).Return(&fftypes.BlockchainEvent{}, nil)
-
-	_, err := cm.GetContractEventByID(context.Background(), id)
-	assert.NoError(t, err)
-}
-
-func TestGetContractEvents(t *testing.T) {
-	cm := newTestContractManager()
-	mdi := cm.database.(*databasemocks.Plugin)
-
-	mdi.On("GetBlockchainEvents", context.Background(), mock.Anything).Return(nil, nil, nil)
-
-	f := database.ContractSubscriptionQueryFactory.NewFilter(context.Background())
-	_, _, err := cm.GetContractEvents(context.Background(), "ns", f.And())
-	assert.NoError(t, err)
-}
-
 func TestInvokeContractAPI(t *testing.T) {
 	cm := newTestContractManager()
 	mdb := cm.database.(*databasemocks.Plugin)

--- a/internal/orchestrator/data_query.go
+++ b/internal/orchestrator/data_query.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -285,4 +285,12 @@ func (or *orchestrator) GetOperations(ctx context.Context, ns string, filter dat
 func (or *orchestrator) GetEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Event, *database.FilterResult, error) {
 	filter = or.scopeNS(ns, filter)
 	return or.database.GetEvents(ctx, filter)
+}
+
+func (or *orchestrator) GetBlockchainEventByID(ctx context.Context, id *fftypes.UUID) (*fftypes.BlockchainEvent, error) {
+	return or.database.GetBlockchainEventByID(ctx, id)
+}
+
+func (or *orchestrator) GetBlockchainEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.BlockchainEvent, *database.FilterResult, error) {
+	return or.database.GetBlockchainEvents(ctx, or.scopeNS(ns, filter))
 }

--- a/internal/orchestrator/data_query_test.go
+++ b/internal/orchestrator/data_query_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -569,5 +569,25 @@ func TestGetEvents(t *testing.T) {
 	fb := database.EventQueryFactory.NewFilter(context.Background())
 	f := fb.And(fb.Eq("id", u))
 	_, _, err := or.GetEvents(context.Background(), "ns1", f)
+	assert.NoError(t, err)
+}
+
+func TestGetBlockchainEventByID(t *testing.T) {
+	or := newTestOrchestrator()
+
+	id := fftypes.NewUUID()
+	or.mdi.On("GetBlockchainEventByID", context.Background(), id).Return(&fftypes.BlockchainEvent{}, nil)
+
+	_, err := or.GetBlockchainEventByID(context.Background(), id)
+	assert.NoError(t, err)
+}
+
+func TestGetBlockchainEvents(t *testing.T) {
+	or := newTestOrchestrator()
+
+	or.mdi.On("GetBlockchainEvents", context.Background(), mock.Anything).Return(nil, nil, nil)
+
+	f := database.ContractSubscriptionQueryFactory.NewFilter(context.Background())
+	_, _, err := or.GetBlockchainEvents(context.Background(), "ns", f.And())
 	assert.NoError(t, err)
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -109,6 +109,8 @@ type Orchestrator interface {
 	GetOperations(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Operation, *database.FilterResult, error)
 	GetEventByID(ctx context.Context, ns, id string) (*fftypes.Event, error)
 	GetEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Event, *database.FilterResult, error)
+	GetBlockchainEventByID(ctx context.Context, id *fftypes.UUID) (*fftypes.BlockchainEvent, error)
+	GetBlockchainEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.BlockchainEvent, *database.FilterResult, error)
 
 	// Charts
 	GetChartHistogram(ctx context.Context, ns string, startTime int64, endTime int64, buckets int64, tableName database.CollectionName) ([]*fftypes.ChartHistogram, error)

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -155,61 +155,6 @@ func (_m *Manager) GetContractAPIs(ctx context.Context, httpServerURL string, ns
 	return r0, r1, r2
 }
 
-// GetContractEventByID provides a mock function with given fields: ctx, id
-func (_m *Manager) GetContractEventByID(ctx context.Context, id *fftypes.UUID) (*fftypes.BlockchainEvent, error) {
-	ret := _m.Called(ctx, id)
-
-	var r0 *fftypes.BlockchainEvent
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID) *fftypes.BlockchainEvent); ok {
-		r0 = rf(ctx, id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*fftypes.BlockchainEvent)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID) error); ok {
-		r1 = rf(ctx, id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetContractEvents provides a mock function with given fields: ctx, ns, filter
-func (_m *Manager) GetContractEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.BlockchainEvent, *database.FilterResult, error) {
-	ret := _m.Called(ctx, ns, filter)
-
-	var r0 []*fftypes.BlockchainEvent
-	if rf, ok := ret.Get(0).(func(context.Context, string, database.AndFilter) []*fftypes.BlockchainEvent); ok {
-		r0 = rf(ctx, ns, filter)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*fftypes.BlockchainEvent)
-		}
-	}
-
-	var r1 *database.FilterResult
-	if rf, ok := ret.Get(1).(func(context.Context, string, database.AndFilter) *database.FilterResult); ok {
-		r1 = rf(ctx, ns, filter)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*database.FilterResult)
-		}
-	}
-
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, string, database.AndFilter) error); ok {
-		r2 = rf(ctx, ns, filter)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // GetContractSubscriptionByNameOrID provides a mock function with given fields: ctx, ns, nameOrID
 func (_m *Manager) GetContractSubscriptionByNameOrID(ctx context.Context, ns string, nameOrID string) (*fftypes.ContractSubscription, error) {
 	ret := _m.Called(ctx, ns, nameOrID)

--- a/mocks/orchestratormocks/orchestrator.go
+++ b/mocks/orchestratormocks/orchestrator.go
@@ -239,6 +239,61 @@ func (_m *Orchestrator) GetBatches(ctx context.Context, ns string, filter databa
 	return r0, r1, r2
 }
 
+// GetBlockchainEventByID provides a mock function with given fields: ctx, id
+func (_m *Orchestrator) GetBlockchainEventByID(ctx context.Context, id *fftypes.UUID) (*fftypes.BlockchainEvent, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *fftypes.BlockchainEvent
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID) *fftypes.BlockchainEvent); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.BlockchainEvent)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetBlockchainEvents provides a mock function with given fields: ctx, ns, filter
+func (_m *Orchestrator) GetBlockchainEvents(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.BlockchainEvent, *database.FilterResult, error) {
+	ret := _m.Called(ctx, ns, filter)
+
+	var r0 []*fftypes.BlockchainEvent
+	if rf, ok := ret.Get(0).(func(context.Context, string, database.AndFilter) []*fftypes.BlockchainEvent); ok {
+		r0 = rf(ctx, ns, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*fftypes.BlockchainEvent)
+		}
+	}
+
+	var r1 *database.FilterResult
+	if rf, ok := ret.Get(1).(func(context.Context, string, database.AndFilter) *database.FilterResult); ok {
+		r1 = rf(ctx, ns, filter)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*database.FilterResult)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, string, database.AndFilter) error); ok {
+		r2 = rf(ctx, ns, filter)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // GetChartHistogram provides a mock function with given fields: ctx, ns, startTime, endTime, buckets, tableName
 func (_m *Orchestrator) GetChartHistogram(ctx context.Context, ns string, startTime int64, endTime int64, buckets int64, tableName database.CollectionName) ([]*fftypes.ChartHistogram, error) {
 	ret := _m.Called(ctx, ns, startTime, endTime, buckets, tableName)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -304,32 +304,11 @@ func waitForMessageConfirmed(t *testing.T, c chan *fftypes.EventDelivery, msgTyp
 	}
 }
 
-func waitForChangeEvent(t *testing.T, client *resty.Client, c chan *fftypes.ChangeEvent, match map[string]interface{}) map[string]interface{} {
-	for {
-		changeEvent := <-c
-		if changeEvent.Collection == "events" || changeEvent.Collection == "contractevents" {
-			event, err := GetChangeEvent(t, client, changeEvent)
-			if err != nil {
-				t.Logf("WARN: unable to get changeEvent: %v", err.Error())
-				continue
-			}
-			eventJSON, ok := event.(map[string]interface{})
-			if !ok {
-				t.Logf("WARN: unable to parse changeEvent: %v", event)
-				continue
-			}
-			if checkObject(t, match, eventJSON) {
-				return eventJSON
-			}
-		}
-	}
-}
-
 func waitForContractEvent(t *testing.T, client *resty.Client, c chan *fftypes.EventDelivery, match map[string]interface{}) map[string]interface{} {
 	for {
 		eventDelivery := <-c
 		if eventDelivery.Type == fftypes.EventTypeBlockchainEvent {
-			event, err := GetContractEvent(t, client, eventDelivery.Event.Reference.String())
+			event, err := GetBlockchainEvent(t, client, eventDelivery.Event.Reference.String())
 			if err != nil {
 				t.Logf("WARN: unable to get event: %v", err.Error())
 				continue

--- a/test/e2e/restclient.go
+++ b/test/e2e/restclient.go
@@ -55,7 +55,7 @@ var (
 	urlContractQuery         = "/namespaces/default/contracts/query"
 	urlContractInterface     = "/namespaces/default/contracts/interfaces"
 	urlContractSubscriptions = "/namespaces/default/contracts/subscriptions"
-	urlContractEvents        = "/namespaces/default/contracts/events"
+	urlBlockchainEvents      = "/namespaces/default/blockchainevents"
 	urlGetOrganizations      = "/network/organizations"
 )
 
@@ -508,7 +508,7 @@ func GetContractSubscriptions(t *testing.T, client *resty.Client, startTime time
 }
 
 func GetContractEvents(t *testing.T, client *resty.Client, startTime time.Time, subscriptionID *fftypes.UUID) (events []*fftypes.BlockchainEvent) {
-	path := urlContractEvents
+	path := urlBlockchainEvents
 	resp, err := client.R().
 		SetQueryParam("timestamp", fmt.Sprintf(">%d", startTime.UnixNano())).
 		SetQueryParam("subscriptionId", subscriptionID.String()).
@@ -586,24 +586,6 @@ func QueryFFIMethod(t *testing.T, client *resty.Client, interfaceID, methodName 
 	return res, err
 }
 
-func GetChangeEvent(t *testing.T, client *resty.Client, changeEvent *fftypes.ChangeEvent) (interface{}, error) {
-	var res interface{}
-	var url string
-	switch changeEvent.Collection {
-	case "contractevents":
-		url = urlContractEvents
-	case "events":
-		url = urlGetEvents
-	}
-	path := fmt.Sprintf("%s/%s", url, changeEvent.ID)
-	resp, err := client.R().
-		SetResult(&res).
-		Get(path)
-	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode(), "GET %s [%d]: %s", path, resp.StatusCode(), resp.String())
-	return res, err
-}
-
 func GetEvent(t *testing.T, client *resty.Client, eventID string) (interface{}, error) {
 	var res interface{}
 	path := fmt.Sprintf("%s/%s", urlGetEvents, eventID)
@@ -615,9 +597,9 @@ func GetEvent(t *testing.T, client *resty.Client, eventID string) (interface{}, 
 	return res, err
 }
 
-func GetContractEvent(t *testing.T, client *resty.Client, eventID string) (interface{}, error) {
+func GetBlockchainEvent(t *testing.T, client *resty.Client, eventID string) (interface{}, error) {
 	var res interface{}
-	path := fmt.Sprintf("%s/%s", urlContractEvents, eventID)
+	path := fmt.Sprintf("%s/%s", urlBlockchainEvents, eventID)
 	resp, err := client.R().
 		SetResult(&res).
 		Get(path)


### PR DESCRIPTION
Also move the query helpers from Contract Manager to Orchestrator, as this
has become a generic construct that spans more than one manager/plugin.