### PR TITLE
Add query support for Fabric

### DIFF
--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -66,17 +66,13 @@ type eventStreamWebsocket struct {
 	Topic string `json:"topic"`
 }
 
-type fabBatchPinInput struct {
-	Namespace  string   `json:"namespace"`
-	UUIDs      string   `json:"uuids"`
-	BatchHash  string   `json:"batchHash"`
-	PayloadRef string   `json:"payloadRef"`
-	Contexts   []string `json:"contexts"`
-}
-
 type fabTxInputHeaders struct {
+	ID            string         `json:"id,omitempty"`
 	Type          string         `json:"type"`
 	PayloadSchema *PayloadSchema `json:"payloadSchema,omitempty"`
+	Signer        string         `json:"signer,omitempty"`
+	Channel       string         `json:"channel,omitempty"`
+	Chaincode     string         `json:"chaincode,omitempty"`
 }
 
 type PayloadSchema struct {
@@ -89,39 +85,19 @@ type PrefixItem struct {
 	Type string `json:"type"`
 }
 
-func newTxInputHeaders() *fabTxInputHeaders {
-	return &fabTxInputHeaders{
-		Type: "SendTransaction",
-	}
-}
-
-type fabTxInput struct {
-	Headers *fabTxInputHeaders `json:"headers"`
-	Func    string             `json:"func"`
-	Args    []string           `json:"args"`
-}
-
 type fabTxNamedInput struct {
 	Headers *fabTxInputHeaders `json:"headers"`
 	Func    string             `json:"func"`
 	Args    map[string]string  `json:"args"`
 }
 
-func newTxInput(pinInput *fabBatchPinInput) *fabTxInput {
-	hashesJSON, _ := json.Marshal(pinInput.Contexts)
-	stringifiedHashes := string(hashesJSON)
-	input := &fabTxInput{
-		Headers: newTxInputHeaders(),
-		Func:    "PinBatch",
-		Args: []string{
-			pinInput.Namespace,
-			pinInput.UUIDs,
-			pinInput.BatchHash,
-			pinInput.PayloadRef,
-			stringifiedHashes,
-		},
-	}
-	return input
+type fabQueryNamedOutput struct {
+	Headers *fabTxInputHeaders `json:"headers"`
+	Result  interface{}        `json:"result"`
+}
+
+type ffiParamSchema struct {
+	Type string `json:"type,omitempty"`
 }
 
 type fabWSCommandPayload struct {
@@ -141,8 +117,33 @@ type Location struct {
 }
 
 var batchPinEvent = "BatchPin"
+var batchPinMethodName = "PinBatch"
+var batchPinPrefixItems = []*PrefixItem{
+	{
+		Name: "namespace",
+		Type: "string",
+	},
+	{
+		Name: "uuids",
+		Type: "string",
+	},
+	{
+		Name: "batchHash",
+		Type: "string",
+	},
+	{
+		Name: "payloadRef",
+		Type: "string",
+	},
+	{
+		Name: "contexts",
+		Type: "string",
+	},
+}
+
 var fullIdentityPattern = regexp.MustCompile(".+::x509::(.+)::.+")
-var cnPatteren = regexp.MustCompile("CN=([^,]+)")
+
+var cnPattern = regexp.MustCompile("CN=([^,]+)")
 
 func (f *Fabric) Name() string {
 	return "fabric"
@@ -495,15 +496,25 @@ func (f *Fabric) ResolveSigningKey(ctx context.Context, signingKeyInput string) 
 	return signingKeyInput, nil
 }
 
-func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, signingKey string, requestID string, input interface{}) (*resty.Response, error) {
+func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, methodName, signingKey, requestID string, prefixItems []*PrefixItem, input map[string]string) (*resty.Response, error) {
+	in := &fabTxNamedInput{
+		Headers: &fabTxInputHeaders{
+			ID: requestID,
+			PayloadSchema: &PayloadSchema{
+				Type:        "array",
+				PrefixItems: prefixItems,
+			},
+			Channel:   channel,
+			Chaincode: chaincode,
+			Signer:    getUserName(signingKey),
+		},
+		Func: methodName,
+		Args: input,
+	}
+
 	return f.client.R().
 		SetContext(ctx).
-		SetQueryParam(f.prefixShort+"-signer", getUserName(signingKey)).
-		SetQueryParam(f.prefixShort+"-channel", channel).
-		SetQueryParam(f.prefixShort+"-chaincode", chaincode).
-		SetQueryParam(f.prefixShort+"-sync", "false").
-		SetQueryParam(f.prefixShort+"-id", requestID).
-		SetBody(input).
+		SetBody(in).
 		Post("/transactions")
 }
 
@@ -512,7 +523,7 @@ func getUserName(fullIDString string) string {
 	if len(matches) == 0 {
 		return fullIDString
 	}
-	matches = cnPatteren.FindStringSubmatch(matches[1])
+	matches = cnPattern.FindStringSubmatch(matches[1])
 	if len(matches) > 1 {
 		return matches[1]
 	}
@@ -534,15 +545,17 @@ func (f *Fabric) SubmitBatchPin(ctx context.Context, operationID *fftypes.UUID, 
 	var uuids fftypes.Bytes32
 	copy(uuids[0:16], (*batch.TransactionID)[:])
 	copy(uuids[16:32], (*batch.BatchID)[:])
-	pinInput := &fabBatchPinInput{
-		Namespace:  batch.Namespace,
-		UUIDs:      hexFormatB32(&uuids),
-		BatchHash:  hexFormatB32(batch.BatchHash),
-		PayloadRef: batch.BatchPayloadRef,
-		Contexts:   hashes,
+	pinInput := map[string]interface{}{
+		"namespace":  batch.Namespace,
+		"uuids":      hexFormatB32(&uuids),
+		"batchHash":  hexFormatB32(batch.BatchHash),
+		"payloadRef": batch.BatchPayloadRef,
+		"contexts":   hashes,
 	}
-	input := newTxInput(pinInput)
-	res, err := f.invokeContractMethod(ctx, f.defaultChannel, f.chaincode, signingKey, operationID.String(), input)
+
+	input, _ := jsonEncodeInput(pinInput)
+
+	res, err := f.invokeContractMethod(ctx, f.defaultChannel, f.chaincode, batchPinMethodName, signingKey, operationID.String(), batchPinPrefixItems, input)
 	if err != nil || !res.IsSuccess() {
 		return restclient.WrapRestErr(ctx, res, err, i18n.MsgFabconnectRESTErr)
 	}
@@ -555,50 +568,100 @@ func (f *Fabric) InvokeContract(ctx context.Context, operationID *fftypes.UUID, 
 	if err != nil {
 		return i18n.WrapError(ctx, err, i18n.MsgJSONObjectParseFailed, "params")
 	}
-	in := &fabTxNamedInput{
-		Func:    method.Name,
-		Headers: newTxInputHeaders(),
-		Args:    args,
-	}
-	in.Headers.PayloadSchema = &PayloadSchema{
-		Type:        "array",
-		PrefixItems: make([]*PrefixItem, len(method.Params)),
-	}
-
-	// Build the payload schema for the method parameters
-	for i, param := range method.Params {
-		in.Headers.PayloadSchema.PrefixItems[i] = &PrefixItem{
-			Name: param.Name,
-			Type: "string",
-		}
-	}
 
 	fabricOnChainLocation, err := parseContractLocation(ctx, location)
 	if err != nil {
 		return err
 	}
 
-	res, err := f.invokeContractMethod(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode, signingKey, operationID.String(), in)
+	// Build the payload schema for the method parameters
+	prefixItems := make([]*PrefixItem, len(method.Params))
+	for i, param := range method.Params {
+		var paramSchema ffiParamSchema
+		if err := json.Unmarshal(param.Schema.Bytes(), &paramSchema); err != nil {
+			return i18n.WrapError(ctx, err, i18n.MsgJSONObjectParseFailed, fmt.Sprintf("%s.schema", param.Name))
+		}
+
+		prefixItems[i] = &PrefixItem{
+			Name: param.Name,
+			Type: paramSchema.Type,
+		}
+	}
+
+	res, err := f.invokeContractMethod(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode, method.Name, signingKey, operationID.String(), prefixItems, args)
+
 	if err != nil || !res.IsSuccess() {
 		return restclient.WrapRestErr(ctx, res, err, i18n.MsgFabconnectRESTErr)
 	}
 	return nil
 }
 
+func (f *Fabric) QueryContract(ctx context.Context, location *fftypes.JSONAny, method *fftypes.FFIMethod, input map[string]interface{}) (interface{}, error) {
+	// All arguments must be JSON serialized
+	args, err := jsonEncodeInput(input)
+	if err != nil {
+		return nil, i18n.WrapError(ctx, err, i18n.MsgJSONObjectParseFailed, "params")
+	}
+
+	fabricOnChainLocation, err := parseContractLocation(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the payload schema for the method parameters
+	prefixItems := make([]*PrefixItem, len(method.Params))
+	for i, param := range method.Params {
+		prefixItems[i] = &PrefixItem{
+			Name: param.Name,
+			Type: "string",
+		}
+	}
+
+	in := &fabTxNamedInput{
+		Headers: &fabTxInputHeaders{
+			PayloadSchema: &PayloadSchema{
+				Type:        "array",
+				PrefixItems: prefixItems,
+			},
+			Channel:   fabricOnChainLocation.Channel,
+			Chaincode: fabricOnChainLocation.Chaincode,
+			Signer:    f.signer,
+		},
+		Func: method.Name,
+		Args: args,
+	}
+
+	res, err := f.client.R().
+		SetContext(ctx).
+		SetBody(in).
+		Post("/query")
+
+	if err != nil || !res.IsSuccess() {
+		return nil, restclient.WrapRestErr(ctx, res, err, i18n.MsgFabconnectRESTErr)
+	}
+	output := &fabQueryNamedOutput{}
+	if err = json.Unmarshal(res.Body(), output); err != nil {
+		return nil, err
+	}
+	return output.Result, nil
+}
+
 func jsonEncodeInput(params map[string]interface{}) (output map[string]string, err error) {
 	output = make(map[string]string, len(params))
 	for field, value := range params {
-		encodedValue, err := json.Marshal(value)
-		if err != nil {
-			return nil, err
+		switch v := value.(type) {
+		case string:
+			output[field] = v
+		default:
+			encodedValue, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			output[field] = string(encodedValue)
 		}
-		output[field] = string(encodedValue)
+
 	}
 	return
-}
-
-func (f *Fabric) QueryContract(ctx context.Context, location *fftypes.JSONAny, method *fftypes.FFIMethod, input map[string]interface{}) (interface{}, error) {
-	return nil, fmt.Errorf(("not yet supported"))
 }
 
 func (f *Fabric) ValidateContractLocation(ctx context.Context, location *fftypes.JSONAny) (err error) {

--- a/test/data/assetcreator/chaincode/smartcontract.go
+++ b/test/data/assetcreator/chaincode/smartcontract.go
@@ -24,3 +24,8 @@ func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface,
 	ctx.GetStub().SetEvent("AssetCreated", assetJSON)
 	return ctx.GetStub().PutState(name, assetJSON)
 }
+
+func (s *SmartContract) GetAsset(ctx contractapi.TransactionContextInterface, name string) (string, error) {
+	b, err := ctx.GetStub().GetState(name)
+	return string(b), err
+}

--- a/test/e2e/fabric_contract_test.go
+++ b/test/e2e/fabric_contract_test.go
@@ -154,8 +154,6 @@ func (suite *FabricContractTestSuite) TestE2EContractEvents() {
 	assert.Equal(suite.T(), sub.ProtocolID, subs[0].ProtocolID)
 
 	assetName := nanoid.New()
-	// invokeFabContract(suite.T(), suite.fabClient, "firefly", suite.chaincodeName, "org_0", "CreateAsset", []string{asset})
-
 	location := map[string]interface{}{
 		"chaincode": suite.chaincodeName,
 		"channel":   "firefly",

--- a/test/e2e/fabric_contract_test.go
+++ b/test/e2e/fabric_contract_test.go
@@ -17,6 +17,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -47,6 +48,37 @@ var assetCreatedEvent = &fftypes.FFIEvent{
 	FFIEventDefinition: fftypes.FFIEventDefinition{
 		Name: "AssetCreated",
 	},
+}
+
+func assetManagerCreateAsset() *fftypes.FFIMethod {
+	return &fftypes.FFIMethod{
+		Name: "CreateAsset",
+		Params: fftypes.FFIParams{
+			{
+				Name:   "name",
+				Schema: fftypes.JSONAnyPtr(`{"type": "string"}`),
+			},
+		},
+		Returns: fftypes.FFIParams{},
+	}
+}
+
+func assetManagerGetAsset() *fftypes.FFIMethod {
+	return &fftypes.FFIMethod{
+		Name: "GetAsset",
+		Params: fftypes.FFIParams{
+			{
+				Name:   "name",
+				Schema: fftypes.JSONAnyPtr(`{"type": "string"}`),
+			},
+		},
+		Returns: fftypes.FFIParams{
+			{
+				Name:   "name",
+				Schema: fftypes.JSONAnyPtr(`{"type": "string"}`),
+			},
+		},
+	}
 }
 
 func deployChaincode(t *testing.T, stackName string) string {
@@ -121,8 +153,25 @@ func (suite *FabricContractTestSuite) TestE2EContractEvents() {
 	assert.Equal(suite.T(), 1, len(subs))
 	assert.Equal(suite.T(), sub.ProtocolID, subs[0].ProtocolID)
 
-	asset := nanoid.New()
-	invokeFabContract(suite.T(), suite.fabClient, "firefly", suite.chaincodeName, "org_0", "CreateAsset", []string{asset})
+	assetName := nanoid.New()
+	// invokeFabContract(suite.T(), suite.fabClient, "firefly", suite.chaincodeName, "org_0", "CreateAsset", []string{asset})
+
+	location := map[string]interface{}{
+		"chaincode": suite.chaincodeName,
+		"channel":   "firefly",
+	}
+	locationBytes, _ := json.Marshal(location)
+	invokeContractRequest := &fftypes.ContractCallRequest{
+		Location: fftypes.JSONAnyPtrBytes(locationBytes),
+		Method:   assetManagerCreateAsset(),
+		Input: map[string]interface{}{
+			"name": assetName,
+		},
+	}
+
+	res, err := InvokeContractMethod(suite.testState.t, suite.testState.client1, invokeContractRequest)
+	suite.T().Log(res)
+	assert.NoError(suite.T(), err)
 
 	<-received1
 	<-changes1 // also expect database change events
@@ -130,7 +179,20 @@ func (suite *FabricContractTestSuite) TestE2EContractEvents() {
 	events := GetContractEvents(suite.T(), suite.testState.client1, suite.testState.startTime, sub.ID)
 	assert.Equal(suite.T(), 1, len(events))
 	assert.Equal(suite.T(), "AssetCreated", events[0].Name)
-	assert.Equal(suite.T(), asset, events[0].Output.GetString("name"))
+	assert.Equal(suite.T(), assetName, events[0].Output.GetString("name"))
+
+	queryContractRequest := &fftypes.ContractCallRequest{
+		Location: fftypes.JSONAnyPtrBytes(locationBytes),
+		Method:   assetManagerGetAsset(),
+		Input: map[string]interface{}{
+			"name": assetName,
+		},
+	}
+
+	res, err = QueryContractMethod(suite.testState.t, suite.testState.client1, queryContractRequest)
+	suite.T().Log(res)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), assetName, res.(map[string]interface{})["name"])
 
 	DeleteContractSubscription(suite.T(), suite.testState.client1, subs[0].ID)
 	subs = GetContractSubscriptions(suite.T(), suite.testState.client1, suite.testState.startTime)


### PR DESCRIPTION
This PR also removes query parameters on `POST` requests to Fabconnect in favor of always using the request body and a well defined `payloadSchema`