### PR TITLE
Use bash for variable expansion prior to make

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -22,11 +22,11 @@ jobs:
 
       - name: Build
         run: |
-          make DOCKER_ARGS='\
+          make DOCKER_ARGS="\
             --label commit=$GITHUB_SHA \
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
-            --tag ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }}' \
+            --tag ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }}" \
             docker
 
       - name: Tag release

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -14,11 +14,11 @@ jobs:
 
       - name: Build
         run: |
-          make DOCKER_ARGS='\
+          make DOCKER_ARGS="\
             --label commit=$GITHUB_SHA \
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${GITHUB_REF##*/} \
-            --tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/}' \
+            --tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/}" \
             docker
 
       - name: Tag release


### PR DESCRIPTION
Fixes #527 

My theory (can't prove without actions running) is that the `'` single quotes is just passing the special `${GITHUB_REF##*/}` bash syntax into `make` - which doesn't understand all that fancyness, and is just treating it as an empty variable