### PR TITLE
Store all token transfer inputs on operation

### DIFF
--- a/internal/assets/token_pool.go
+++ b/internal/assets/token_pool.go
@@ -76,13 +76,12 @@ func (am *assetManager) createTokenPoolInternal(ctx context.Context, pool *fftyp
 		pool.TX.ID = txid
 		pool.TX.Type = fftypes.TransactionTypeTokenPool
 
-		op = fftypes.NewTXOperation(
+		op = fftypes.NewOperation(
 			plugin,
 			pool.Namespace,
 			txid,
 			"",
-			fftypes.OpTypeTokenCreatePool,
-			fftypes.OpStatusPending)
+			fftypes.OpTypeTokenCreatePool)
 		txcommon.AddTokenPoolCreateInputs(op, pool)
 
 		return am.database.InsertOperation(ctx, op)

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -239,13 +239,12 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) er
 		s.transfer.TX.ID = txid
 		s.transfer.TX.Type = fftypes.TransactionTypeTokenTransfer
 
-		op = fftypes.NewTXOperation(
+		op = fftypes.NewOperation(
 			plugin,
 			s.namespace,
 			txid,
 			"",
-			fftypes.OpTypeTokenTransfer,
-			fftypes.OpStatusPending)
+			fftypes.OpTypeTokenTransfer)
 		if err = txcommon.AddTokenTransferInputs(op, &s.transfer.TokenTransfer); err == nil {
 			err = s.mgr.database.InsertOperation(ctx, op)
 		}

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -246,11 +246,13 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) er
 			"",
 			fftypes.OpTypeTokenTransfer,
 			fftypes.OpStatusPending)
