### PR TITLE
Add Transaction ID to Events

### DIFF
--- a/db/migrations/postgres/000054_create_blockchainevents_table.up.sql
+++ b/db/migrations/postgres/000054_create_blockchainevents_table.up.sql
@@ -8,8 +8,8 @@ CREATE TABLE blockchainevents (
   protocol_id      VARCHAR(256)    NOT NULL,
   timestamp        BIGINT          NOT NULL,
   subscription_id  UUID,
-  output           BYTEA,
-  info             BYTEA,
+  output           TEXT,
+  info             TEXT,
   tx_type          VARCHAR(64),
   tx_id            UUID
 );

--- a/db/migrations/postgres/000056_refactor_transactions_columns.down.sql
+++ b/db/migrations/postgres/000056_refactor_transactions_columns.down.sql
@@ -3,7 +3,7 @@ ALTER TABLE transactions ADD COLUMN ref         UUID;
 ALTER TABLE transactions ADD COLUMN signer      VARCHAR(1024);
 ALTER TABLE transactions ADD COLUMN hash        CHAR(64);
 ALTER TABLE transactions ADD COLUMN protocol_id VARCHAR(256);
-ALTER TABLE transactions ADD COLUMN info        BYTEA;
+ALTER TABLE transactions ADD COLUMN info        TEXT;
 ALTER TABLE transactions ADD COLUMN status      VARCHAR(64);
 
 CREATE INDEX transactions_protocol_id ON transactions(protocol_id);

--- a/db/migrations/postgres/000061_add_event_tx.down.sql
+++ b/db/migrations/postgres/000061_add_event_tx.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE events DROP COLUMN tx_id;
+COMMIT;

--- a/db/migrations/postgres/000061_add_event_tx.up.sql
+++ b/db/migrations/postgres/000061_add_event_tx.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE events ADD COLUMN tx_id UUID;
+COMMIT;

--- a/db/migrations/sqlite/000056_refactor_transactions_columns.down.sql
+++ b/db/migrations/sqlite/000056_refactor_transactions_columns.down.sql
@@ -2,7 +2,7 @@ ALTER TABLE transactions ADD COLUMN ref         UUID;
 ALTER TABLE transactions ADD COLUMN signer      VARCHAR(1024);
 ALTER TABLE transactions ADD COLUMN hash        CHAR(64);
 ALTER TABLE transactions ADD COLUMN protocol_id VARCHAR(256);
-ALTER TABLE transactions ADD COLUMN info        BYTEA;
+ALTER TABLE transactions ADD COLUMN info        TEXT;
 ALTER TABLE transactions ADD COLUMN status      VARCHAR(64);
 
 CREATE INDEX transactions_protocol_id ON transactions(protocol_id);

--- a/db/migrations/sqlite/000061_add_event_tx.down.sql
+++ b/db/migrations/sqlite/000061_add_event_tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN tx_id;

--- a/db/migrations/sqlite/000061_add_event_tx.up.sql
+++ b/db/migrations/sqlite/000061_add_event_tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN tx_id UUID;

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3786,11 +3786,6 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
-        name: group
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
         name: id
         schema:
           type: string
@@ -3807,6 +3802,11 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: sequence
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: tx
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -3862,6 +3862,7 @@ paths:
                   sequence:
                     format: int64
                     type: integer
+                  tx: {}
                   type:
                     enum:
                     - transaction_submitted
@@ -3920,6 +3921,7 @@ paths:
                   sequence:
                     format: int64
                     type: integer
+                  tx: {}
                   type:
                     enum:
                     - transaction_submitted
@@ -4509,11 +4511,6 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
-        name: group
-        schema:
-          type: string
-      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
-        in: query
         name: id
         schema:
           type: string
@@ -4530,6 +4527,11 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: sequence
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: tx
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -4585,6 +4587,7 @@ paths:
                   sequence:
                     format: int64
                     type: integer
+                  tx: {}
                   type:
                     enum:
                     - transaction_submitted

--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -516,7 +516,7 @@ func (bp *batchProcessor) markMessagesDispatched(batch *fftypes.Batch) error {
 			if bp.conf.txType == fftypes.TransactionTypeUnpinned {
 				for _, msg := range batch.Payload.Messages {
 					// Emit a confirmation event locally immediately
-					event := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, batch.Namespace, msg.Header.ID)
+					event := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, batch.Namespace, msg.Header.ID, batch.Payload.TX.ID)
 					if err := bp.database.InsertEvent(ctx, event); err != nil {
 						return err
 					}

--- a/internal/database/sqlcommon/event_sql.go
+++ b/internal/database/sqlcommon/event_sql.go
@@ -33,12 +33,13 @@ var (
 		"etype",
 		"namespace",
 		"ref",
+		"tx_id",
 		"created",
 	}
 	eventFilterFieldMap = map[string]string{
 		"type":      "etype",
 		"reference": "ref",
-		"group":     "group_hash",
+		"tx":        "tx_id",
 	}
 )
 
