### PR TITLE
Fix possibility for nil access in sendloop

### DIFF
--- a/internal/apiserver/http_server_test.go
+++ b/internal/apiserver/http_server_test.go
@@ -145,6 +145,7 @@ func TestTLSServerSelfSignedWithClientAuth(t *testing.T) {
 	pem.Encode(publicKeyFile, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 
 	// Start up a listener configured for TLS Mutual auth
+	config.Reset() // ensure APIShutdownTimeout cleared from earlier tests
 	cp := config.NewPluginConfig("ut")
 	initHTTPConfPrefx(cp, 0)
 	cp.Set(HTTPConfAddress, "127.0.0.1")

--- a/pkg/wsclient/wsclient.go
+++ b/pkg/wsclient/wsclient.go
@@ -324,13 +324,13 @@ func (w *wsClient) receiveReconnectLoop() {
 			// Synchronously invoke the reader, as it's important we react immediately to any error there.
 			w.readLoop()
 			close(receiverDone)
+			<-w.sendDone
 
-			// Ensure the connection is closed after the receiver exits
+			// Ensure the connection is closed after the sender and receivers exit
 			err = w.wsconn.Close()
 			if err != nil {
 				l.Debugf("WS %s close failed: %s", w.url, err)
 			}
-			<-w.sendDone
 			w.sendDone = nil
 			w.wsconn = nil
 		}


### PR DESCRIPTION
Fix for #485 with a bonus fix for this timing issue I'm seeing intermittently since upgrading my laptop.

```
time="2022-02-07T13:21:00-05:00" level=info msg="API server context cancelled - shutting down"
time="2022-02-07T13:21:00-05:00" level=info msg="API server complete"
--- FAIL: TestTLSServerSelfSignedWithClientAuth (0.13s)
    http_server_test.go:197: 
                Error Trace:    http_server_test.go:197
                Error:          Received unexpected error:
                                context deadline exceeded
                Test:           TestTLSServerSelfSignedWithClientAuth
```