### PR TITLE
Add endpoint to automatically generate an FFI

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2333,6 +2333,113 @@ paths:
           description: Success
         default:
           description: ""
+  /namespaces/{ns}/contracts/interfaces/generate:
+    post:
+      description: 'TODO: Description'
+      operationId: postGenerateContractInterface
+      parameters:
+      - description: 'TODO: Description'
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: When true the HTTP request blocks until the message is confirmed
+        in: query
+        name: confirm
+        schema:
+          example: "true"
+          type: string
+      - description: Server-side request timeout (millseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 120s
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  description:
+                    type: string
+                  events:
+                    items:
+                      properties:
+                        contract: {}
+                        description:
+                          type: string
+                        id: {}
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        params:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              schema:
+                                type: string
+                            type: object
+                          type: array
+                        pathname:
+                          type: string
+                      type: object
+                    type: array
+                  id: {}
+                  message: {}
+                  methods:
+                    items:
+                      properties:
+                        contract: {}
+                        description:
+                          type: string
+                        id: {}
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        params:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              schema:
+                                type: string
+                            type: object
+                          type: array
+                        pathname:
+                          type: string
+                        returns:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              schema:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  version:
+                    type: string
+                type: object
+          description: Success
+        default:
+          description: ""
   /namespaces/{ns}/contracts/invoke:
     post:
       description: 'TODO: Description'

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2345,12 +2345,6 @@ paths:
         schema:
           example: default
           type: string
-      - description: When true the HTTP request blocks until the message is confirmed
-        in: query
-        name: confirm
-        schema:
-          example: "true"
-          type: string
       - description: Server-side request timeout (millseconds, or set a custom suffix
           like 10s)
         in: header
@@ -2362,7 +2356,18 @@ paths:
         content:
           application/json:
             schema:
-              type: string
+              properties:
+                description:
+                  type: string
+                input:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                version:
+                  type: string
+              type: object
       responses:
         "200":
           content:

--- a/internal/apiserver/route_post_contract_interface_generate.go
+++ b/internal/apiserver/route_post_contract_interface_generate.go
@@ -1,0 +1,47 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/hyperledger/firefly/internal/config"
+	"github.com/hyperledger/firefly/internal/i18n"
+	"github.com/hyperledger/firefly/internal/oapispec"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+)
+
+var postContractInterfaceGenerate = &oapispec.Route{
+	Name:   "postGenerateContractInterface",
+	Path:   "namespaces/{ns}/contracts/interfaces/generate",
+	Method: http.MethodPost,
+	PathParams: []*oapispec.PathParam{
+		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
+	},
+	QueryParams: []*oapispec.QueryParam{
+		{Name: "confirm", Description: i18n.MsgConfirmQueryParam, IsBool: true, Example: "true"},
+	},
+	FilterFactory:   nil,
+	Description:     i18n.MsgTBD,
+	JSONInputValue:  func() interface{} { return fftypes.JSONAnyPtr("{}") },
+	JSONInputMask:   nil,
+	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
+	JSONOutputCodes: []int{http.StatusOK},
+	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
+		return getOr(r.Ctx).Contracts().GenerateFFI(r.Ctx, r.PP["ns"], "", "", r.Input.(*fftypes.JSONAny))
+	},
+}

--- a/internal/apiserver/route_post_contract_interface_generate.go
+++ b/internal/apiserver/route_post_contract_interface_generate.go
@@ -32,16 +32,15 @@ var postContractInterfaceGenerate = &oapispec.Route{
 	PathParams: []*oapispec.PathParam{
 		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
 	},
-	QueryParams: []*oapispec.QueryParam{
-		{Name: "confirm", Description: i18n.MsgConfirmQueryParam, IsBool: true, Example: "true"},
-	},
+	QueryParams:     []*oapispec.QueryParam{},
 	FilterFactory:   nil,
 	Description:     i18n.MsgTBD,
-	JSONInputValue:  func() interface{} { return fftypes.JSONAnyPtr("{}") },
+	JSONInputValue:  func() interface{} { return &fftypes.FFIGenerationRequest{} },
 	JSONInputMask:   nil,
 	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
-		return getOr(r.Ctx).Contracts().GenerateFFI(r.Ctx, r.PP["ns"], "", "", r.Input.(*fftypes.JSONAny))
+		generationRequest := r.Input.(*fftypes.FFIGenerationRequest)
+		return getOr(r.Ctx).Contracts().GenerateFFI(r.Ctx, r.PP["ns"], generationRequest)
 	},
 }