@@ -82,6 +83,7 @@ func (s *SQLCommon) insertEventPreCommit(ctx context.Context, tx *txWrapper, eve
 				string(event.Type),
 				event.Namespace,
 				event.Reference,
+				event.Transaction,
 				event.Created,
 			),
 		func() {
@@ -98,6 +100,7 @@ func (s *SQLCommon) eventResult(ctx context.Context, row *sql.Rows) (*fftypes.Ev
 		&event.Type,
 		&event.Namespace,
 		&event.Reference,
+		&event.Transaction,
 		&event.Created,
 		// Must be added to the list of columns in all selects
 		&event.Sequence,

--- a/internal/definitions/definition_handler.go
+++ b/internal/definitions/definition_handler.go
@@ -35,7 +35,7 @@ import (
 type DefinitionHandlers interface {
 	privatemessaging.GroupManager
 
-	HandleDefinitionBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (DefinitionMessageAction, *DefinitionBatchActions, error)
+	HandleDefinitionBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (DefinitionMessageAction, *DefinitionBatchActions, error)
 	SendReply(ctx context.Context, event *fftypes.Event, reply *fftypes.MessageInOut)
 }
 
@@ -104,14 +104,14 @@ func (dh *definitionHandlers) EnsureLocalGroup(ctx context.Context, group *fftyp
 	return dh.messaging.EnsureLocalGroup(ctx, group)
 }
 
-func (dh *definitionHandlers) HandleDefinitionBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (msgAction DefinitionMessageAction, batchActions *DefinitionBatchActions, err error) {
+func (dh *definitionHandlers) HandleDefinitionBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (msgAction DefinitionMessageAction, batchActions *DefinitionBatchActions, err error) {
 	l := log.L(ctx)
 	l.Infof("Confirming system definition broadcast '%s' [%s]", msg.Header.Tag, msg.Header.ID)
 	switch fftypes.SystemTag(msg.Header.Tag) {
 	case fftypes.SystemTagDefineDatatype:
-		return dh.handleDatatypeBroadcast(ctx, msg, data)
+		return dh.handleDatatypeBroadcast(ctx, msg, data, tx)
 	case fftypes.SystemTagDefineNamespace:
-		return dh.handleNamespaceBroadcast(ctx, msg, data)
+		return dh.handleNamespaceBroadcast(ctx, msg, data, tx)
 	case fftypes.SystemTagDefineOrganization:
 		return dh.handleOrganizationBroadcast(ctx, msg, data)
 	case fftypes.SystemTagDefineNode:
@@ -119,9 +119,9 @@ func (dh *definitionHandlers) HandleDefinitionBroadcast(ctx context.Context, msg
 	case fftypes.SystemTagDefinePool:
 		return dh.handleTokenPoolBroadcast(ctx, msg, data)
 	case fftypes.SystemTagDefineFFI:
-		return dh.handleFFIBroadcast(ctx, msg, data)
+		return dh.handleFFIBroadcast(ctx, msg, data, tx)
 	case fftypes.SystemTagDefineContractAPI:
-		return dh.handleContractAPIBroadcast(ctx, msg, data)
+		return dh.handleContractAPIBroadcast(ctx, msg, data, tx)
 	default:
 		l.Warnf("Unknown SystemTag '%s' for definition ID '%s'", msg.Header.Tag, msg.Header.ID)
 		return ActionReject, nil, nil

--- a/internal/definitions/definition_handler_contracts.go
+++ b/internal/definitions/definition_handler_contracts.go
@@ -65,7 +65,7 @@ func (dh *definitionHandlers) persistContractAPI(ctx context.Context, api *fftyp
 	return err == nil, err
 }
 
-func (dh *definitionHandlers) handleFFIBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (DefinitionMessageAction, *DefinitionBatchActions, error) {
+func (dh *definitionHandlers) handleFFIBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (DefinitionMessageAction, *DefinitionBatchActions, error) {
 	l := log.L(ctx)
 	var broadcast fftypes.FFI
 	valid := dh.getSystemBroadcastPayload(ctx, msg, data, &broadcast)
@@ -91,13 +91,13 @@ func (dh *definitionHandlers) handleFFIBroadcast(ctx context.Context, msg *fftyp
 	l.Infof("Contract interface created id=%s author=%s", broadcast.ID, msg.Header.Author)
 	return ActionConfirm, &DefinitionBatchActions{
 		Finalize: func(ctx context.Context) error {
-			event := fftypes.NewEvent(fftypes.EventTypeContractInterfaceConfirmed, broadcast.Namespace, broadcast.ID)
+			event := fftypes.NewEvent(fftypes.EventTypeContractInterfaceConfirmed, broadcast.Namespace, broadcast.ID, tx)
 			return dh.database.InsertEvent(ctx, event)
 		},
 	}, nil
 }
 
-func (dh *definitionHandlers) handleContractAPIBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (DefinitionMessageAction, *DefinitionBatchActions, error) {
+func (dh *definitionHandlers) handleContractAPIBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (DefinitionMessageAction, *DefinitionBatchActions, error) {
 	l := log.L(ctx)
 	var broadcast fftypes.ContractAPI
 	valid := dh.getSystemBroadcastPayload(ctx, msg, data, &broadcast)
@@ -123,7 +123,7 @@ func (dh *definitionHandlers) handleContractAPIBroadcast(ctx context.Context, ms
 	l.Infof("Contract API created id=%s author=%s", broadcast.ID, msg.Header.Author)
 	return ActionConfirm, &DefinitionBatchActions{
 		Finalize: func(ctx context.Context) error {
-			event := fftypes.NewEvent(fftypes.EventTypeContractAPIConfirmed, broadcast.Namespace, broadcast.ID)
+			event := fftypes.NewEvent(fftypes.EventTypeContractAPIConfirmed, broadcast.Namespace, broadcast.ID, tx)
 			return dh.database.InsertEvent(ctx, event)
 		},
 	}, nil

--- a/internal/definitions/definition_handler_contracts_test.go
+++ b/internal/definitions/definition_handler_contracts_test.go
@@ -106,7 +106,7 @@ func TestHandleFFIBroadcastOk(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineFFI),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -134,7 +134,7 @@ func TestHandleFFIBroadcastReject(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineFFI),
 		},
-	}, []*fftypes.Data{})
+	}, []*fftypes.Data{}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -193,7 +193,7 @@ func TestHandleFFIBroadcastValidateFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineFFI),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -215,7 +215,7 @@ func TestHandleFFIBroadcastPersistFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineFFI),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.Regexp(t, "pop", err)
 }
@@ -237,7 +237,7 @@ func TestHandleContractAPIBroadcastOk(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineContractAPI),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -291,7 +291,7 @@ func TestHandleContractAPIBroadcastValidateFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineContractAPI),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -312,7 +312,7 @@ func TestHandleContractAPIBroadcastPersistFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineContractAPI),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.Regexp(t, "pop", err)
 }

--- a/internal/definitions/definition_handler_datatype.go
+++ b/internal/definitions/definition_handler_datatype.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
-func (dh *definitionHandlers) handleDatatypeBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (DefinitionMessageAction, *DefinitionBatchActions, error) {
+func (dh *definitionHandlers) handleDatatypeBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (DefinitionMessageAction, *DefinitionBatchActions, error) {
 	l := log.L(ctx)
 
 	var dt fftypes.Datatype
@@ -57,7 +57,7 @@ func (dh *definitionHandlers) handleDatatypeBroadcast(ctx context.Context, msg *
 
 	return ActionConfirm, &DefinitionBatchActions{
 		Finalize: func(ctx context.Context) error {
-			event := fftypes.NewEvent(fftypes.EventTypeDatatypeConfirmed, dt.Namespace, dt.ID)
+			event := fftypes.NewEvent(fftypes.EventTypeDatatypeConfirmed, dt.Namespace, dt.ID, tx)
 			return dh.database.InsertEvent(ctx, event)
 		},
 	}, nil

--- a/internal/definitions/definition_handler_datatype_test.go
+++ b/internal/definitions/definition_handler_datatype_test.go
@@ -57,7 +57,7 @@ func TestHandleDefinitionBroadcastDatatypeOk(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -95,7 +95,7 @@ func TestHandleDefinitionBroadcastDatatypeEventFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -126,7 +126,7 @@ func TestHandleDefinitionBroadcastDatatypeMissingID(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -155,7 +155,7 @@ func TestHandleDefinitionBroadcastBadSchema(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestHandleDefinitionBroadcastMissingData(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{})
+	}, []*fftypes.Data{}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -211,7 +211,7 @@ func TestHandleDefinitionBroadcastDatatypeLookupFail(t *testing.T) {
 			Namespace: fftypes.SystemNamespace,
 			Tag:       string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -246,7 +246,7 @@ func TestHandleDefinitionBroadcastUpsertFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -280,7 +280,7 @@ func TestHandleDefinitionBroadcastDatatypeDuplicate(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineDatatype),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 

--- a/internal/definitions/definition_handler_namespace.go
+++ b/internal/definitions/definition_handler_namespace.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
-func (dh *definitionHandlers) handleNamespaceBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (DefinitionMessageAction, *DefinitionBatchActions, error) {
+func (dh *definitionHandlers) handleNamespaceBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (DefinitionMessageAction, *DefinitionBatchActions, error) {
 	l := log.L(ctx)
 
 	var ns fftypes.Namespace
@@ -57,7 +57,7 @@ func (dh *definitionHandlers) handleNamespaceBroadcast(ctx context.Context, msg 
 
 	return ActionConfirm, &DefinitionBatchActions{
 		Finalize: func(ctx context.Context) error {
-			event := fftypes.NewEvent(fftypes.EventTypeNamespaceConfirmed, ns.Name, ns.ID)
+			event := fftypes.NewEvent(fftypes.EventTypeNamespaceConfirmed, ns.Name, ns.ID, tx)
 			return dh.database.InsertEvent(ctx, event)
 		},
 	}, nil

--- a/internal/definitions/definition_handler_namespace_test.go
+++ b/internal/definitions/definition_handler_namespace_test.go
@@ -49,7 +49,7 @@ func TestHandleDefinitionBroadcastNSOk(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -79,7 +79,7 @@ func TestHandleDefinitionBroadcastNSEventFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -108,7 +108,7 @@ func TestHandleDefinitionBroadcastNSUpsertFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -122,7 +122,7 @@ func TestHandleDefinitionBroadcastNSMissingData(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{})
+	}, []*fftypes.Data{}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -141,7 +141,7 @@ func TestHandleDefinitionBroadcastNSBadID(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -157,7 +157,7 @@ func TestHandleDefinitionBroadcastNSBadData(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -181,7 +181,7 @@ func TestHandleDefinitionBroadcastDuplicate(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestHandleDefinitionBroadcastDuplicateOverrideLocal(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.Finalize(context.Background())
@@ -241,7 +241,7 @@ func TestHandleDefinitionBroadcastDuplicateOverrideLocalFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -267,7 +267,7 @@ func TestHandleDefinitionBroadcastDupCheckFail(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: string(fftypes.SystemTagDefineNamespace),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 

--- a/internal/definitions/definition_handler_network_node_test.go
+++ b/internal/definitions/definition_handler_network_node_test.go
@@ -64,7 +64,7 @@ func TestHandleDefinitionBroadcastNodeOk(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 
@@ -107,7 +107,7 @@ func TestHandleDefinitionBroadcastNodeUpsertFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -149,7 +149,7 @@ func TestHandleDefinitionBroadcastNodeAddPeerFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 	err = ba.PreFinalize(context.Background())
@@ -189,7 +189,7 @@ func TestHandleDefinitionBroadcastNodeDupMismatch(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -230,7 +230,7 @@ func TestHandleDefinitionBroadcastNodeDupOK(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 
@@ -268,7 +268,7 @@ func TestHandleDefinitionBroadcastNodeGetFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -305,7 +305,7 @@ func TestHandleDefinitionBroadcastNodeBadAuthor(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestHandleDefinitionBroadcastNodeGetOrgNotFound(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -379,7 +379,7 @@ func TestHandleDefinitionBroadcastNodeGetOrgFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -414,7 +414,7 @@ func TestHandleDefinitionBroadcastNodeValidateFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -435,7 +435,7 @@ func TestHandleDefinitionBroadcastNodeUnmarshalFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineNode),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }

--- a/internal/definitions/definition_handler_network_org_test.go
+++ b/internal/definitions/definition_handler_network_org_test.go
@@ -67,7 +67,7 @@ func TestHandleDefinitionBroadcastChildOrgOk(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 
@@ -111,7 +111,7 @@ func TestHandleDefinitionBroadcastChildOrgDupOk(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestHandleDefinitionBroadcastChildOrgBadKey(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -188,7 +188,7 @@ func TestHandleDefinitionBroadcastOrgDupMismatch(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -224,7 +224,7 @@ func TestHandleDefinitionBroadcastOrgUpsertFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -257,7 +257,7 @@ func TestHandleDefinitionBroadcastOrgGetOrgFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -291,7 +291,7 @@ func TestHandleDefinitionBroadcastOrgAuthorMismatch(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -326,7 +326,7 @@ func TestHandleDefinitionBroadcastGetParentFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -361,7 +361,7 @@ func TestHandleDefinitionBroadcastGetParentNotFound(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -392,7 +392,7 @@ func TestHandleDefinitionBroadcastValidateFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -413,7 +413,7 @@ func TestHandleDefinitionBroadcastUnmarshalFail(t *testing.T) {
 			},
 			Tag: string(fftypes.SystemTagDefineOrganization),
 		},
-	}, []*fftypes.Data{data})
+	}, []*fftypes.Data{data}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }

--- a/internal/definitions/definition_handler_test.go
+++ b/internal/definitions/definition_handler_test.go
@@ -49,7 +49,7 @@ func TestHandleDefinitionBroadcastUnknown(t *testing.T) {
 		Header: fftypes.MessageHeader{
 			Tag: "unknown",
 		},
-	}, []*fftypes.Data{})
+	}, []*fftypes.Data{}, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }

--- a/internal/definitions/definition_handler_tokenpool_test.go
+++ b/internal/definitions/definition_handler_tokenpool_test.go
@@ -82,7 +82,7 @@ func TestHandleDefinitionBroadcastTokenPoolActivateOK(t *testing.T) {
 	})).Return(nil)
 	mam.On("ActivateTokenPool", context.Background(), mock.AnythingOfType("*fftypes.TokenPool"), mock.AnythingOfType("*fftypes.BlockchainEvent")).Return(nil)
 
-	action, ba, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, ba, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionWait, action)
 	assert.NoError(t, err)
 
@@ -103,7 +103,7 @@ func TestHandleDefinitionBroadcastTokenPoolGetPoolFail(t *testing.T) {
 	mdi := sh.database.(*databasemocks.Plugin)
 	mdi.On("GetTokenPoolByID", context.Background(), pool.ID).Return(nil, fmt.Errorf("pop"))
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -126,7 +126,7 @@ func TestHandleDefinitionBroadcastTokenPoolExisting(t *testing.T) {
 	})).Return(nil)
 	mam.On("ActivateTokenPool", context.Background(), mock.AnythingOfType("*fftypes.TokenPool"), mock.AnythingOfType("*fftypes.BlockchainEvent")).Return(nil)
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionWait, action)
 	assert.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingConfirmed(t *testing.T) {
 	mdi := sh.database.(*databasemocks.Plugin)
 	mdi.On("GetTokenPoolByID", context.Background(), pool.ID).Return(existing, nil)
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionConfirm, action)
 	assert.NoError(t, err)
 
@@ -168,7 +168,7 @@ func TestHandleDefinitionBroadcastTokenPoolIDMismatch(t *testing.T) {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(database.IDMismatch)
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 
@@ -189,7 +189,7 @@ func TestHandleDefinitionBroadcastTokenPoolFailUpsert(t *testing.T) {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(fmt.Errorf("pop"))
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionRetry, action)
 	assert.EqualError(t, err, "pop")
 
@@ -212,7 +212,7 @@ func TestHandleDefinitionBroadcastTokenPoolActivateFail(t *testing.T) {
 	})).Return(nil)
 	mam.On("ActivateTokenPool", context.Background(), mock.AnythingOfType("*fftypes.TokenPool"), mock.AnythingOfType("*fftypes.BlockchainEvent")).Return(fmt.Errorf("pop"))
 
-	action, batchAction, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, batchAction, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionWait, action)
 	assert.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestHandleDefinitionBroadcastTokenPoolValidateFail(t *testing.T) {
 	msg, data, err := buildPoolDefinitionMessage(announce)
 	assert.NoError(t, err)
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, data, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }
@@ -247,7 +247,7 @@ func TestHandleDefinitionBroadcastTokenPoolBadMessage(t *testing.T) {
 		},
 	}
 
-	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, nil)
+	action, _, err := sh.HandleDefinitionBroadcast(context.Background(), msg, nil, fftypes.NewUUID())
 	assert.Equal(t, ActionReject, action)
 	assert.NoError(t, err)
 }

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -875,7 +875,7 @@ func TestAttemptMessageDispatchFailGetData(t *testing.T) {
 
 	_, err := ag.attemptMessageDispatch(ag.ctx, &fftypes.Message{
 		Header: fftypes.MessageHeader{ID: fftypes.NewUUID()},
-	}, nil)
+	}, nil, nil)
 	assert.EqualError(t, err, "pop")
 
 }
@@ -893,7 +893,7 @@ func TestAttemptMessageDispatchFailValidateData(t *testing.T) {
 		Data: fftypes.DataRefs{
 			{ID: fftypes.NewUUID()},
 		},
-	}, nil)
+	}, nil, nil)
 	assert.EqualError(t, err, "pop")
 
 }
@@ -919,7 +919,7 @@ func TestAttemptMessageDispatchMissingBlobs(t *testing.T) {
 
 	dispatched, err := ag.attemptMessageDispatch(ag.ctx, &fftypes.Message{
 		Header: fftypes.MessageHeader{ID: fftypes.NewUUID()},
-	}, nil)
+	}, nil, nil)
 	assert.NoError(t, err)
 	assert.False(t, dispatched)
 
