### PR TITLE
Move blob publish to broadcast batch dispatch, ensure public refs on inbound

### DIFF
--- a/internal/batch/batch_manager_test.go
+++ b/internal/batch/batch_manager_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/hyperledger/firefly/internal/config"
-	"github.com/hyperledger/firefly/internal/data"
 	"github.com/hyperledger/firefly/internal/log"
 	"github.com/hyperledger/firefly/internal/txcommon"
 	"github.com/hyperledger/firefly/mocks/databasemocks"
@@ -352,7 +351,7 @@ func TestMessageSequencerMissingMessageData(t *testing.T) {
 		}).
 		Once()
 	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Message{}, nil, nil)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything, data.CRORequirePublicBlobRefs).Return(fftypes.DataArray{}, false, nil)
+	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{}, false, nil)
 
 	bm.(*batchManager).messageSequencer()
 
@@ -541,7 +540,7 @@ func TestAssembleMessageDataNilData(t *testing.T) {
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
 	bm.Close()
 	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(nil, false, nil)
-	_, err := bm.(*batchManager).assembleMessageData(fftypes.BatchTypePrivate, &fftypes.Message{
+	_, err := bm.(*batchManager).assembleMessageData(&fftypes.Message{
 		Header: fftypes.MessageHeader{
 			ID: fftypes.NewUUID(),
 		},
@@ -558,7 +557,7 @@ func TestGetMessageDataFail(t *testing.T) {
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
 	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(nil, false, fmt.Errorf("pop"))
 	bm.Close()
-	_, _ = bm.(*batchManager).assembleMessageData(fftypes.BatchTypePrivate, &fftypes.Message{
+	_, _ = bm.(*batchManager).assembleMessageData(&fftypes.Message{
 		Header: fftypes.MessageHeader{
 			ID: fftypes.NewUUID(),
 		},
@@ -575,9 +574,9 @@ func TestGetMessageNotFound(t *testing.T) {
 	mni := &sysmessagingmocks.LocalNodeInfo{}
 	txHelper := txcommon.NewTransactionHelper(mdi, mdm)
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything, data.CRORequirePublicBlobRefs).Return(nil, false, nil)
+	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(nil, false, nil)
 	bm.Close()
-	_, err := bm.(*batchManager).assembleMessageData(fftypes.BatchTypeBroadcast, &fftypes.Message{
+	_, err := bm.(*batchManager).assembleMessageData(&fftypes.Message{
 		Header: fftypes.MessageHeader{
 			ID: fftypes.NewUUID(),
 		},

--- a/internal/broadcast/definition.go
+++ b/internal/broadcast/definition.go
@@ -87,10 +87,8 @@ func (bm *broadcastManager) broadcastDefinitionCommon(ctx context.Context, ns st
 				},
 			},
 		},
-		ResolvedData: data.Resolved{
-			NewData: fftypes.DataArray{d},
-			AllData: fftypes.DataArray{d},
-		},
+		NewData: fftypes.DataArray{d},
+		AllData: fftypes.DataArray{d},
 	}
 
 	// Broadcast the message

--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -105,13 +105,6 @@ func (s *broadcastSender) resolveAndSend(ctx context.Context, method sendMethod)
 		if msgSizeEstimate > s.mgr.maxBatchPayloadLength {
 			return i18n.NewError(ctx, i18n.MsgTooLargeBroadcast, float64(msgSizeEstimate)/1024, float64(s.mgr.maxBatchPayloadLength)/1024)
 		}
-
-		// Perform deferred processing
-		if len(s.msg.ResolvedData.DataToPublish) > 0 {
-			if err := s.mgr.publishBlobs(ctx, s.msg); err != nil {
-				return err
-			}
-		}
 		s.resolved = true
 	}
 	return s.sendInternal(ctx, method)
@@ -128,7 +121,7 @@ func (s *broadcastSender) resolve(ctx context.Context) error {
 	}
 
 	// The data manager is responsible for the heavy lifting of storing/validating all our in-line data elements
-	err := s.mgr.data.ResolveInlineDataBroadcast(ctx, s.msg)
+	err := s.mgr.data.ResolveInlineData(ctx, s.msg)
 	return err
 }
 
@@ -154,7 +147,7 @@ func (s *broadcastSender) sendInternal(ctx context.Context, method sendMethod) (
 	if err := s.mgr.data.WriteNewMessage(ctx, s.msg); err != nil {
 		return err
 	}
-	log.L(ctx).Infof("Sent broadcast message %s:%s sequence=%d datacount=%d", msg.Header.Namespace, msg.Header.ID, msg.Sequence, len(s.msg.ResolvedData.AllData))
+	log.L(ctx).Infof("Sent broadcast message %s:%s sequence=%d datacount=%d", msg.Header.Namespace, msg.Header.ID, msg.Sequence, len(s.msg.AllData))
 
 	return err
 }

--- a/internal/broadcast/operations.go
+++ b/internal/broadcast/operations.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 
 	"github.com/hyperledger/firefly/internal/i18n"
+	"github.com/hyperledger/firefly/internal/log"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
@@ -78,6 +79,7 @@ func (bm *broadcastManager) RunOperation(ctx context.Context, op *fftypes.Prepar
 		if err != nil {
 			return false, err
 		}
+		log.L(ctx).Infof("Published batch '%s' to shared storage: '%s'", data.Batch.ID, payloadRef)
 
 		// Update the batch to store the payloadRef
 		data.Batch.PayloadRef = payloadRef

--- a/internal/data/message_writer.go
+++ b/internal/data/message_writer.go
@@ -27,14 +27,9 @@ import (
 )
 
 type NewMessage struct {
-	Message      *fftypes.MessageInOut
-	ResolvedData Resolved
-}
-
-type Resolved struct {
-	AllData       fftypes.DataArray
-	NewData       fftypes.DataArray
-	DataToPublish []*fftypes.DataAndBlob
+	Message *fftypes.MessageInOut
+	AllData fftypes.DataArray
+	NewData fftypes.DataArray
 }
 
 // writeRequest is a combination of a message and a list of data that is new and needs to be
@@ -100,7 +95,7 @@ func (mw *messageWriter) WriteNewMessage(ctx context.Context, newMsg *NewMessage
 		}
 		nmi := &writeRequest{
 			newMessage: &newMsg.Message.Message,
-			newData:    newMsg.ResolvedData.NewData,
+			newData:    newMsg.NewData,
 			result:     make(chan error),
 		}
 		select {
@@ -112,7 +107,7 @@ func (mw *messageWriter) WriteNewMessage(ctx context.Context, newMsg *NewMessage
 	}
 	// Otherwise do it in-line on this context
 	return mw.database.RunAsGroup(ctx, func(ctx context.Context) error {
-		return mw.writeMessages(ctx, []*fftypes.Message{&newMsg.Message.Message}, newMsg.ResolvedData.NewData)
+		return mw.writeMessages(ctx, []*fftypes.Message{&newMsg.Message.Message}, newMsg.NewData)
 	})
 }
 

--- a/internal/data/message_writer_test.go
+++ b/internal/data/message_writer_test.go
@@ -91,9 +91,7 @@ func TestWriteNewMessageSyncFallback(t *testing.T) {
 
 	err := mw.WriteNewMessage(customCtx, &NewMessage{
 		Message: msg1,
-		ResolvedData: Resolved{
-			NewData: fftypes.DataArray{data1},
-		},
+		NewData: fftypes.DataArray{data1},
 	})
 
 	assert.NoError(t, err)

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -428,7 +428,7 @@ func TestAggregationBroadcast(t *testing.T) {
 	// Do not resolve any pins earlier
 	mdi.On("GetPins", mock.Anything, mock.Anything).Return([]*fftypes.Pin{}, nil, nil)
 	// Validate the message is ok
-	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
+	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID, data.CRORequirePublicBlobRefs).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
 	mdm.On("ValidateAll", ag.ctx, mock.Anything).Return(true, nil)
 	// Insert the confirmed event
 	mdi.On("InsertEvent", ag.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
@@ -521,7 +521,7 @@ func TestAggregationMigratedBroadcast(t *testing.T) {
 	// Do not resolve any pins earlier
 	mdi.On("GetPins", mock.Anything, mock.Anything).Return([]*fftypes.Pin{}, nil, nil)
 	// Validate the message is ok
-	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
+	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID, data.CRORequirePublicBlobRefs).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
 	mdm.On("ValidateAll", ag.ctx, mock.Anything).Return(true, nil)
 	// Insert the confirmed event
 	mdi.On("InsertEvent", ag.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
@@ -841,7 +841,7 @@ func TestProcessSkipDupMsg(t *testing.T) {
 	mdi.On("UpdateOffset", ag.ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mdm := ag.data.(*datamocks.Manager)
-	mdm.On("GetMessageWithDataCached", ag.ctx, mock.Anything).Return(batch.Payload.Messages[0], nil, true, nil)
+	mdm.On("GetMessageWithDataCached", ag.ctx, mock.Anything, data.CRORequirePublicBlobRefs).Return(batch.Payload.Messages[0], nil, true, nil)
 
 	err := ag.processPins(ag.ctx, []*fftypes.Pin{
 		{Sequence: 12345, Batch: batchID, Index: 0, Hash: fftypes.NewRandB32()},
@@ -879,7 +879,7 @@ func TestProcessMsgFailGetPins(t *testing.T) {
 	mdi.On("GetPins", mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
 
 	mdm := ag.data.(*datamocks.Manager)
-	mdm.On("GetMessageWithDataCached", ag.ctx, mock.Anything).Return(batch.Payload.Messages[0], nil, true, nil)
+	mdm.On("GetMessageWithDataCached", ag.ctx, mock.Anything, data.CRORequirePublicBlobRefs).Return(batch.Payload.Messages[0], nil, true, nil)
 
 	err := ag.processPins(ag.ctx, []*fftypes.Pin{
 		{Sequence: 12345, Batch: batchID, Index: 0, Hash: fftypes.NewRandB32()},
@@ -1010,7 +1010,7 @@ func TestProcessMsgFailDispatch(t *testing.T) {
 	}
 
 	mdm := ag.data.(*datamocks.Manager)
-	mdm.On("GetMessageWithDataCached", ag.ctx, mock.Anything).Return(msg, nil, true, nil)
+	mdm.On("GetMessageWithDataCached", ag.ctx, mock.Anything, data.CRORequirePublicBlobRefs).Return(msg, nil, true, nil)
 
 	mim := ag.identity.(*identitymanagermocks.Manager)
 	mim.On("FindIdentityForVerifier", ag.ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
@@ -1572,8 +1572,8 @@ func TestDispatchBroadcastQueuesLaterDispatch(t *testing.T) {
 	mim.On("FindIdentityForVerifier", ag.ctx, mock.Anything, mock.Anything, mock.Anything).Return(org1, nil)
 
 	mdm := ag.data.(*datamocks.Manager)
-	mdm.On("GetMessageWithDataCached", ag.ctx, msg1.Header.ID).Return(msg1, fftypes.DataArray{}, true, nil).Once()
-	mdm.On("GetMessageWithDataCached", ag.ctx, msg2.Header.ID).Return(msg2, fftypes.DataArray{}, true, nil).Once()
+	mdm.On("GetMessageWithDataCached", ag.ctx, msg1.Header.ID, data.CRORequirePublicBlobRefs).Return(msg1, fftypes.DataArray{}, true, nil).Once()
+	mdm.On("GetMessageWithDataCached", ag.ctx, msg2.Header.ID, data.CRORequirePublicBlobRefs).Return(msg2, fftypes.DataArray{}, true, nil).Once()
 
 	mdi := ag.database.(*databasemocks.Plugin)
 	mdi.On("GetPins", ag.ctx, mock.Anything).Return([]*fftypes.Pin{}, nil, nil)

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -141,7 +141,7 @@ func (s *messageSender) resolve(ctx context.Context) error {
 	}
 
 	// The data manager is responsible for the heavy lifting of storing/validating all our in-line data elements
-	err := s.mgr.data.ResolveInlineDataPrivate(ctx, s.msg)
+	err := s.mgr.data.ResolveInlineData(ctx, s.msg)
 	return err
 }
 

--- a/internal/privatemessaging/message_test.go
+++ b/internal/privatemessaging/message_test.go
@@ -85,7 +85,7 @@ func TestSendConfirmMessageE2EOk(t *testing.T) {
 	mim.On("CachedIdentityLookupByID", pm.ctx, rootOrg.ID).Return(rootOrg, nil)
 
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Return(nil)
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Return(nil)
 	mdm.On("WriteNewMessage", pm.ctx, mock.Anything).Return(nil).Once()
 
 	mdi := pm.database.(*databasemocks.Plugin)
@@ -138,7 +138,7 @@ func TestSendUnpinnedMessageE2EOk(t *testing.T) {
 
 	groupID := fftypes.NewRandB32()
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Return(nil)
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Return(nil)
 	mdm.On("WriteNewMessage", pm.ctx, mock.Anything).Return(nil).Once()
 
 	mdi := pm.database.(*databasemocks.Plugin)
@@ -235,7 +235,7 @@ func TestResolveAndSendBadInlineData(t *testing.T) {
 	mdi.On("GetGroupByHash", pm.ctx, mock.Anything, mock.Anything).Return(&fftypes.Group{Hash: fftypes.NewRandB32()}, nil, nil).Once()
 
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Return(fmt.Errorf("pop"))
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Return(fmt.Errorf("pop"))
 
 	message := &messageSender{
 		mgr:       pm,
@@ -277,7 +277,7 @@ func TestSendUnpinnedMessageTooLarge(t *testing.T) {
 	dataID := fftypes.NewUUID()
 	groupID := fftypes.NewRandB32()
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Run(func(args mock.Arguments) {
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Run(func(args mock.Arguments) {
 		newMsg := args[1].(*data.NewMessage)
 		newMsg.Message.Data = fftypes.DataRefs{
 			{ID: dataID, Hash: fftypes.NewRandB32(), ValueSize: 100001},
@@ -352,7 +352,7 @@ func TestMessagePrepare(t *testing.T) {
 	mdi.On("GetGroupByHash", pm.ctx, mock.Anything, mock.Anything).Return(&fftypes.Group{Hash: fftypes.NewRandB32()}, nil, nil).Once()
 
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Return(nil)
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Return(nil)
 
 	message := pm.NewMessage("ns1", &fftypes.MessageInOut{
 		Message: fftypes.Message{
@@ -425,7 +425,7 @@ func TestSendUnpinnedMessageInsertFail(t *testing.T) {
 
 	groupID := fftypes.NewRandB32()
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Return(nil)
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Return(nil)
 	mdm.On("WriteNewMessage", pm.ctx, mock.Anything).Return(fmt.Errorf("pop")).Once()
 
 	mdi := pm.database.(*databasemocks.Plugin)
@@ -606,7 +606,7 @@ func TestRequestReplySuccess(t *testing.T) {
 		Return(nil, nil)
 
 	mdm := pm.data.(*datamocks.Manager)
-	mdm.On("ResolveInlineDataPrivate", pm.ctx, mock.Anything).Return(nil)
+	mdm.On("ResolveInlineData", pm.ctx, mock.Anything).Return(nil)
 	mdm.On("WriteNewMessage", pm.ctx, mock.Anything).Return(nil).Once()
 
 	groupID := fftypes.NewRandB32()

--- a/mocks/datamocks/manager.go
+++ b/mocks/datamocks/manager.go
@@ -32,11 +32,6 @@ func (_m *Manager) CheckDatatype(ctx context.Context, ns string, datatype *fftyp
 	return r0
 }
 
-// Close provides a mock function with given fields:
-func (_m *Manager) Close() {
-	_m.Called()
-}
-
 // CopyBlobPStoDX provides a mock function with given fields: ctx, _a1
 func (_m *Manager) CopyBlobPStoDX(ctx context.Context, _a1 *fftypes.Data) (*fftypes.Blob, error) {
 	ret := _m.Called(ctx, _a1)
@@ -198,22 +193,8 @@ func (_m *Manager) HydrateBatch(ctx context.Context, persistedBatch *fftypes.Bat
 	return r0, r1
 }
 
-// ResolveInlineDataBroadcast provides a mock function with given fields: ctx, msg
-func (_m *Manager) ResolveInlineDataBroadcast(ctx context.Context, msg *data.NewMessage) error {
-	ret := _m.Called(ctx, msg)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *data.NewMessage) error); ok {
-		r0 = rf(ctx, msg)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// ResolveInlineDataPrivate provides a mock function with given fields: ctx, msg
-func (_m *Manager) ResolveInlineDataPrivate(ctx context.Context, msg *data.NewMessage) error {
+// ResolveInlineData provides a mock function with given fields: ctx, msg
+func (_m *Manager) ResolveInlineData(ctx context.Context, msg *data.NewMessage) error {
 	ret := _m.Called(ctx, msg)
 
 	var r0 error


### PR DESCRIPTION
Resolves #595 

- No longer set `CRORequirePublicBlobRefs` when assembling the messages prior to dispatching a batch (timing issue with this seen in #595)
- Move upload of blobs from API thread, to the batch dispatch thread
- Set `CRORequirePublicBlobRefs` when aggregating pins for broadcast messages