### PR TITLE
Add extra logging for message/event ids

### DIFF
--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/hyperledger/firefly/internal/i18n"
+	"github.com/hyperledger/firefly/internal/log"
 	"github.com/hyperledger/firefly/internal/sysmessaging"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
@@ -162,7 +163,12 @@ func (s *broadcastSender) sendInternal(ctx context.Context, method sendMethod) (
 	}
 
 	// Store the message - this asynchronously triggers the next step in process
-	return s.mgr.database.UpsertMessage(ctx, &s.msg.Message, database.UpsertOptimizationNew)
+	if err := s.mgr.database.UpsertMessage(ctx, &s.msg.Message, database.UpsertOptimizationNew); err != nil {
+		return err
+	}
+	log.L(ctx).Infof("Sent broadcast message %s:%s", s.msg.Header.Namespace, s.msg.Header.ID)
+
+	return err
 }
 
 func (s *broadcastSender) isRootOrgBroadcast(ctx context.Context) bool {

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -380,7 +380,7 @@ func (ag *aggregator) attemptMessageDispatch(ctx context.Context, msg *fftypes.M
 		if err = ag.database.InsertEvent(ctx, event); err != nil {
 			return err
 		}
-		log.L(ctx).Infof("Emitting %s for message %s:%s", eventType, msg.Header.Namespace, msg.Header.ID)
+		log.L(ctx).Infof("Emitting %s %s for message %s:%s", eventType, event.ID, msg.Header.Namespace, msg.Header.ID)
 		return nil
 	})
 

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/hyperledger/firefly/internal/i18n"
+	"github.com/hyperledger/firefly/internal/log"
 	"github.com/hyperledger/firefly/internal/sysmessaging"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
@@ -184,6 +185,7 @@ func (s *messageSender) sendInternal(ctx context.Context, method sendMethod) err
 	if err := s.mgr.database.UpsertMessage(ctx, &s.msg.Message, database.UpsertOptimizationNew); err != nil {
 		return err
 	}
+	log.L(ctx).Infof("Sent private message %s:%s", s.msg.Header.Namespace, s.msg.Header.ID)
 
 	if method == methodSendImmediate {
 		if err := s.sendUnpinned(ctx); err != nil {


### PR DESCRIPTION
Notices these were missing when investigating a set of performance logs