@@ -942,7 +942,7 @@ func TestAttemptMessageDispatchMissingTransfers(t *testing.T) {
 		},
 	}
 	msg.Hash = msg.Header.Hash()
-	dispatched, err := ag.attemptMessageDispatch(ag.ctx, msg, nil)
+	dispatched, err := ag.attemptMessageDispatch(ag.ctx, msg, nil, nil)
 	assert.NoError(t, err)
 	assert.False(t, dispatched)
 
@@ -967,7 +967,7 @@ func TestAttemptMessageDispatchGetTransfersFail(t *testing.T) {
 		},
 	}
 	msg.Hash = msg.Header.Hash()
-	dispatched, err := ag.attemptMessageDispatch(ag.ctx, msg, nil)
+	dispatched, err := ag.attemptMessageDispatch(ag.ctx, msg, nil, nil)
 	assert.EqualError(t, err, "pop")
 	assert.False(t, dispatched)
 
@@ -998,7 +998,7 @@ func TestAttemptMessageDispatchTransferMismatch(t *testing.T) {
 	mdi := ag.database.(*databasemocks.Plugin)
 	mdi.On("GetTokenTransfers", ag.ctx, mock.Anything).Return(transfers, nil, nil)
 
-	dispatched, err := ag.attemptMessageDispatch(ag.ctx, msg, nil)
+	dispatched, err := ag.attemptMessageDispatch(ag.ctx, msg, nil, nil)
 	assert.NoError(t, err)
 	assert.False(t, dispatched)
 
@@ -1012,7 +1012,7 @@ func TestDefinitionBroadcastActionReject(t *testing.T) {
 	bs := newBatchState(ag)
 
 	msh := ag.definitions.(*definitionsmocks.DefinitionHandlers)
-	msh.On("HandleDefinitionBroadcast", mock.Anything, mock.Anything, mock.Anything).Return(definitions.ActionReject, &definitions.DefinitionBatchActions{}, nil)
+	msh.On("HandleDefinitionBroadcast", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(definitions.ActionReject, &definitions.DefinitionBatchActions{}, nil)
 
 	mdm := ag.data.(*datamocks.Manager)
 	mdm.On("GetMessageData", ag.ctx, mock.Anything, true).Return([]*fftypes.Data{}, true, nil)
@@ -1046,7 +1046,7 @@ func TestDefinitionBroadcastActionReject(t *testing.T) {
 		Data: fftypes.DataRefs{
 			{ID: fftypes.NewUUID()},
 		},
-	}, bs)
+	}, nil, bs)
 	assert.NoError(t, err)
 
 }
