### PR TITLE
Remove extra "rejected" events

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3868,13 +3868,10 @@ paths:
                     - datatype_confirmed
                     - group_confirmed
                     - token_pool_confirmed
-                    - token_pool_rejected
                     - token_transfer_confirmed
                     - token_transfer_op_failed
                     - contract_interface_confirmed
-                    - contract_interface_rejected
                     - contract_api_confirmed
-                    - contract_api_rejected
                     - blockchain_event
                     type: string
                 type: object
@@ -3929,13 +3926,10 @@ paths:
                     - datatype_confirmed
                     - group_confirmed
                     - token_pool_confirmed
-                    - token_pool_rejected
                     - token_transfer_confirmed
                     - token_transfer_op_failed
                     - contract_interface_confirmed
-                    - contract_interface_rejected
                     - contract_api_confirmed
-                    - contract_api_rejected
                     - blockchain_event
                     type: string
                 type: object
@@ -4595,13 +4589,10 @@ paths:
                     - datatype_confirmed
                     - group_confirmed
                     - token_pool_confirmed
-                    - token_pool_rejected
                     - token_transfer_confirmed
                     - token_transfer_op_failed
                     - contract_interface_confirmed
-                    - contract_interface_rejected
                     - contract_api_confirmed
-                    - contract_api_rejected
                     - blockchain_event
                     type: string
                 type: object

--- a/internal/definitions/definition_handler_contracts.go
+++ b/internal/definitions/definition_handler_contracts.go
@@ -83,20 +83,15 @@ func (dh *definitionHandlers) handleFFIBroadcast(ctx context.Context, msg *fftyp
 		}
 	}
 
