### PR TITLE
Fix group to be constant throughout test

### DIFF
--- a/test/e2e/onchain_offchain_test.go
+++ b/test/e2e/onchain_offchain_test.go
@@ -157,7 +157,7 @@ func (suite *OnChainOffChainTestSuite) TestStrongDatatypesPrivate() {
 	}
 
 	// Should be rejected as datatype not known
-	resp, err := PrivateMessage(suite.T(), suite.testState.client1, "topic1", &data, []string{
+	resp, err := PrivateMessage(suite.testState, suite.testState.client1, "topic1", &data, []string{
 		suite.testState.org1.Name,
 		suite.testState.org2.Name,
 	}, "", fftypes.TransactionTypeBatchPin, true)
@@ -172,7 +172,7 @@ func (suite *OnChainOffChainTestSuite) TestStrongDatatypesPrivate() {
 	}
 	dt = CreateDatatype(suite.T(), suite.testState.client1, dt, true)
 
-	resp, err = PrivateMessage(suite.T(), suite.testState.client1, "topic1", &data, []string{
+	resp, err = PrivateMessage(suite.testState, suite.testState.client1, "topic1", &data, []string{
 		suite.testState.org1.Name,
 		suite.testState.org2.Name,
 	}, "", fftypes.TransactionTypeBatchPin, false)
@@ -185,7 +185,7 @@ func (suite *OnChainOffChainTestSuite) TestStrongDatatypesPrivate() {
 		"name": "mywidget"
 	}`)
 
-	resp, err = PrivateMessage(suite.T(), suite.testState.client1, "topic1", &data, []string{
+	resp, err = PrivateMessage(suite.testState, suite.testState.client1, "topic1", &data, []string{
 		suite.testState.org1.Name,
 		suite.testState.org2.Name,
 	}, "", fftypes.TransactionTypeBatchPin, true)
@@ -218,7 +218,7 @@ func (suite *OnChainOffChainTestSuite) TestE2EPrivate() {
 
 		expectedData[topic] = append(expectedData[topic], data)
 
-		resp, err := PrivateMessage(suite.T(), suite.testState.client1, topic, data, []string{
+		resp, err := PrivateMessage(suite.testState, suite.testState.client1, topic, data, []string{
 			suite.testState.org1.Name,
 			suite.testState.org2.Name,
 		}, "", fftypes.TransactionTypeBatchPin, false)
@@ -278,7 +278,7 @@ func (suite *OnChainOffChainTestSuite) TestE2EPrivateBlobDatatypeTagged() {
 
 	var resp *resty.Response
 
-	data, resp, err := PrivateBlobMessageDatatypeTagged(suite.T(), suite.testState.client1, "topic1", []string{
+	data, resp, err := PrivateBlobMessageDatatypeTagged(suite.testState, suite.testState.client1, "topic1", []string{
 		suite.testState.org1.Name,
 		suite.testState.org2.Name,
 	})
@@ -330,7 +330,7 @@ func (suite *OnChainOffChainTestSuite) TestE2EWebhookExchange() {
 	}
 
 	var resp *resty.Response
-	resp, err := PrivateMessage(suite.T(), suite.testState.client1, "topic1", &data, []string{
+	resp, err := PrivateMessage(suite.testState, suite.testState.client1, "topic1", &data, []string{
 		suite.testState.org1.Name,
 		suite.testState.org2.Name,
 	}, "myrequest", fftypes.TransactionTypeBatchPin, false)
@@ -385,7 +385,7 @@ func (suite *OnChainOffChainTestSuite) TestE2EWebhookRequestReplyNoTx() {
 		Value: fftypes.JSONAnyPtr(`{}`),
 	}
 
-	reply := RequestReply(suite.T(), suite.testState.client1, &data, []string{
+	reply := RequestReply(suite.testState, suite.testState.client1, &data, []string{
 		suite.testState.org1.Name,
 		suite.testState.org2.Name,
 	}, "myrequest", fftypes.TransactionTypeNone)

--- a/test/e2e/restclient_test.go
+++ b/test/e2e/restclient_test.go
@@ -254,8 +254,8 @@ func BroadcastBlobMessage(t *testing.T, client *resty.Client, topic string) (*ff
 	return data, res, err
 }
 
-func PrivateBlobMessageDatatypeTagged(t *testing.T, client *resty.Client, topic string, orgNames []string) (*fftypes.Data, *resty.Response, error) {
-	data := CreateBlob(t, client, &fftypes.DatatypeRef{Name: "myblob"})
+func PrivateBlobMessageDatatypeTagged(ts *testState, client *resty.Client, topic string, orgNames []string) (*fftypes.Data, *resty.Response, error) {
+	data := CreateBlob(ts.t, client, &fftypes.DatatypeRef{Name: "myblob"})
 	members := make([]fftypes.MemberInput, len(orgNames))
 	for i, oName := range orgNames {
 		// We let FireFly resolve the friendly name of the org to the identity
@@ -275,14 +275,14 @@ func PrivateBlobMessageDatatypeTagged(t *testing.T, client *resty.Client, topic 
 			},
 			Group: &fftypes.InputGroup{
 				Members: members,
-				Name:    fmt.Sprintf("test_%d", time.Now().Unix()),
+				Name:    fmt.Sprintf("test_%d", ts.startTime.UnixNano()),
 			},
 		}).
 		Post(urlPrivateMessage)
 	return data, res, err
 }
 
-func PrivateMessage(t *testing.T, client *resty.Client, topic string, data *fftypes.DataRefOrValue, orgNames []string, tag string, txType fftypes.TransactionType, confirm bool) (*resty.Response, error) {
+func PrivateMessage(ts *testState, client *resty.Client, topic string, data *fftypes.DataRefOrValue, orgNames []string, tag string, txType fftypes.TransactionType, confirm bool) (*resty.Response, error) {
 	members := make([]fftypes.MemberInput, len(orgNames))
 	for i, oName := range orgNames {
 		// We let FireFly resolve the friendly name of the org to the identity
@@ -301,7 +301,7 @@ func PrivateMessage(t *testing.T, client *resty.Client, topic string, data *ffty
 		InlineData: fftypes.InlineData{data},
 		Group: &fftypes.InputGroup{
 			Members: members,
-			Name:    fmt.Sprintf("test_%d", time.Now().Unix()),
+			Name:    fmt.Sprintf("test_%d", ts.startTime.UnixNano()),
 		},
 	}
 	return client.R().
@@ -310,7 +310,7 @@ func PrivateMessage(t *testing.T, client *resty.Client, topic string, data *ffty
 		Post(urlPrivateMessage)
 }
 
-func RequestReply(t *testing.T, client *resty.Client, data *fftypes.DataRefOrValue, orgNames []string, tag string, txType fftypes.TransactionType) *fftypes.MessageInOut {
+func RequestReply(ts *testState, client *resty.Client, data *fftypes.DataRefOrValue, orgNames []string, tag string, txType fftypes.TransactionType) *fftypes.MessageInOut {
 	members := make([]fftypes.MemberInput, len(orgNames))
 	for i, oName := range orgNames {
 		// We let FireFly resolve the friendly name of the org to the identity
@@ -328,7 +328,7 @@ func RequestReply(t *testing.T, client *resty.Client, data *fftypes.DataRefOrVal
 		InlineData: fftypes.InlineData{data},
 		Group: &fftypes.InputGroup{
 			Members: members,
-			Name:    fmt.Sprintf("test_%d", time.Now().Unix()),
+			Name:    fmt.Sprintf("test_%d", ts.startTime.UnixNano()),
 		},
 	}
 	var replyMsg fftypes.MessageInOut
@@ -336,8 +336,8 @@ func RequestReply(t *testing.T, client *resty.Client, data *fftypes.DataRefOrVal
 		SetBody(msg).
 		SetResult(&replyMsg).
 		Post(urlRequestMessage)
-	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode(), "POST %s [%d]: %s", urlUploadData, resp.StatusCode(), resp.String())
+	require.NoError(ts.t, err)
+	require.Equal(ts.t, 200, resp.StatusCode(), "POST %s [%d]: %s", urlUploadData, resp.StatusCode(), resp.String())
 	return &replyMsg
 }
 


### PR DESCRIPTION
Fix for #487 

Note rename of `restclient.go` to `restclient_test.go` is to allow it to share `testState`