-		txcommon.AddTokenTransferInputs(op, &s.transfer.TokenTransfer)
-
-		if err = s.mgr.database.InsertOperation(ctx, op); err != nil {
+		if err = txcommon.AddTokenTransferInputs(op, &s.transfer.TokenTransfer); err == nil {
+			err = s.mgr.database.InsertOperation(ctx, op)
+		}
+		if err != nil {
 			return err
 		}
+
 		if s.transfer.Message != nil {
 			s.transfer.Message.State = fftypes.MessageStateStaged
 			err = s.mgr.database.UpsertMessage(ctx, &s.transfer.Message.Message, database.UpsertOptimizationNew)

--- a/internal/batchpin/batchpin.go
+++ b/internal/batchpin/batchpin.go
@@ -50,13 +50,12 @@ func NewBatchPinSubmitter(di database.Plugin, im identity.Manager, bi blockchain
 func (bp *batchPinSubmitter) SubmitPinnedBatch(ctx context.Context, batch *fftypes.Batch, contexts []*fftypes.Bytes32) error {
 
 	// The pending blockchain transaction
-	op := fftypes.NewTXOperation(
+	op := fftypes.NewOperation(
 		bp.blockchain,
 		batch.Namespace,
 		batch.Payload.TX.ID,
 		"",
-		fftypes.OpTypeBlockchainBatchPin,
-		fftypes.OpStatusPending)
+		fftypes.OpTypeBlockchainBatchPin)
 	if err := bp.database.InsertOperation(ctx, op); err != nil {
 		return err
 	}

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -124,14 +124,13 @@ func (bm *broadcastManager) submitTXAndUpdateDB(ctx context.Context, batch *ffty
 	}
 
 	// The completed PublicStorage upload
-	op := fftypes.NewTXOperation(
+	op := fftypes.NewOperation(
 		bm.publicstorage,
 		batch.Namespace,
 		batch.Payload.TX.ID,
 		batch.PayloadRef,
-		fftypes.OpTypePublicStorageBatchBroadcast,
-		fftypes.OpStatusSucceeded, // Note we performed the action synchronously above
-	)
+		fftypes.OpTypePublicStorageBatchBroadcast)
+	op.Status = fftypes.OpStatusSucceeded // Note we performed the action synchronously above
 	err = bm.database.InsertOperation(ctx, op)
 	if err != nil {
 		return err

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -183,13 +183,12 @@ func (cm *contractManager) InvokeContract(ctx context.Context, ns string, req *f
 			return err
 		}
 
-		op = fftypes.NewTXOperation(
+		op = fftypes.NewOperation(
 			cm.blockchain,
 			ns,
 			txid,
 			"",
-			fftypes.OpTypeContractInvoke,
-			fftypes.OpStatusPending)
+			fftypes.OpTypeContractInvoke)
 		op.Input = req.Input
 		return cm.database.InsertOperation(ctx, op)
 	})

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -106,13 +106,12 @@ func (em *eventManager) shouldAnnounce(ctx context.Context, ti tokens.Plugin, po
 	}
 	addPoolDetailsFromPlugin(announcePool, pool)
 
-	nextOp := fftypes.NewTXOperation(
+	nextOp := fftypes.NewOperation(
 		ti,
 		op.Namespace,
 		op.Transaction,
 		"",
-		fftypes.OpTypeTokenAnnouncePool,
-		fftypes.OpStatusPending)
+		fftypes.OpTypeTokenAnnouncePool)
 	return announcePool, em.database.InsertOperation(ctx, nextOp)
 }
 

--- a/internal/events/tokens_transferred_test.go
+++ b/internal/events/tokens_transferred_test.go
@@ -148,7 +148,7 @@ func TestPersistTransferBadOp(t *testing.T) {
 	}
 	ops := []*fftypes.Operation{{
 		Input: fftypes.JSONObject{
-			"id": "bad",
+			"localId": "bad",
 		},
 		Transaction: fftypes.NewUUID(),
 	}}
@@ -179,7 +179,7 @@ func TestPersistTransferTxFail(t *testing.T) {
 	localID := fftypes.NewUUID()
 	ops := []*fftypes.Operation{{
 		Input: fftypes.JSONObject{
-			"id": localID.String(),
+			"localId": localID.String(),
 		},
 	}}
 
@@ -209,7 +209,7 @@ func TestPersistTransferGetTransferFail(t *testing.T) {
 	localID := fftypes.NewUUID()
 	ops := []*fftypes.Operation{{
 		Input: fftypes.JSONObject{
-			"id": localID.String(),
+			"localId": localID.String(),
 		},
 	}}
 
@@ -240,7 +240,7 @@ func TestPersistTransferBlockchainEventFail(t *testing.T) {
 	localID := fftypes.NewUUID()
 	ops := []*fftypes.Operation{{
 		Input: fftypes.JSONObject{
-			"id": localID.String(),
+			"localId": localID.String(),
 		},
 	}}
 
@@ -275,7 +275,7 @@ func TestTokensTransferredWithTransactionRegenerateLocalID(t *testing.T) {
 	localID := fftypes.NewUUID()
 	operations := []*fftypes.Operation{{
 		Input: fftypes.JSONObject{
-			"id": localID.String(),
+			"localId": localID.String(),
 		},
 	}}
 

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -158,13 +158,12 @@ func (pm *privateMessaging) transferBlobs(ctx context.Context, data []*fftypes.D
 			}
 
 			if txid != nil {
-				op := fftypes.NewTXOperation(
+				op := fftypes.NewOperation(
 					pm.exchange,
 					d.Namespace,
 					txid,
 					trackingID,
-					fftypes.OpTypeDataExchangeBlobSend,
-					fftypes.OpStatusPending)
+					fftypes.OpTypeDataExchangeBlobSend)
 				if err = pm.database.InsertOperation(ctx, op); err != nil {
 					return err
 				}
@@ -210,13 +209,12 @@ func (pm *privateMessaging) sendData(ctx context.Context, mType string, mID *fft
 		}
 
 		if txid != nil {
-			op := fftypes.NewTXOperation(
+			op := fftypes.NewOperation(
 				pm.exchange,
 				ns,
 				txid,
 				trackingID,
-				fftypes.OpTypeDataExchangeBatchSend,
-				fftypes.OpStatusPending)
+				fftypes.OpTypeDataExchangeBatchSend)
 			op.Input = fftypes.JSONObject{
 				"manifest": tw.Manifest().String(),
 			}

--- a/internal/syncasync/sync_async_bridge_test.go
+++ b/internal/syncasync/sync_async_bridge_test.go
@@ -645,7 +645,7 @@ func TestAwaitFailedTokenTransfer(t *testing.T) {
 	op := &fftypes.Operation{
 		ID: fftypes.NewUUID(),
 		Input: fftypes.JSONObject{
-			"id": requestID.String(),
+			"localId": requestID.String(),
 		},
 	}
 
@@ -686,7 +686,7 @@ func TestFailedTokenTransferOpError(t *testing.T) {
 	op := &fftypes.Operation{
 		ID: fftypes.NewUUID(),
 		Input: fftypes.JSONObject{
-			"id": requestID.String(),
+			"localId": requestID.String(),
 		},
 	}
 
@@ -721,7 +721,7 @@ func TestFailedTokenTransferOpNotFound(t *testing.T) {
 	op := &fftypes.Operation{
 		ID: fftypes.NewUUID(),
 		Input: fftypes.JSONObject{
-			"id": requestID.String(),
+			"localId": requestID.String(),
 		},
 	}
 

--- a/pkg/fftypes/operation.go
+++ b/pkg/fftypes/operation.go
@@ -56,8 +56,8 @@ type Named interface {
 	Name() string
 }
 
-// NewTXOperation creates a new operation for a transaction
-func NewTXOperation(plugin Named, namespace string, tx *UUID, backendID string, opType OpType, opStatus OpStatus) *Operation {
+// NewOperation creates a new operation in a transaction
+func NewOperation(plugin Named, namespace string, tx *UUID, backendID string, opType OpType) *Operation {
 	return &Operation{
 		ID:          NewUUID(),
 		Namespace:   namespace,
@@ -65,7 +65,7 @@ func NewTXOperation(plugin Named, namespace string, tx *UUID, backendID string, 
 		BackendID:   backendID,
 		Transaction: tx,
 		Type:        opType,
-		Status:      opStatus,
+		Status:      OpStatusPending,
 		Created:     Now(),
 	}
 }

--- a/pkg/fftypes/operation_test.go
+++ b/pkg/fftypes/operation_test.go
@@ -29,7 +29,7 @@ func (f *fakePlugin) Name() string { return "fake" }
 func TestNewPendingMessageOp(t *testing.T) {
 
 	txID := NewUUID()
-	op := NewTXOperation(&fakePlugin{}, "ns1", txID, "testBackend", OpTypePublicStorageBatchBroadcast, OpStatusPending)
+	op := NewOperation(&fakePlugin{}, "ns1", txID, "testBackend", OpTypePublicStorageBatchBroadcast)
 	assert.Equal(t, Operation{
 		ID:          op.ID,
 		Namespace:   "ns1",


### PR DESCRIPTION
Since the transfer is only recorded upon success, all inputs must be stored
on the operation in order to support retries or accurately report failures.

Needed for #400 and #316