--- a/internal/apiserver/route_post_contract_interface_generate_test.go
+++ b/internal/apiserver/route_post_contract_interface_generate_test.go
@@ -39,7 +39,7 @@ func TestPostContractInterfaceGenerate(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	mcm.On("GenerateFFI", mock.Anything, "ns1", mock.Anything, mock.Anything, mock.Anything).
+	mcm.On("GenerateFFI", mock.Anything, "ns1", mock.Anything).
 		Return(&fftypes.FFI{}, nil)
 	r.ServeHTTP(res, req)
 

--- a/internal/apiserver/route_post_contract_interface_generate_test.go
+++ b/internal/apiserver/route_post_contract_interface_generate_test.go
@@ -1,0 +1,47 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/firefly/mocks/contractmocks"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestPostContractInterfaceGenerate(t *testing.T) {
+	o, r := newTestAPIServer()
+	mcm := &contractmocks.Manager{}
+	o.On("Contracts").Return(mcm)
+	input := fftypes.Datatype{}
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(&input)
+	req := httptest.NewRequest("POST", "/api/v1/namespaces/ns1/contracts/interfaces/generate", &buf)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	mcm.On("GenerateFFI", mock.Anything, "ns1", mock.Anything, mock.Anything, mock.Anything).
+		Return(&fftypes.FFI{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 200, res.Result().StatusCode)
+}

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -98,6 +98,7 @@ var routes = []*oapispec.Route{
 	postContractInterfaceInvoke,
 	postContractInterfaceQuery,
 	postContractInterfaceSubscribe,
+	postContractInterfaceGenerate,
 
 	postNewContractAPI,
 	getContractAPIByName,

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -73,7 +73,7 @@ type asyncTXSubmission struct {
 }
 
 type queryOutput struct {
-	Output string `json:"output"`
+	Output interface{} `json:"output"`
 }
 
 type ethWSCommandPayload struct {

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -756,23 +756,24 @@ func (e *Ethereum) getContractAddress(ctx context.Context, instancePath string) 
 	return output["address"], nil
 }
 
-func (e *Ethereum) GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
+func (e *Ethereum) GenerateFFI(ctx context.Context, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
 	var abi []ABIElementMarshaling
-	err := json.Unmarshal(input.Bytes(), &abi)
+	err := json.Unmarshal(generationRequest.Input.Bytes(), &abi)
 	if err != nil {
 		return nil, i18n.NewError(ctx, i18n.MsgFFIGenerationFailed, "unable to deserialize JSON as ABI")
 	}
-	ffi := e.convertABIToFFI(ns, name, version, abi)
+	ffi := e.convertABIToFFI(generationRequest.Namespace, generationRequest.Name, generationRequest.Version, generationRequest.Description, abi)
 	return ffi, nil
 }
 
-func (e *Ethereum) convertABIToFFI(ns, name, version string, abi []ABIElementMarshaling) *fftypes.FFI {
+func (e *Ethereum) convertABIToFFI(ns, name, version, description string, abi []ABIElementMarshaling) *fftypes.FFI {
 	ffi := &fftypes.FFI{
-		Namespace: ns,
-		Name:      name,
-		Version:   version,
-		Methods:   []*fftypes.FFIMethod{},
-		Events:    []*fftypes.FFIEvent{},
+		Namespace:   ns,
+		Name:        name,
+		Version:     version,
+		Description: description,
+		Methods:     []*fftypes.FFIMethod{},
+		Events:      []*fftypes.FFIEvent{},
 	}
 
 	for _, element := range abi {

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -2040,9 +2040,10 @@ func TestConvertABIToFFI(t *testing.T) {
 	schema := fftypes.JSONAnyPtr(`{"type":"integer","details":{"type":"uint256","internalType":"uint256"}}`)
 
 	expectedFFI := &fftypes.FFI{
-		Name:      "SimpleStorage",
-		Version:   "v0.0.1",
-		Namespace: "default",
+		Name:        "SimpleStorage",
+		Version:     "v0.0.1",
+		Namespace:   "default",
+		Description: "desc",
 		Methods: []*fftypes.FFIMethod{
 			{
 				Name: "set",
@@ -2080,7 +2081,7 @@ func TestConvertABIToFFI(t *testing.T) {
 		},
 	}
 
-	actualFFI := e.convertABIToFFI("default", "SimpleStorage", "v0.0.1", abi)
+	actualFFI := e.convertABIToFFI("default", "SimpleStorage", "v0.0.1", "desc", abi)
 	assert.NotNil(t, actualFFI)
 	assert.Equal(t, expectedFFI, actualFFI)
 }
@@ -2118,9 +2119,10 @@ func TestConvertABIToFFIWithObject(t *testing.T) {
 	schema := fftypes.JSONAnyPtr(`{"type":"object","details":{"type":"tuple","internalType":"struct WidgetFactory.Widget"},"properties":{"description":{"type":"string","details":{"type":"string","internalType":"string","index":1}},"size":{"type":"integer","details":{"type":"uint256","internalType":"uint256","index":0}}}}`)
 
 	expectedFFI := &fftypes.FFI{
-		Name:      "WidgetTest",
-		Version:   "v0.0.1",
-		Namespace: "default",
+		Name:        "WidgetTest",
+		Version:     "v0.0.1",
+		Namespace:   "default",
+		Description: "desc",
 		Methods: []*fftypes.FFIMethod{
 			{
 				Name: "set",
@@ -2136,7 +2138,7 @@ func TestConvertABIToFFIWithObject(t *testing.T) {
 		Events: []*fftypes.FFIEvent{},
 	}
 
-	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", abi)
+	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", "desc", abi)
 	assert.NotNil(t, actualFFI)
 	assert.Equal(t, expectedFFI, actualFFI)
 }
@@ -2162,9 +2164,10 @@ func TestConvertABIToFFIWithArray(t *testing.T) {
 	schema := fftypes.JSONAnyPtr(`{"type":"array","details":{"type":"string[]","internalType":"string[]"},"items":{"type":"string"}}`)
 
 	expectedFFI := &fftypes.FFI{
-		Name:      "WidgetTest",
-		Version:   "v0.0.1",
-		Namespace: "default",
+		Name:        "WidgetTest",
+		Version:     "v0.0.1",
+		Namespace:   "default",
+		Description: "desc",
 		Methods: []*fftypes.FFIMethod{
 			{
 				Name: "set",
@@ -2180,7 +2183,7 @@ func TestConvertABIToFFIWithArray(t *testing.T) {
 		Events: []*fftypes.FFIEvent{},
 	}
 
-	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", abi)
+	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", "desc", abi)
 	assert.NotNil(t, actualFFI)
 	assert.Equal(t, expectedFFI, actualFFI)
 }
@@ -2205,9 +2208,10 @@ func TestConvertABIToFFIWithNestedArray(t *testing.T) {
 
 	schema := fftypes.JSONAnyPtr(`{"type":"array","details":{"type":"string[][]","internalType":"string[][]"},"items":{"type":"array","items":{"type":"string"}}}`)
 	expectedFFI := &fftypes.FFI{
-		Name:      "WidgetTest",
-		Version:   "v0.0.1",
-		Namespace: "default",
+		Name:        "WidgetTest",
+		Version:     "v0.0.1",
+		Namespace:   "default",
+		Description: "desc",
 		Methods: []*fftypes.FFIMethod{
 			{
 				Name: "set",
@@ -2223,7 +2227,7 @@ func TestConvertABIToFFIWithNestedArray(t *testing.T) {
 		Events: []*fftypes.FFIEvent{},
 	}
 
-	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", abi)
+	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", "desc", abi)
 	assert.NotNil(t, actualFFI)
 	assert.Equal(t, expectedFFI, actualFFI)
 }
@@ -2265,9 +2269,10 @@ func TestConvertABIToFFIWithNestedArrayOfObjects(t *testing.T) {
 
 	schema := fftypes.JSONAnyPtr(`{"type":"array","details":{"type":"tuple[][]","internalType":"struct WidgetFactory.Widget[][]"},"items":{"type":"array","items":{"type":"object","properties":{"description":{"type":"string","details":{"type":"string","internalType":"string","index":0}},"inUse":{"type":"boolean","details":{"type":"bool","internalType":"bool","index":2}},"size":{"type":"integer","details":{"type":"uint256","internalType":"uint256","index":1}}}}}}`)
 	expectedFFI := &fftypes.FFI{
-		Name:      "WidgetTest",
-		Version:   "v0.0.1",
-		Namespace: "default",
+		Name:        "WidgetTest",
+		Version:     "v0.0.1",
+		Namespace:   "default",
+		Description: "desc",
 		Methods: []*fftypes.FFIMethod{
 			{
 				Name: "set",
@@ -2283,20 +2288,43 @@ func TestConvertABIToFFIWithNestedArrayOfObjects(t *testing.T) {
 		Events: []*fftypes.FFIEvent{},
 	}
 
-	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", abi)
+	actualFFI := e.convertABIToFFI("default", "WidgetTest", "v0.0.1", "desc", abi)
 	assert.NotNil(t, actualFFI)
 	assert.Equal(t, expectedFFI, actualFFI)
 }
 
 func TestGenerateFFI(t *testing.T) {
 	e, _ := newTestEthereum()
-	_, err := e.GenerateFFI(context.Background(), "default", "Simple", "v0.0.01", fftypes.JSONAnyPtr(`[]`))
+	_, err := e.GenerateFFI(context.Background(), &fftypes.FFIGenerationRequest{
+		Name:        "Simple",
+		Version:     "v0.0.1",
+		Description: "desc",
+		Input:       fftypes.JSONAnyPtr(`[]`),
+	})
 	assert.NoError(t, err)
+}
+
+func TestGenerateFFIInlineNamespace(t *testing.T) {
+	e, _ := newTestEthereum()
+	ffi, err := e.GenerateFFI(context.Background(), &fftypes.FFIGenerationRequest{
+		Name:        "Simple",
+		Version:     "v0.0.1",
+		Description: "desc",
+		Namespace:   "ns1",
+		Input:       fftypes.JSONAnyPtr(`[]`),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, ffi.Namespace, "ns1")
 }
 
 func TestGenerateFFIFail(t *testing.T) {
 	e, _ := newTestEthereum()
-	_, err := e.GenerateFFI(context.Background(), "default", "SimpleFailure", "v0.0.01", fftypes.JSONAnyPtr(`{"type": "not an ABI"}`))
+	_, err := e.GenerateFFI(context.Background(), &fftypes.FFIGenerationRequest{
+		Name:        "Simple",
+		Version:     "v0.0.1",
+		Description: "desc",
+		Input:       fftypes.JSONAnyPtr(`{"type": "not an ABI"}`),
+	})
 	assert.Regexp(t, "FF10346", err)
 }
 

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -649,3 +649,7 @@ func (f *Fabric) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamVali
 	// Fabconnect does not require any additional validation beyond "JSON Schema correctness" at this time
 	return nil, nil
 }
+
+func (f *Fabric) GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
+	return nil, i18n.NewError(ctx, i18n.MsgFFIGenerationUnsupported)
+}

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -650,6 +650,6 @@ func (f *Fabric) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamVali
 	return nil, nil
 }
 
-func (f *Fabric) GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
+func (f *Fabric) GenerateFFI(ctx context.Context, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
 	return nil, i18n.NewError(ctx, i18n.MsgFFIGenerationUnsupported)
 }

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -1501,3 +1501,9 @@ func TestGetFFIParamValidator(t *testing.T) {
 	_, err := e.GetFFIParamValidator(context.Background())
 	assert.NoError(t, err)
 }
+
+func TestGenerateFFI(t *testing.T) {
+	e, _ := newTestFabric()
+	_, err := e.GenerateFFI(context.Background(), "default", "Simple", "v0.0.01", fftypes.JSONAnyPtr(`[]`))
+	assert.Regexp(t, "FF10347", err)
+}

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -1504,6 +1504,11 @@ func TestGetFFIParamValidator(t *testing.T) {
 
 func TestGenerateFFI(t *testing.T) {
 	e, _ := newTestFabric()
-	_, err := e.GenerateFFI(context.Background(), "default", "Simple", "v0.0.01", fftypes.JSONAnyPtr(`[]`))
+	_, err := e.GenerateFFI(context.Background(), &fftypes.FFIGenerationRequest{
+		Name:        "Simple",
+		Version:     "v0.0.1",
+		Description: "desc",
+		Input:       fftypes.JSONAnyPtr(`[]`),
+	})
 	assert.Regexp(t, "FF10347", err)
 }

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -53,6 +53,7 @@ type Manager interface {
 	GetContractSubscriptionByNameOrID(ctx context.Context, ns, nameOrID string) (*fftypes.ContractSubscription, error)
 	GetContractSubscriptions(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.ContractSubscription, *database.FilterResult, error)
 	DeleteContractSubscriptionByNameOrID(ctx context.Context, ns, nameOrID string) error
+	GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error)
 }
 
 type contractManager struct {
@@ -591,4 +592,8 @@ func (cm *contractManager) checkParamSchema(ctx context.Context, input interface
 		return i18n.WrapError(ctx, err, i18n.MsgFFIValidationFail, param.Name)
 	}
 	return nil
+}
+
+func (cm *contractManager) GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
+	return cm.blockchain.GenerateFFI(ctx, ns, name, version, input)
 }

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -595,8 +595,6 @@ func (cm *contractManager) checkParamSchema(ctx context.Context, input interface
 }
 
 func (cm *contractManager) GenerateFFI(ctx context.Context, ns string, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
-	if generationRequest.Namespace == "" {
-		generationRequest.Namespace = ns
-	}
+	generationRequest.Namespace = ns
 	return cm.blockchain.GenerateFFI(ctx, generationRequest)
 }

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -53,7 +53,7 @@ type Manager interface {
 	GetContractSubscriptionByNameOrID(ctx context.Context, ns, nameOrID string) (*fftypes.ContractSubscription, error)
 	GetContractSubscriptions(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.ContractSubscription, *database.FilterResult, error)
 	DeleteContractSubscriptionByNameOrID(ctx context.Context, ns, nameOrID string) error
-	GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error)
+	GenerateFFI(ctx context.Context, ns string, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error)
 }
 
 type contractManager struct {
@@ -594,6 +594,9 @@ func (cm *contractManager) checkParamSchema(ctx context.Context, input interface
 	return nil
 }
 
-func (cm *contractManager) GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
-	return cm.blockchain.GenerateFFI(ctx, ns, name, version, input)
+func (cm *contractManager) GenerateFFI(ctx context.Context, ns string, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
+	if generationRequest.Namespace == "" {
+		generationRequest.Namespace = ns
+	}
+	return cm.blockchain.GenerateFFI(ctx, generationRequest)
 }

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -1898,6 +1898,18 @@ func TestAddJSONSchemaExtension(t *testing.T) {
 	assert.NotNil(t, c)
 }
 
+func TestGenerateFFI(t *testing.T) {
+	cm := newTestContractManager()
+	mbi := cm.blockchain.(*blockchainmocks.Plugin)
+	mbi.On("GenerateFFI", mock.Anything, mock.Anything).Return(&fftypes.FFI{
+		Name: "generated",
+	}, nil)
+	ffi, err := cm.GenerateFFI(context.Background(), "default", &fftypes.FFIGenerationRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, ffi)
+	assert.Equal(t, "generated", ffi.Name)
+}
+
 type MockFFIParamValidator struct{}
 
 func (v MockFFIParamValidator) Compile(ctx jsonschema.CompilerContext, m map[string]interface{}) (jsonschema.ExtSchema, error) {

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -262,4 +262,6 @@ var (
 	MsgInvalidTXTypeForMessage      = ffm("FF10343", "Invalid transaction type for sending a message: %s", 400)
 	MsgGroupRequired                = ffm("FF10344", "Group must be set", 400)
 	MsgDBLockFailed                 = ffm("FF10345", "Database lock failed")
+	MsgFFIGenerationFailed          = ffm("FF10346", "Error generating smart contract interface: %s", 400)
+	MsgFFIGenerationUnsupported     = ffm("FF10347", "Smart contract interface generation is not supported by this blockchain plugin", 400)
 )

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -62,6 +62,29 @@ func (_m *Plugin) DeleteSubscription(ctx context.Context, subscription *fftypes.
 	return r0
 }
 
+// GenerateFFI provides a mock function with given fields: ctx, ns, name, version, input
+func (_m *Plugin) GenerateFFI(ctx context.Context, ns string, name string, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, ns, name, version, input)
+
+	var r0 *fftypes.FFI
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *fftypes.JSONAny) *fftypes.FFI); ok {
+		r0 = rf(ctx, ns, name, version, input)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.FFI)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *fftypes.JSONAny) error); ok {
+		r1 = rf(ctx, ns, name, version, input)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetFFIParamValidator provides a mock function with given fields: ctx
 func (_m *Plugin) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {
 	ret := _m.Called(ctx)

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -62,13 +62,13 @@ func (_m *Plugin) DeleteSubscription(ctx context.Context, subscription *fftypes.
 	return r0
 }
 
-// GenerateFFI provides a mock function with given fields: ctx, ns, name, version, input
-func (_m *Plugin) GenerateFFI(ctx context.Context, ns string, name string, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
-	ret := _m.Called(ctx, ns, name, version, input)
+// GenerateFFI provides a mock function with given fields: ctx, generationRequest
+func (_m *Plugin) GenerateFFI(ctx context.Context, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, generationRequest)
 
 	var r0 *fftypes.FFI
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *fftypes.JSONAny) *fftypes.FFI); ok {
-		r0 = rf(ctx, ns, name, version, input)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.FFIGenerationRequest) *fftypes.FFI); ok {
+		r0 = rf(ctx, generationRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.FFI)
@@ -76,8 +76,8 @@ func (_m *Plugin) GenerateFFI(ctx context.Context, ns string, name string, versi
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *fftypes.JSONAny) error); ok {
-		r1 = rf(ctx, ns, name, version, input)
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.FFIGenerationRequest) error); ok {
+		r1 = rf(ctx, generationRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -100,6 +100,29 @@ func (_m *Manager) DeleteContractSubscriptionByNameOrID(ctx context.Context, ns 
 	return r0
 }
 
+// GenerateFFI provides a mock function with given fields: ctx, ns, name, version, input
+func (_m *Manager) GenerateFFI(ctx context.Context, ns string, name string, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, ns, name, version, input)
+
+	var r0 *fftypes.FFI
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *fftypes.JSONAny) *fftypes.FFI); ok {
+		r0 = rf(ctx, ns, name, version, input)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.FFI)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *fftypes.JSONAny) error); ok {
+		r1 = rf(ctx, ns, name, version, input)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetContractAPI provides a mock function with given fields: ctx, httpServerURL, ns, apiName
 func (_m *Manager) GetContractAPI(ctx context.Context, httpServerURL string, ns string, apiName string) (*fftypes.ContractAPI, error) {
 	ret := _m.Called(ctx, httpServerURL, ns, apiName)

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -100,13 +100,13 @@ func (_m *Manager) DeleteContractSubscriptionByNameOrID(ctx context.Context, ns 
 	return r0
 }
 
-// GenerateFFI provides a mock function with given fields: ctx, ns, name, version, input
-func (_m *Manager) GenerateFFI(ctx context.Context, ns string, name string, version string, input *fftypes.JSONAny) (*fftypes.FFI, error) {
-	ret := _m.Called(ctx, ns, name, version, input)
+// GenerateFFI provides a mock function with given fields: ctx, ns, generationRequest
+func (_m *Manager) GenerateFFI(ctx context.Context, ns string, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, ns, generationRequest)
 
 	var r0 *fftypes.FFI
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *fftypes.JSONAny) *fftypes.FFI); ok {
-		r0 = rf(ctx, ns, name, version, input)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.FFIGenerationRequest) *fftypes.FFI); ok {
+		r0 = rf(ctx, ns, generationRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.FFI)
@@ -114,8 +114,8 @@ func (_m *Manager) GenerateFFI(ctx context.Context, ns string, name string, vers
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *fftypes.JSONAny) error); ok {
-		r1 = rf(ctx, ns, name, version, input)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.FFIGenerationRequest) error); ok {
+		r1 = rf(ctx, ns, generationRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -61,6 +61,9 @@ type Plugin interface {
 
 	// GetFFIParamValidator returns a blockchain-plugin-specific validator for FFIParams and their JSON Schema
 	GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error)
+
+	// GenerateFFI returns an FFI from a blockchain specific interface format e.g. an Ethereum ABI
+	GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error)
 }
 
 // Callbacks is the interface provided to the blockchain plugin, to allow it to pass events back to firefly.

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -63,7 +63,7 @@ type Plugin interface {
 	GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error)
 
 	// GenerateFFI returns an FFI from a blockchain specific interface format e.g. an Ethereum ABI
-	GenerateFFI(ctx context.Context, ns, name, version string, input *fftypes.JSONAny) (*fftypes.FFI, error)
+	GenerateFFI(ctx context.Context, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error)
 }
 
 // Callbacks is the interface provided to the blockchain plugin, to allow it to pass events back to firefly.

--- a/pkg/fftypes/ffi.go
+++ b/pkg/fftypes/ffi.go
@@ -80,6 +80,14 @@ type FFIParam struct {
 
 type FFIParams []*FFIParam
 
+type FFIGenerationRequest struct {
+	Namespace   string   `json:"namespace,omitempty"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Version     string   `json:"version"`
+	Input       *JSONAny `json:"input"`
+}
+
 func (f *FFI) Validate(ctx context.Context, existing bool) (err error) {
 	if err = ValidateFFNameField(ctx, f.Namespace, "namespace"); err != nil {
 		return err

--- a/pkg/fftypes/ffi.go
+++ b/pkg/fftypes/ffi.go
@@ -41,9 +41,9 @@ type FFI struct {
 	ID          *UUID        `json:"id,omitempty"`
 	Message     *UUID        `json:"message,omitempty"`
 	Namespace   string       `json:"namespace,omitempty"`
-	Name        string       `json:"name,omitempty"`
+	Name        string       `json:"name"`
 	Description string       `json:"description"`
-	Version     string       `json:"version,omitempty"`
+	Version     string       `json:"version"`
 	Methods     []*FFIMethod `json:"methods,omitempty"`
 	Events      []*FFIEvent  `json:"events,omitempty"`
 }

--- a/test/data/assetcreator/chaincode/smartcontract.go
+++ b/test/data/assetcreator/chaincode/smartcontract.go
@@ -24,3 +24,11 @@ func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface,
 	ctx.GetStub().SetEvent("AssetCreated", assetJSON)
 	return ctx.GetStub().PutState(name, assetJSON)
 }
+
+func (s *SmartContract) GetAsset(ctx contractapi.TransactionContextInterface, name string) (string, error) {
+	b, err := ctx.GetStub().GetState(name)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/test/data/assetcreator/chaincode/smartcontract.go
+++ b/test/data/assetcreator/chaincode/smartcontract.go
@@ -24,11 +24,3 @@ func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface,
 	ctx.GetStub().SetEvent("AssetCreated", assetJSON)
 	return ctx.GetStub().PutState(name, assetJSON)
 }
-
-func (s *SmartContract) GetAsset(ctx contractapi.TransactionContextInterface, name string) (string, error) {
-	b, err := ctx.GetStub().GetState(name)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}


### PR DESCRIPTION
This PR adds an endpoint to automatically generate an FFI. The implementation is handled by the blockchain plugin. Right now, only the Ethereum plugin implements this functionality, but other blockchain plugins in the future could as well, if they have their own DSL to describe a smart contract.

Resolves https://github.com/hyperledger/firefly/issues/397