### PR TITLE
Provide Migration / Registration / Debugging Utilities in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,6 @@ COPY --from=firefly-builder /firefly/frontend/ /firefly/frontend/
 COPY --from=firefly-builder /firefly/db ./db
 COPY --from=solidity-builder /firefly/solidity_firefly/build/contracts ./contracts
 COPY --from=fabric-builder /firefly/smart_contracts/fabric/firefly-go/firefly_fabric.tar.gz ./contracts/firefly_fabric.tar.gz
-RUN ln -s /firefly/firefly /usr/bin/firefly
+RUN ln -s /firefly/firefly /usr/bin/firefly \
+    && apk add --update --no-cache postgresql-client curl jq
 ENTRYPOINT [ "firefly" ]


### PR DESCRIPTION
This would allow us remove the bits in the [helm chart](https://github.com/hyperledger/firefly-helm-charts/blob/main/charts/firefly/scripts/ff-register-contracts.sh#L21) that download `apk` packages at runtime. This is a best practice for Docker images and would allow enterprises using the chart / images to use them within their networks where they do not allow for public internet access.

Obviously the chart could simply use different images (however for migrations we take advantage of the fact that the migration are bundled into the firefly image), however I wanted to get the community's feedback on taking the hit in the image size being slightly larger for the sake of operational simplicity.