### PR TITLE
Compile directly with solc to avoid full Node.js npm install of Truffle

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
       "platform": "linux/x86_64"
     },
     "solidity-builder": {
-      "image": "node:14-alpine3.15"
+      "image": "ethereum/solc:0.8.11-alpine"
     },
     "base": {
       "image": "alpine:3.15"


### PR DESCRIPTION
Saves a lot of time and I/O activity during the docker build.

The `jq` command converts the `combined.json` output from `solc` in this syntax of JSON required by the CLI (which is a subset of the Truffle output):
https://github.com/hyperledger/firefly-cli/blob/680665495e45074b250e5ed5a74e8f152774254c/pkg/types/ethconnect.go#L19-L23