@@ -1236,7 +1236,7 @@ func TestDefinitionBroadcastActionRetry(t *testing.T) {
 	defer cancel()
 
 	msh := ag.definitions.(*definitionsmocks.DefinitionHandlers)
-	msh.On("HandleDefinitionBroadcast", mock.Anything, mock.Anything, mock.Anything).Return(definitions.ActionRetry, &definitions.DefinitionBatchActions{}, fmt.Errorf("pop"))
+	msh.On("HandleDefinitionBroadcast", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(definitions.ActionRetry, &definitions.DefinitionBatchActions{}, fmt.Errorf("pop"))
 
 	mdm := ag.data.(*datamocks.Manager)
 	mdm.On("GetMessageData", ag.ctx, mock.Anything, true).Return([]*fftypes.Data{}, true, nil)
@@ -1250,7 +1250,7 @@ func TestDefinitionBroadcastActionRetry(t *testing.T) {
 		Data: fftypes.DataRefs{
 			{ID: fftypes.NewUUID()},
 		},
-	}, nil)
+	}, nil, nil)
 	assert.EqualError(t, err, "pop")
 
 }
@@ -1260,7 +1260,7 @@ func TestDefinitionBroadcastActionWait(t *testing.T) {
 	defer cancel()
 
 	msh := ag.definitions.(*definitionsmocks.DefinitionHandlers)
-	msh.On("HandleDefinitionBroadcast", mock.Anything, mock.Anything, mock.Anything).Return(definitions.ActionWait, &definitions.DefinitionBatchActions{}, nil)
+	msh.On("HandleDefinitionBroadcast", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(definitions.ActionWait, &definitions.DefinitionBatchActions{}, nil)
 
 	mdm := ag.data.(*datamocks.Manager)
 	mdm.On("GetMessageData", ag.ctx, mock.Anything, true).Return([]*fftypes.Data{}, true, nil)
@@ -1274,7 +1274,7 @@ func TestDefinitionBroadcastActionWait(t *testing.T) {
 		Data: fftypes.DataRefs{
 			{ID: fftypes.NewUUID()},
 		},
-	}, nil)
+	}, nil, nil)
 	assert.NoError(t, err)
 
 }
