### PR TITLE
wsReader cannot rely on `testing.T` as it might extend past test scope

### DIFF
--- a/test/e2e/ethereum_contract_test.go
+++ b/test/e2e/ethereum_contract_test.go
@@ -192,7 +192,7 @@ func (suite *EthereumContractTestSuite) BeforeTest(suiteName, testName string) {
 func (suite *EthereumContractTestSuite) TestE2EContractEvents() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
+	received1, changes1 := wsReader(suite.testState.ws1)
 
 	sub := CreateContractSubscription(suite.T(), suite.testState.client1, simpleStorageFFIChanged(), &fftypes.JSONObject{
 		"address": suite.contractAddress,
@@ -230,7 +230,7 @@ func (suite *EthereumContractTestSuite) TestE2EContractEvents() {
 func (suite *EthereumContractTestSuite) TestDirectInvokeMethod() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
+	received1, changes1 := wsReader(suite.testState.ws1)
 
 	sub := CreateContractSubscription(suite.T(), suite.testState.client1, simpleStorageFFIChanged(), &fftypes.JSONObject{
 		"address": suite.contractAddress,
@@ -286,7 +286,7 @@ func (suite *EthereumContractTestSuite) TestDirectInvokeMethod() {
 func (suite *EthereumContractTestSuite) TestFFIInvokeMethod() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
+	received1, changes1 := wsReader(suite.testState.ws1)
 
 	sub := CreateContractSubscription(suite.T(), suite.testState.client1, simpleStorageFFIChanged(), &fftypes.JSONObject{
 		"address": suite.contractAddress,

--- a/test/e2e/fabric_contract_test.go
+++ b/test/e2e/fabric_contract_test.go
@@ -108,7 +108,7 @@ func (suite *FabricContractTestSuite) BeforeTest(suiteName, testName string) {
 func (suite *FabricContractTestSuite) TestE2EContractEvents() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
+	received1, changes1 := wsReader(suite.testState.ws1)
 
 	sub := CreateContractSubscription(suite.T(), suite.testState.client1, assetCreatedEvent, &fftypes.JSONObject{
 		"channel":   "firefly",

--- a/test/e2e/onchain_offchain_test.go
+++ b/test/e2e/onchain_offchain_test.go
@@ -46,8 +46,8 @@ func (suite *OnChainOffChainTestSuite) BeforeTest(suiteName, testName string) {
 func (suite *OnChainOffChainTestSuite) TestE2EBroadcast() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
-	received2, changes2 := wsReader(suite.T(), suite.testState.ws2)
+	received1, changes1 := wsReader(suite.testState.ws1)
+	received2, changes2 := wsReader(suite.testState.ws2)
 
 	var resp *resty.Response
 	value := fftypes.JSONAnyPtr(`"Hello"`)
@@ -74,8 +74,8 @@ func (suite *OnChainOffChainTestSuite) TestE2EBroadcast() {
 func (suite *OnChainOffChainTestSuite) TestStrongDatatypesBroadcast() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
-	received2, changes2 := wsReader(suite.T(), suite.testState.ws2)
+	received1, changes1 := wsReader(suite.testState.ws1)
+	received2, changes2 := wsReader(suite.testState.ws2)
 
 	var resp *resty.Response
 	value := fftypes.JSONAnyPtr(`"Hello"`)
@@ -125,8 +125,8 @@ func (suite *OnChainOffChainTestSuite) TestStrongDatatypesBroadcast() {
 func (suite *OnChainOffChainTestSuite) TestStrongDatatypesPrivate() {
 	defer suite.testState.done()
 
-	received1, changes1 := wsReader(suite.T(), suite.testState.ws1)
-	received2, changes2 := wsReader(suite.T(), suite.testState.ws2)
+	received1, changes1 := wsReader(suite.testState.ws1)
+	received2, changes2 := wsReader(suite.testState.ws2)
 
 	var resp *resty.Response
 	value := fftypes.JSONAnyPtr(`{"foo":"bar"}`)
@@ -185,8 +185,8 @@ func (suite *OnChainOffChainTestSuite) TestStrongDatatypesPrivate() {
 func (suite *OnChainOffChainTestSuite) TestE2EPrivate() {
 	defer suite.testState.done()
 
-	received1, _ := wsReader(suite.T(), suite.testState.ws1)
-	received2, _ := wsReader(suite.T(), suite.testState.ws2)
+	received1, _ := wsReader(suite.testState.ws1)
+	received2, _ := wsReader(suite.testState.ws2)
 
 	var resp *resty.Response
 	value := fftypes.JSONAnyPtr(`"Hello"`)
@@ -213,8 +213,8 @@ func (suite *OnChainOffChainTestSuite) TestE2EPrivate() {
 func (suite *OnChainOffChainTestSuite) TestE2EBroadcastBlob() {
 	defer suite.testState.done()
 
-	received1, _ := wsReader(suite.T(), suite.testState.ws1)
-	received2, _ := wsReader(suite.T(), suite.testState.ws2)
+	received1, _ := wsReader(suite.testState.ws1)
+	received2, _ := wsReader(suite.testState.ws2)
 
 	var resp *resty.Response
 
@@ -239,8 +239,8 @@ func (suite *OnChainOffChainTestSuite) TestE2EBroadcastBlob() {
 func (suite *OnChainOffChainTestSuite) TestE2EPrivateBlobDatatypeTagged() {
 	defer suite.testState.done()
 
-	received1, _ := wsReader(suite.T(), suite.testState.ws1)
-	received2, _ := wsReader(suite.T(), suite.testState.ws2)
+	received1, _ := wsReader(suite.testState.ws1)
+	received2, _ := wsReader(suite.testState.ws2)
 
 	var resp *resty.Response
 
@@ -269,8 +269,8 @@ func (suite *OnChainOffChainTestSuite) TestE2EPrivateBlobDatatypeTagged() {
 func (suite *OnChainOffChainTestSuite) TestE2EWebhookExchange() {
 	defer suite.testState.done()
 
-	received1, _ := wsReader(suite.T(), suite.testState.ws1)
-	received2, _ := wsReader(suite.T(), suite.testState.ws2)
+	received1, _ := wsReader(suite.testState.ws1)
+	received2, _ := wsReader(suite.testState.ws2)
 
 	subJSON := `{
 		"transport": "webhooks",

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -37,8 +37,8 @@ func (suite *TokensTestSuite) BeforeTest(suiteName, testName string) {
 func (suite *TokensTestSuite) TestE2EFungibleTokensAsync() {
 	defer suite.testState.done()
 
-	received1, _ := wsReader(suite.T(), suite.testState.ws1)
-	received2, _ := wsReader(suite.T(), suite.testState.ws2)
+	received1, _ := wsReader(suite.testState.ws1)
+	received2, _ := wsReader(suite.testState.ws2)
 
 	pools := GetTokenPools(suite.T(), suite.testState.client1, time.Unix(0, 0))
 	poolName := fmt.Sprintf("pool%d", len(pools))
@@ -184,8 +184,8 @@ func (suite *TokensTestSuite) TestE2EFungibleTokensAsync() {
 func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	defer suite.testState.done()
 
-	received1, _ := wsReader(suite.T(), suite.testState.ws1)
-	received2, _ := wsReader(suite.T(), suite.testState.ws2)
+	received1, _ := wsReader(suite.testState.ws1)
+	received2, _ := wsReader(suite.testState.ws2)
 
 	pools := GetTokenPools(suite.T(), suite.testState.client1, time.Unix(0, 0))
 	poolName := fmt.Sprintf("pool%d", len(pools))


### PR DESCRIPTION
Fix for #471 