### PR TITLE
Fixing E2E Tests for Multi-Member Networks

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -204,9 +204,19 @@ func beforeE2ETest(t *testing.T) *testState {
 		orgsC1 := GetOrgs(t, ts.client1, 200)
 		orgsC2 := GetOrgs(t, ts.client2, 200)
 		if len(orgsC1) >= 2 && len(orgsC2) >= 2 {
-			ts.org1 = orgsC1[0]
-			ts.org2 = orgsC1[1]
-			break
+			// in case there are more than two orgs in the network we need to ensure
+			// we select the same two that were provided in the first two elements
+			// of the stack file
+			for _, org := range orgsC1 {
+				if org.Name == stack.Members[0].OrgName {
+					ts.org1 = org
+				} else if org.Name == stack.Members[1].OrgName {
+					ts.org2 = org
+				}
+			}
+			if ts.org1 != nil && ts.org2 != nil {
+				break
+			}
 		}
 		t.Logf("Waiting for 2 orgs to appear. Currently have: node1=%d node2=%d", len(orgsC1), len(orgsC2))
 		time.Sleep(3 * time.Second)

--- a/test/e2e/stack.go
+++ b/test/e2e/stack.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -33,6 +33,7 @@ type Member struct {
 	Password             string `json:"password,omitempty"`
 	UseHTTPS             bool   `json:"useHttps,omitempty"`
 	ExposedConnectorPort int    `json:"exposedConnectorPort,omitempty"`
+	OrgName              string `json:"orgName,omitempty"`
 }
 
 func GetMemberPort(filename string, n int) (int, error) {


### PR DESCRIPTION
Noticed if I use the E2E tests to validate a multi-member (2+ members) network that it'd get confused about which members it was testing because the order of the members in the stack file can never be guaranteed to match the order of the orgs returned by the API of one of the nodes.