@@ -1293,7 +1293,7 @@ func TestAttemptMessageDispatchEventFail(t *testing.T) {
 
 	_, err := ag.attemptMessageDispatch(ag.ctx, &fftypes.Message{
 		Header: fftypes.MessageHeader{ID: fftypes.NewUUID()},
-	}, bs)
+	}, nil, bs)
 	assert.NoError(t, err)
 
 	err = bs.RunFinalize(ag.ctx)
@@ -1318,7 +1318,7 @@ func TestAttemptMessageDispatchGroupInit(t *testing.T) {
 			ID:   fftypes.NewUUID(),
 			Type: fftypes.MessageTypeGroupInit,
 		},
-	}, bs)
+	}, nil, bs)
 	assert.NoError(t, err)
 
 }
@@ -1336,7 +1336,7 @@ func TestAttemptMessageUpdateMessageFail(t *testing.T) {
 
 	_, err := ag.attemptMessageDispatch(ag.ctx, &fftypes.Message{
 		Header: fftypes.MessageHeader{ID: fftypes.NewUUID()},
-	}, bs)
+	}, nil, bs)
 	assert.NoError(t, err)
 
 	err = bs.RunFinalize(ag.ctx)

--- a/internal/events/blockchain_event.go
+++ b/internal/events/blockchain_event.go
@@ -46,7 +46,7 @@ func (em *eventManager) persistBlockchainEvent(ctx context.Context, chainEvent *
 	if err := em.database.InsertBlockchainEvent(ctx, chainEvent); err != nil {
 		return err
 	}
-	ffEvent := fftypes.NewEvent(fftypes.EventTypeBlockchainEvent, chainEvent.Namespace, chainEvent.ID)
+	ffEvent := fftypes.NewEvent(fftypes.EventTypeBlockchainEvent, chainEvent.Namespace, chainEvent.ID, chainEvent.TX.ID)
 	if err := em.database.InsertEvent(ctx, ffEvent); err != nil {
 		return err
 	}

--- a/internal/events/dx_callbacks.go
+++ b/internal/events/dx_callbacks.go
@@ -178,7 +178,7 @@ func (em *eventManager) markUnpinnedMessagesConfirmed(ctx context.Context, batch
 	}
 
 	for _, msg := range batch.Payload.Messages {
-		event := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, batch.Namespace, msg.Header.ID)
+		event := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, batch.Namespace, msg.Header.ID, batch.Payload.TX.ID)
 		if err := em.database.InsertEvent(ctx, event); err != nil {
 			return err
 		}

