### PR TITLE
Allow building in docker by removing .git from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,4 @@
 **/coverage
 **/.nyc_output
 smart_contracts/ethereum/solidity_firefly/build
-.git
 firefly


### PR DESCRIPTION
If you currently try and do `make` in Docker, including the unit tests, it fails because the `.git` history is not there so the linter doesn't know when the last change was to apply the copyright building correctly:

```
[0minternal/log/log.go:1:17: Expected:2022, Actual: 2021 Kaleido, Inc. (goheader)
// Copyright © 2021 Kaleido, Inc.
                ^
internal/i18n/errors.go:1:17: Expected:2022, Actual: 2021 Kaleido, Inc. (goheader)
// Copyright © 2021 Kaleido, Inc.
                ^
internal/i18n/messages.go:1:17: Expected:2022, Actual: 2021 Kaleido, Inc. (goheader)
// Copyright © 2021 Kaleido, Inc.
                ^
[91mlevel=info msg="File cache stats: 325 entries of total size 1.2MiB"
level=info msg="Memory: 826 samples, avg is 225.0MB, max is 276.1MB"
level=info msg="Execution took 1m22.599796017s"
[0m[91mmake: *** [Makefile:21: lint] Error 1
[0mThe command '/bin/sh -c make' returned a non-zero code: 2
```