-	var eventType fftypes.EventType
-	var actionResult DefinitionMessageAction
-	if valid {
-		l.Infof("Contract interface created id=%s author=%s", broadcast.ID, msg.Header.Author)
-		eventType = fftypes.EventTypeContractInterfaceConfirmed
-		actionResult = ActionConfirm
-	} else {
+	if !valid {
 		l.Warnf("Contract interface rejected id=%s author=%s", broadcast.ID, msg.Header.Author)
-		eventType = fftypes.EventTypeContractInterfaceRejected
-		actionResult = ActionReject
+		return ActionReject, nil, nil
 	}
-	return actionResult, &DefinitionBatchActions{
+
+	l.Infof("Contract interface created id=%s author=%s", broadcast.ID, msg.Header.Author)
+	return ActionConfirm, &DefinitionBatchActions{
 		Finalize: func(ctx context.Context) error {
-			event := fftypes.NewEvent(eventType, broadcast.Namespace, broadcast.ID)
+			event := fftypes.NewEvent(fftypes.EventTypeContractInterfaceConfirmed, broadcast.Namespace, broadcast.ID)
 			return dh.database.InsertEvent(ctx, event)
 		},
 	}, nil
@@ -120,20 +115,15 @@ func (dh *definitionHandlers) handleContractAPIBroadcast(ctx context.Context, ms
 		}
 	}
 
-	var eventType fftypes.EventType
-	var actionResult DefinitionMessageAction
-	if valid {
-		l.Infof("Contract API created id=%s author=%s", broadcast.ID, msg.Header.Author)
-		eventType = fftypes.EventTypeContractAPIConfirmed
-		actionResult = ActionConfirm
-	} else {
+	if !valid {
 		l.Warnf("Contract API rejected id=%s author=%s", broadcast.ID, msg.Header.Author)
-		eventType = fftypes.EventTypeContractAPIRejected
-		actionResult = ActionReject
+		return ActionReject, nil, nil
 	}
-	return actionResult, &DefinitionBatchActions{
+
+	l.Infof("Contract API created id=%s author=%s", broadcast.ID, msg.Header.Author)
+	return ActionConfirm, &DefinitionBatchActions{
 		Finalize: func(ctx context.Context) error {
-			event := fftypes.NewEvent(eventType, broadcast.Namespace, broadcast.ID)
+			event := fftypes.NewEvent(fftypes.EventTypeContractAPIConfirmed, broadcast.Namespace, broadcast.ID)
 			return dh.database.InsertEvent(ctx, event)
 		},
 	}, nil

--- a/internal/definitions/definition_handler_contracts_test.go
+++ b/internal/definitions/definition_handler_contracts_test.go
@@ -130,14 +130,12 @@ func TestHandleFFIBroadcastReject(t *testing.T) {
 	mcm := dh.contracts.(*contractmocks.Manager)
 	mbi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	mcm.On("ValidateFFIAndSetPathnames", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
-	action, ba, err := dh.handleFFIBroadcast(context.Background(), &fftypes.Message{
+	action, _, err := dh.handleFFIBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineFFI),
 		},
 	}, []*fftypes.Data{})
 	assert.Equal(t, ActionReject, action)
-	assert.NoError(t, err)
-	err = ba.Finalize(context.Background())
 	assert.NoError(t, err)
 }
 

--- a/internal/definitions/definition_handler_tokenpool_test.go
+++ b/internal/definitions/definition_handler_tokenpool_test.go
@@ -167,9 +167,6 @@ func TestHandleDefinitionBroadcastTokenPoolIDMismatch(t *testing.T) {
 	mdi.On("UpsertTokenPool", context.Background(), mock.MatchedBy(func(p *fftypes.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(database.IDMismatch)
-	mdi.On("InsertEvent", context.Background(), mock.MatchedBy(func(event *fftypes.Event) bool {
-		return *event.Reference == *pool.ID && event.Namespace == pool.Namespace && event.Type == fftypes.EventTypePoolRejected
-	})).Return(nil)
 
 	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
 	assert.Equal(t, ActionReject, action)
@@ -235,16 +232,9 @@ func TestHandleDefinitionBroadcastTokenPoolValidateFail(t *testing.T) {
 	msg, data, err := buildPoolDefinitionMessage(announce)
 	assert.NoError(t, err)
 
-	mdi := sh.database.(*databasemocks.Plugin)
-	mdi.On("InsertEvent", context.Background(), mock.MatchedBy(func(event *fftypes.Event) bool {
-		return event.Type == fftypes.EventTypePoolRejected
-	})).Return(nil)
-
 	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
-
-	mdi.AssertExpectations(t)
 }
 
 func TestHandleDefinitionBroadcastTokenPoolBadMessage(t *testing.T) {

--- a/pkg/fftypes/event.go
+++ b/pkg/fftypes/event.go
@@ -35,20 +35,14 @@ var (
 	EventTypeGroupConfirmed EventType = ffEnum("eventtype", "group_confirmed")
 	// EventTypePoolConfirmed occurs when a new token pool is ready for use
 	EventTypePoolConfirmed EventType = ffEnum("eventtype", "token_pool_confirmed")
-	// EventTypePoolRejected occurs when a new token pool is rejected (due to validation errors, duplicates, etc)
-	EventTypePoolRejected EventType = ffEnum("eventtype", "token_pool_rejected")
 	// EventTypeTransferConfirmed occurs when a token transfer has been confirmed
 	EventTypeTransferConfirmed EventType = ffEnum("eventtype", "token_transfer_confirmed")
 	// EventTypeTransferOpFailed occurs when a token transfer submitted by this node has failed (based on feedback from connector)
 	EventTypeTransferOpFailed EventType = ffEnum("eventtype", "token_transfer_op_failed")
 	// EventTypeContractInterfaceConfirmed occurs when a new contract interface has been confirmed
 	EventTypeContractInterfaceConfirmed EventType = ffEnum("eventtype", "contract_interface_confirmed")
-	// EventTypeContractInterfaceRejected occurs when a new contract interface has been rejected
-	EventTypeContractInterfaceRejected EventType = ffEnum("eventtype", "contract_interface_rejected")
 	// EventTypeContractAPIConfirmed occurs when a new contract API has been confirmed
 	EventTypeContractAPIConfirmed EventType = ffEnum("eventtype", "contract_api_confirmed")
-	// EventTypeContractInterfaceRejected occurs when a new contract API has been rejected
-	EventTypeContractAPIRejected EventType = ffEnum("eventtype", "contract_api_rejected")
 	// EventTypeBlockchainEvent occurs when a new event has been recorded from the blockchain
 	EventTypeBlockchainEvent EventType = ffEnum("eventtype", "blockchain_event")
 )


### PR DESCRIPTION
Only "message_rejected" will be emitted for rejected definition messages -
no special per-type event will be emitted.

This requires one extra lookup in syncasync to find rejected token pools,
but seems better for overall consistency.