--- a/internal/events/event_poller_test.go
+++ b/internal/events/event_poller_test.go
@@ -207,7 +207,7 @@ func TestReadPageSingleCommitEvent(t *testing.T) {
 		return false, nil
 	}, nil)
 	cancel()
-	ev1 := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID())
+	ev1 := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID(), nil)
 	mdi.On("GetEvents", mock.Anything, mock.Anything).Return([]*fftypes.Event{ev1}, nil, nil).Once()
 	mdi.On("GetEvents", mock.Anything, mock.Anything).Return([]*fftypes.Event{}, nil, nil)
 	ep.eventLoop()
@@ -227,7 +227,7 @@ func TestReadPageRewind(t *testing.T) {
 		return true, 12345
 	})
 	cancel()
-	ev1 := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID())
+	ev1 := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID(), nil)
 	mdi.On("GetEvents", mock.Anything, mock.MatchedBy(func(filter database.Filter) bool {
 		f, err := filter.Finalize()
 		assert.NoError(t, err)
@@ -248,7 +248,7 @@ func TestReadPageProcessEventsRetryExit(t *testing.T) {
 	mdi := &databasemocks.Plugin{}
 	ep, cancel := newTestEventPoller(t, mdi, func(events []fftypes.LocallySequenced) (bool, error) { return false, fmt.Errorf("pop") }, nil)
 	cancel()
-	ev1 := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID())
+	ev1 := fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID(), nil)
 	mdi.On("GetEvents", mock.Anything, mock.Anything).Return([]*fftypes.Event{ev1}, nil, nil).Once()
 	ep.eventLoop()
 
@@ -262,7 +262,7 @@ func TestProcessEventsFail(t *testing.T) {
 	}, nil)
 	defer cancel()
 	_, err := ep.conf.newEventsHandler([]fftypes.LocallySequenced{
-		fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID()),
+		fftypes.NewEvent(fftypes.EventTypeMessageConfirmed, "ns1", fftypes.NewUUID(), nil),
 	})
 	assert.EqualError(t, err, "pop")
 	mdi.AssertExpectations(t)

