### PR TITLE
Avoid potential double-close of channels due to reconnects after tests complete

### DIFF
--- a/pkg/wsclient/wsclient_test.go
+++ b/pkg/wsclient/wsclient_test.go
@@ -201,6 +201,7 @@ func TestWSReadLoopSendFailure(t *testing.T) {
 	defer done()
 
 	wsconn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	assert.NoError(t, err)
 	wsconn.WriteJSON(map[string]string{"type": "listen", "topic": "topic1"})
 	assert.NoError(t, err)
 	<-toServer
@@ -216,6 +217,10 @@ func TestWSReadLoopSendFailure(t *testing.T) {
 
 	// Ensure the readLoop exits immediately
 	w.readLoop()
+
+	// Try reconnect, should fail here
+	_, _, err = websocket.DefaultDialer.Dial(url, nil)
+	assert.Error(t, err)
 
 }
 

--- a/pkg/wsclient/wstestserver.go
+++ b/pkg/wsclient/wstestserver.go
@@ -36,6 +36,11 @@ func NewTestWSServer(testReq func(req *http.Request)) (toServer, fromServer chan
 		if testReq != nil {
 			testReq(req)
 		}
+		if connected {
+			// test server only handles one open connection, as it only has one set of channels
+			res.WriteHeader(409)
+			return
+		}
 		ws, _ := upgrader.Upgrade(res, req, http.Header{})
 		go func() {
 			defer close(receiveDone)


### PR DESCRIPTION
Fix for #445 

I wasn't able to recreate, but the test runs showed fast timeout heartbeating and connections... so I think in a slow environment a test is reconnecting the websocket after the test had finished.

Our little test websocket server would re-use the channels in that case, even though they were close