### PR TITLE
contract_invoke Transaction should mirror status of contract_invoke Operation

### DIFF
--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -56,7 +56,7 @@ type EventManager interface {
 	WaitStop()
 
 	// Bound blockchain callbacks
-	OperationUpdate(plugin fftypes.Named, operationID *fftypes.UUID, txState blockchain.TransactionStatus, errorMessage string, opOutput fftypes.JSONObject) error
+	OperationUpdate(plugin fftypes.Named, operationID *fftypes.UUID, status blockchain.TransactionStatus, errorMessage string, opOutput fftypes.JSONObject) error
 	BatchPinComplete(bi blockchain.Plugin, batch *blockchain.BatchPin, signingIdentity string) error
 	ContractEvent(event *blockchain.ContractEvent) error
 

--- a/internal/events/operation_update.go
+++ b/internal/events/operation_update.go
@@ -17,37 +17,58 @@
 package events
 
 import (
+	"context"
+
 	"github.com/hyperledger/firefly/internal/log"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
-func (em *eventManager) OperationUpdate(plugin fftypes.Named, operationID *fftypes.UUID, txState fftypes.OpStatus, errorMessage string, opOutput fftypes.JSONObject) error {
-	op, err := em.database.GetOperationByID(em.ctx, operationID)
+func (em *eventManager) persistOpUpdate(ctx context.Context, operationID *fftypes.UUID, txState fftypes.OpStatus, errorMessage string, opOutput fftypes.JSONObject) error {
+	op, err := em.database.GetOperationByID(ctx, operationID)
 	if err != nil || op == nil {
-		log.L(em.ctx).Warnf("Operation update '%s' ignored, as it was not submitted by this node", operationID)
+		log.L(ctx).Warnf("Operation update '%s' ignored, as it was not submitted by this node", operationID)
 		return nil
 	}
 
-	update := database.OperationQueryFactory.NewUpdate(em.ctx).
+	update := database.OperationQueryFactory.NewUpdate(ctx).
 		Set("status", txState).
 		Set("error", errorMessage).
 		Set("output", opOutput)
-	if err := em.database.UpdateOperation(em.ctx, op.ID, update); err != nil {
+	if err := em.database.UpdateOperation(ctx, op.ID, update); err != nil {
 		return err
 	}
 
-	// Special handling for OpTypeTokenTransfer, which writes an event when it fails
-	if op.Type == fftypes.OpTypeTokenTransfer && txState == fftypes.OpStatusFailed {
-		txUpdate := database.TransactionQueryFactory.NewUpdate(em.ctx).Set("status", txState)
-		if err := em.database.UpdateTransaction(em.ctx, op.Transaction, txUpdate); err != nil {
-			return err
+	// Special handling for operations that have cascading effects on other objects
+	switch op.Type {
+	case fftypes.OpTypeTokenTransfer:
+		if txState == fftypes.OpStatusFailed {
+			txUpdate := database.TransactionQueryFactory.NewUpdate(ctx).Set("status", txState)
+			if err := em.database.UpdateTransaction(ctx, op.Transaction, txUpdate); err != nil {
+				return err
+			}
+
+			event := fftypes.NewEvent(fftypes.EventTypeTransferOpFailed, op.Namespace, op.ID)
+			if err := em.database.InsertEvent(ctx, event); err != nil {
+				return err
+			}
 		}
 
-		event := fftypes.NewEvent(fftypes.EventTypeTransferOpFailed, op.Namespace, op.ID)
-		if err := em.database.InsertEvent(em.ctx, event); err != nil {
+	case fftypes.OpTypeContractInvoke:
+		txUpdate := database.TransactionQueryFactory.NewUpdate(ctx).Set("status", txState)
+		if err := em.database.UpdateTransaction(ctx, op.Transaction, txUpdate); err != nil {
 			return err
 		}
 	}
+
 	return nil
+}
+
+func (em *eventManager) OperationUpdate(plugin fftypes.Named, operationID *fftypes.UUID, status fftypes.OpStatus, errorMessage string, opOutput fftypes.JSONObject) error {
+	return em.retry.Do(em.ctx, "persist operation status", func(attempt int) (bool, error) {
+		err := em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
+			return em.persistOpUpdate(ctx, operationID, status, errorMessage, opOutput)
+		})
+		return err != nil, err
+	})
 }


### PR DESCRIPTION
Fundamental question: is this the right place for this logic to live, or is this propagating an anti-pattern?