--- a/internal/events/operation_update.go
+++ b/internal/events/operation_update.go
@@ -37,7 +37,7 @@ func (em *eventManager) operationUpdateCtx(ctx context.Context, operationID *fft
 
 	// Special handling for OpTypeTokenTransfer, which writes an event when it fails
 	if op.Type == fftypes.OpTypeTokenTransfer && txState == fftypes.OpStatusFailed {
-		event := fftypes.NewEvent(fftypes.EventTypeTransferOpFailed, op.Namespace, op.ID)
+		event := fftypes.NewEvent(fftypes.EventTypeTransferOpFailed, op.Namespace, op.ID, op.Transaction)
 		if em.metrics.IsMetricsEnabled() {
 			var tokenTransfer fftypes.TokenTransfer
 			err = txcommon.RetrieveTokenTransferInputs(ctx, op, &tokenTransfer)

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -60,7 +60,7 @@ func (em *eventManager) confirmPool(ctx context.Context, pool *fftypes.TokenPool
 		return err
 	}
 	log.L(ctx).Infof("Token pool confirmed, id=%s", pool.ID)
-	event := fftypes.NewEvent(fftypes.EventTypePoolConfirmed, pool.Namespace, pool.ID)
+	event := fftypes.NewEvent(fftypes.EventTypePoolConfirmed, pool.Namespace, pool.ID, pool.TX.ID)
 	return em.database.InsertEvent(ctx, event)
 }
 

--- a/internal/events/tokens_transferred.go
+++ b/internal/events/tokens_transferred.go
@@ -143,7 +143,7 @@ func (em *eventManager) TokensTransferred(ti tokens.Plugin, transfer *tokens.Tok
 				}
 			}
 
-			event := fftypes.NewEvent(fftypes.EventTypeTransferConfirmed, transfer.Namespace, transfer.LocalID)
+			event := fftypes.NewEvent(fftypes.EventTypeTransferConfirmed, transfer.Namespace, transfer.LocalID, transfer.TX.ID)
 			return em.database.InsertEvent(ctx, event)
 		})
 		return err != nil, err // retry indefinitely (until context closes)

--- a/internal/txcommon/txcommon.go
+++ b/internal/txcommon/txcommon.go
@@ -56,7 +56,7 @@ func (t *transactionHelper) SubmitNewTransaction(ctx context.Context, ns string,
 		return nil, err
 	}
 
