### PR TITLE
Rewind when messages appear behind offset

### DIFF
--- a/internal/batch/batch_manager.go
+++ b/internal/batch/batch_manager.go
@@ -225,7 +225,11 @@ func (bm *batchManager) assembleMessageData(msg *fftypes.Message) (data []*fftyp
 
 func (bm *batchManager) markRewind(rewindTo int64) {
 	bm.rewindMux.Lock()
-	bm.rewindTo = rewindTo
+	// Make sure we only rewind backwards - as we might get multiple shoulder taps
+	// for different message sequences during a single poll cycle.
+	if bm.rewindTo < 0 || rewindTo < bm.rewindTo {
+		bm.rewindTo = rewindTo
+	}
 	bm.rewindMux.Unlock()
 }
 

--- a/internal/batch/batch_manager.go
+++ b/internal/batch/batch_manager.go
@@ -86,6 +86,8 @@ type batchManager struct {
 	readPageSize               uint64
 	messagePollTimeout         time.Duration
 	startupOffsetRetryAttempts int
+	rewindMux                  sync.Mutex
+	rewindTo                   int64
 }
 
 type DispatchHandler func(context.Context, *fftypes.Batch, []*fftypes.Bytes32) error
@@ -116,6 +118,8 @@ func (bm *batchManager) RegisterDispatcher(msgTypes []fftypes.MessageType, handl
 }
 
 func (bm *batchManager) Start() error {
+	bm.markRewind(-1)
+
 	if err := bm.restoreOffset(); err != nil {
 		return err
 	}
@@ -219,7 +223,29 @@ func (bm *batchManager) assembleMessageData(msg *fftypes.Message) (data []*fftyp
 	return data, nil
 }
 
+func (bm *batchManager) markRewind(rewindTo int64) {
+	bm.rewindMux.Lock()
+	bm.rewindTo = rewindTo
+	bm.rewindMux.Unlock()
+}
+
+func (bm *batchManager) popRewind() int64 {
+	bm.rewindMux.Lock()
+	rewindTo := bm.rewindTo
+	bm.rewindTo = -1
+	bm.rewindMux.Unlock()
+	return rewindTo
+}
+
 func (bm *batchManager) readPage() ([]*fftypes.Message, error) {
+
+	rewindTo := bm.popRewind()
+	if rewindTo >= 0 && rewindTo < bm.offset {
+		if err := bm.updateOffset(true, rewindTo); err != nil {
+			return nil, err
+		}
+	}
+
 	var msgs []*fftypes.Message
 	err := bm.retry.Do(bm.ctx, "retrieve messages", func(attempt int) (retry bool, err error) {
 		fb := database.MessageQueryFactory.NewFilterLimit(bm.ctx, bm.readPageSize)
@@ -305,6 +331,7 @@ func (bm *batchManager) newEventNotifications() {
 				return
 			}
 			l.Debugf("New message sequence notification: %d", m)
+			bm.markRewind(m)
 		case <-bm.ctx.Done():
 			l.Debugf("Exiting due to cancelled context")
 			return

--- a/internal/batch/batch_manager_test.go
+++ b/internal/batch/batch_manager_test.go
@@ -510,7 +510,55 @@ func TestWaitConsumesMessagesAndDoesNotBlock(t *testing.T) {
 	}
 	// And should generate a shoulder tap
 	<-bm.(*batchManager).shoulderTap
+	// And a rewind
+	assert.Equal(t, int64(12345), bm.(*batchManager).popRewind())
 	bm.Close()
+}
+
+func TestReadPageWithRewindSuccess(t *testing.T) {
+	config.Reset()
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	mni := &sysmessagingmocks.LocalNodeInfo{}
+
+	msg := &fftypes.Message{Header: fftypes.MessageHeader{ID: fftypes.NewUUID()}}
+	mdi.On("UpdateOffset", mock.Anything, int64(0), mock.Anything).Return(nil)
+	mdi.On("GetMessages", mock.Anything, mock.MatchedBy(func(filter database.Filter) bool {
+		f, _ := filter.Finalize()
+		assert.Contains(t, f.String(), "12345")
+		return true
+	})).Return([]*fftypes.Message{msg}, nil, nil)
+
+	bmi, _ := NewBatchManager(context.Background(), mni, mdi, mdm)
+	bm := bmi.(*batchManager)
+	bm.offset = 22222
+	bm.markRewind(12345)
+	msgs, err := bm.readPage()
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	bm.Close()
+
+	mdi.AssertExpectations(t)
+}
+
+func TestReadPageWithRewindFail(t *testing.T) {
+	config.Reset()
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	mni := &sysmessagingmocks.LocalNodeInfo{}
+
+	mdi.On("UpdateOffset", mock.Anything, int64(0), mock.Anything).Return(fmt.Errorf("pop"))
+
+	bmi, _ := NewBatchManager(context.Background(), mni, mdi, mdm)
+	bm := bmi.(*batchManager)
+	bm.Close()
+
+	bm.offset = 22222
+	bm.markRewind(12345)
+	_, err := bm.readPage()
+	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
 }
 
 func TestAssembleMessageDataNilData(t *testing.T) {


### PR DESCRIPTION
Fix for #493 

Observed reviewing the logs for #493 that the messages were never being picked up by the batch processor, and the perf tool is submitting them in a highly parallel way. My analysis is that with PSQL as used in this test (or any production ready database) parallel writing of messages to the DB could result in the commit order of the transactions, being mismatched with the sequence allocation to the rows. 

The code in the batch manager did not handle this - it would simply do a shoulder tap to re-read from the DB when a message was created, but not check if that message had appeared behind the offset and it needed to do a rewind.

This code change implements a simple rewind (like we have for the event aggregator).
Note this means that in the case of parallel REST API submission of messages, the final delivery order might not match the local sequence order. However, that's in-line with the assurances FireFly provides - as application should only be able to depend on.

- The local order they submitted in (in this case there is parallel submission, so the order is not deterministic) - but they should only rely on this for their own participation, and cannot consider this the global order across participants.
- The final order as ordered by the blockchain, when pinning is used.