### PR TITLE
Added version command to Core Binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(eval $(call makemock, internal/apiserver,        IServer,            apiserver
 $(eval $(call makemock, internal/metrics,          Manager,            metricsmocks))
 
 firefly-nocgo: ${GOFILES}
-		CGO_ENABLED=0 $(VGO) build -o ${BINARY_NAME}-nocgo -ldflags "-X main.buildDate=`date -u +\"%Y-%m-%dT%H:%M:%SZ\"` -X main.buildVersion=$(BUILD_VERSION)" -tags=prod -tags=prod -v
+		CGO_ENABLED=0 $(VGO) build -o ${BINARY_NAME}-nocgo -ldflags "-X main.buildDate=`date -u +\"%Y-%m-%dT%H:%M:%SZ\"` -X main.buildVersion=$(BUILD_VERSION) -X 'github.com/hyperledger/firefly/internal/version.Date=$(DATE)' -X 'github.com/hyperledger/firefly/version.Commit=${GITREF}" -tags=prod -tags=prod -v
 firefly: ${GOFILES}
 		$(VGO) build -o ${BINARY_NAME} -ldflags "-X main.buildDate=`date -u +\"%Y-%m-%dT%H:%M:%SZ\"` -X main.buildVersion=$(BUILD_VERSION)" -tags=prod -tags=prod -v
 go-mod-tidy: .ALWAYS

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,82 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/firefly/internal/version"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var shortened, output = false, "yaml"
+
+type Info struct {
+	Version string `json:"Version,omitempty" yaml:"Version,omitempty"`
+	Commit  string `json:"Commit,omitempty" yaml:"Commit,omitempty"`
+	Date    string `json:"Date,omitempty" yaml:"Date,omitempty"`
+	License string `json:"License,omitempty" yaml:"License,omitempty"`
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints the version info",
+	Long: "Prints the version info of the Core binary",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if shortened {
+			fmt.Println(version.Version)
+		} else {
+			info := &Info{
+				Version: version.Version,
+				Commit: version.Commit,
+				Date: version.Date,
+				License: version.License,
+			}
+
+			var (
+				bytes []byte
+				err error
+			)
+
+			switch output {
+				case "json":
+					bytes, err = json.MarshalIndent(info, "", "  ")
+				case "yaml":
+					bytes, err = yaml.Marshal(info)
+				default:
+					return fmt.Errorf("invalid output '%s'", output)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(bytes))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolVarP(&shortened, "short", "s", false, "Prints only the version number")
+	versionCmd.Flags().StringVarP(&output, "output", "o", "json", "output format (\"yaml\"|\"json\")")
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,25 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+var (
+	Version = "canary"
+	Commit = "ref"
+	Date = "1970-01-01T00:00:00Z"
+)
+
+const License = "Apache-2.0"


### PR DESCRIPTION
Signed-off-by: Swarnim Pratap Singh <swarnimpratap132@gmail.com>
Fixes #132
It provides a command for listing the firefly build version and creating an internal package for the version so that it was accessible to the versionCmd in the cmd package.