-	if err := t.database.InsertEvent(ctx, fftypes.NewEvent(fftypes.EventTypeTransactionSubmitted, tx.Namespace, tx.ID)); err != nil {
+	if err := t.database.InsertEvent(ctx, fftypes.NewEvent(fftypes.EventTypeTransactionSubmitted, tx.Namespace, tx.ID, tx.ID)); err != nil {
 		return nil, err
 	}
 

--- a/mocks/definitionsmocks/definition_handlers.go
+++ b/mocks/definitionsmocks/definition_handlers.go
@@ -94,20 +94,20 @@ func (_m *DefinitionHandlers) GetGroupsNS(ctx context.Context, ns string, filter
 	return r0, r1, r2
 }
 
-// HandleDefinitionBroadcast provides a mock function with given fields: ctx, msg, data
-func (_m *DefinitionHandlers) HandleDefinitionBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (definitions.DefinitionMessageAction, *definitions.DefinitionBatchActions, error) {
-	ret := _m.Called(ctx, msg, data)
+// HandleDefinitionBroadcast provides a mock function with given fields: ctx, msg, data, tx
+func (_m *DefinitionHandlers) HandleDefinitionBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data, tx *fftypes.UUID) (definitions.DefinitionMessageAction, *definitions.DefinitionBatchActions, error) {
+	ret := _m.Called(ctx, msg, data, tx)
 
 	var r0 definitions.DefinitionMessageAction
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message, []*fftypes.Data) definitions.DefinitionMessageAction); ok {
-		r0 = rf(ctx, msg, data)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message, []*fftypes.Data, *fftypes.UUID) definitions.DefinitionMessageAction); ok {
+		r0 = rf(ctx, msg, data, tx)
 	} else {
 		r0 = ret.Get(0).(definitions.DefinitionMessageAction)
 	}
 
 	var r1 *definitions.DefinitionBatchActions
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Message, []*fftypes.Data) *definitions.DefinitionBatchActions); ok {
-		r1 = rf(ctx, msg, data)
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Message, []*fftypes.Data, *fftypes.UUID) *definitions.DefinitionBatchActions); ok {
+		r1 = rf(ctx, msg, data, tx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*definitions.DefinitionBatchActions)
@@ -115,8 +115,8 @@ func (_m *DefinitionHandlers) HandleDefinitionBroadcast(ctx context.Context, msg
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, *fftypes.Message, []*fftypes.Data) error); ok {
-		r2 = rf(ctx, msg, data)
+	if rf, ok := ret.Get(2).(func(context.Context, *fftypes.Message, []*fftypes.Data, *fftypes.UUID) error); ok {
+		r2 = rf(ctx, msg, data, tx)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -770,7 +770,7 @@ var EventQueryFactory = &queryFields{
 	"type":      &StringField{},
 	"namespace": &StringField{},
 	"reference": &UUIDField{},
-	"group":     &Bytes32Field{},
+	"tx":        &UUIDField{},
 	"sequence":  &Int64Field{},
 	"created":   &TimeField{},
 }

--- a/pkg/fftypes/event.go
+++ b/pkg/fftypes/event.go
@@ -49,12 +49,13 @@ var (
 
 // Event is an activity in the system, delivered reliably to applications, that indicates something has happened in the network
 type Event struct {
-	ID        *UUID     `json:"id"`
-	Sequence  int64     `json:"sequence"`
-	Type      EventType `json:"type" ffenum:"eventtype"`
-	Namespace string    `json:"namespace"`
-	Reference *UUID     `json:"reference"`
-	Created   *FFTime   `json:"created"`
+	ID          *UUID     `json:"id"`
+	Sequence    int64     `json:"sequence"`
+	Type        EventType `json:"type" ffenum:"eventtype"`
+	Namespace   string    `json:"namespace"`
+	Reference   *UUID     `json:"reference"`
+	Transaction *UUID     `json:"tx,omitempty"`
+	Created     *FFTime   `json:"created"`
 }
 
 // EventDelivery adds the referred object to an event, as well as details of the subscription that caused the event to
@@ -75,13 +76,14 @@ type EventDeliveryResponse struct {
 	Reply        *MessageInOut   `json:"reply,omitempty"`
 }
 
-func NewEvent(t EventType, ns string, ref *UUID) *Event {
+func NewEvent(t EventType, ns string, ref *UUID, tx *UUID) *Event {
 	return &Event{
-		ID:        NewUUID(),
-		Type:      t,
-		Namespace: ns,
-		Reference: ref,
-		Created:   Now(),
+		ID:          NewUUID(),
+		Type:        t,
+		Namespace:   ns,
+		Reference:   ref,
+		Transaction: tx,
+		Created:     Now(),
 	}
 }
 

--- a/pkg/fftypes/event_test.go
+++ b/pkg/fftypes/event_test.go
@@ -24,11 +24,13 @@ import (
 
 func TestNewEvent(t *testing.T) {
 
-	u := NewUUID()
-	e := NewEvent(EventTypeMessageConfirmed, "ns1", u)
+	ref := NewUUID()
+	tx := NewUUID()
+	e := NewEvent(EventTypeMessageConfirmed, "ns1", ref, tx)
 	assert.Equal(t, EventTypeMessageConfirmed, e.Type)
 	assert.Equal(t, "ns1", e.Namespace)
-	assert.Equal(t, *u, *e.Reference)
+	assert.Equal(t, *ref, *e.Reference)
+	assert.Equal(t, *tx, *e.Transaction)
 
 	e.Sequence = 12345
 	var ls LocallySequenced = e


### PR DESCRIPTION
Nearly every event is issued from the context of a transaction, so it makes sense
to record this relationship.

Allow it to be null since a few events (ie the ones bound to BlockchainEvents)
will not be tied to a transaction.