### PR TITLE
go-migrate in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,8 @@ COPY --from=firefly-builder /firefly/db ./db
 COPY --from=solidity-builder /firefly/solidity_firefly/build/contracts ./contracts
 COPY --from=fabric-builder /firefly/smart_contracts/fabric/firefly-go/firefly_fabric.tar.gz ./contracts/firefly_fabric.tar.gz
 RUN ln -s /firefly/firefly /usr/bin/firefly \
-    && apk add --update --no-cache postgresql-client curl jq
+    && apk add --update --no-cache postgresql-client curl jq \
+    && curl -sL "https://github.com/golang-migrate/migrate/releases/download/$(curl -sL https://api.github.com/repos/golang-migrate/migrate/releases/latest | jq -r '.name')/migrate.linux-amd64.tar.gz" | tar xz \
+    && chmod +x ./migrate \
+    && cp ./migrate /usr/bin/migrate
 ENTRYPOINT [ "firefly" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,5 @@ RUN ln -s /firefly/firefly /usr/bin/firefly \
     && apk add --update --no-cache postgresql-client curl jq \
     && curl -sL "https://github.com/golang-migrate/migrate/releases/download/$(curl -sL https://api.github.com/repos/golang-migrate/migrate/releases/latest | jq -r '.name')/migrate.linux-amd64.tar.gz" | tar xz \
     && chmod +x ./migrate \
-    && cp ./migrate /usr/bin/migrate
+    && mv ./migrate /usr/bin/migrate
 ENTRYPOINT [ "firefly" ]


### PR DESCRIPTION
Follow up to #521, realized the chart scripts also were downloading [`go-migrate`](https://github.com/hyperledger/firefly-helm-charts/blob/main/charts/firefly/scripts/ff-db-migrations.sh#L55-L57) as well so this adds that.

Definitely further re-enforces @peterbroadhurst's comment about a separate `utiltity` tag or image for firefly in the future.