### PR TITLE
Performance enhancements from flame graph analysis

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -95,7 +95,7 @@ func run() error {
 
 	// Setup logging after reading config (even if failed), to output header correctly
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	ctx = log.WithLogger(ctx, logrus.WithField("pid", os.Getpid()))
+	ctx = log.WithLogger(ctx, logrus.WithField("pid", fmt.Sprintf("%d", os.Getpid())))
 	ctx = log.WithLogger(ctx, logrus.WithField("prefix", config.GetString(config.NodeName)))
 
 	config.SetupLogging(ctx)

--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -96,6 +96,7 @@ func run() error {
 	// Setup logging after reading config (even if failed), to output header correctly
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	ctx = log.WithLogger(ctx, logrus.WithField("pid", os.Getpid()))
+	ctx = log.WithLogger(ctx, logrus.WithField("prefix", config.GetString(config.NodeName)))
 
 	config.SetupLogging(ctx)
 	log.L(ctx).Infof("Project Firefly")

--- a/ff-perf.log
+++ b/ff-perf.log
@@ -1,1 +1,0 @@
-nohup: ff-perf: No such file or directory

--- a/ff-perf.log
+++ b/ff-perf.log
@@ -1,0 +1,1 @@
+nohup: ff-perf: No such file or directory

--- a/internal/batch/batch_manager_test.go
+++ b/internal/batch/batch_manager_test.go
@@ -34,9 +34,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestE2EDispatchBroadcast(t *testing.T) {
-	log.SetLevel("debug")
+func testConfigReset() {
 	config.Reset()
+	config.Set(config.BatchManagerMinimumPollTime, "1ns")
+	log.SetLevel("debug")
+}
+
+func TestE2EDispatchBroadcast(t *testing.T) {
+	testConfigReset()
 
 	mdi := &databasemocks.Plugin{}
 	mdm := &datamocks.Manager{}
@@ -150,8 +155,7 @@ func TestE2EDispatchBroadcast(t *testing.T) {
 }
 
 func TestE2EDispatchPrivateUnpinned(t *testing.T) {
-	log.SetLevel("debug")
-	config.Reset()
+	testConfigReset()
 
 	mdi := &databasemocks.Plugin{}
 	mdm := &datamocks.Manager{}
@@ -264,8 +268,7 @@ func TestE2EDispatchPrivateUnpinned(t *testing.T) {
 }
 
 func TestDispatchUnknownType(t *testing.T) {
-	log.SetLevel("debug")
-	config.Reset()
+	testConfigReset()
 
 	mdi := &databasemocks.Plugin{}
 	mdm := &datamocks.Manager{}

--- a/internal/batch/batch_manager_test.go
+++ b/internal/batch/batch_manager_test.go
@@ -99,10 +99,10 @@ func TestE2EDispatchBroadcast(t *testing.T) {
 		ID:   dataID1,
 		Hash: dataHash,
 	}
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{data}, true, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{data}, true, nil)
 	mdm.On("UpdateMessageIfCached", mock.Anything, mock.Anything).Return()
-	mdi.On("GetMessages", mock.Anything, mock.Anything).Return([]*fftypes.Message{msg}, nil, nil).Once()
-	mdi.On("GetMessages", mock.Anything, mock.Anything).Return([]*fftypes.Message{}, nil, nil)
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil).Once()
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{}, nil)
 	mdi.On("UpsertBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil) // pins
@@ -218,10 +218,10 @@ func TestE2EDispatchPrivateUnpinned(t *testing.T) {
 		ID:   dataID1,
 		Hash: dataHash,
 	}
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{data}, true, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{data}, true, nil)
 	mdm.On("UpdateMessageIfCached", mock.Anything, mock.Anything).Return()
-	mdi.On("GetMessages", mock.Anything, mock.Anything).Return([]*fftypes.Message{msg}, nil, nil).Once()
-	mdi.On("GetMessages", mock.Anything, mock.Anything).Return([]*fftypes.Message{}, nil, nil)
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil).Once()
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{}, nil)
 	mdi.On("UpdateMessage", mock.Anything, mock.Anything, mock.Anything).Return(nil) // pins
 	mdi.On("UpsertBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -275,9 +275,13 @@ func TestDispatchUnknownType(t *testing.T) {
 	bmi, _ := NewBatchManager(ctx, mni, mdi, mdm, txHelper)
 	bm := bmi.(*batchManager)
 
-	msg := &fftypes.Message{}
-	mdi.On("GetMessages", mock.Anything, mock.Anything).Return([]*fftypes.Message{msg}, nil, nil).Once()
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{}, true, nil)
+	msg := &fftypes.Message{
+		Header: fftypes.MessageHeader{
+			ID: fftypes.NewUUID(),
+		},
+	}
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil).Once()
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{}, true, nil)
 
 	err := bm.Start()
 	assert.NoError(t, err)
@@ -309,7 +313,7 @@ func TestMessageSequencerCancelledContext(t *testing.T) {
 	mdm := &datamocks.Manager{}
 	mni := &sysmessagingmocks.LocalNodeInfo{}
 	txHelper := txcommon.NewTransactionHelper(mdi, mdm)
-	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop")).Once()
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
 	defer bm.Close()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -333,25 +337,25 @@ func TestMessageSequencerMissingMessageData(t *testing.T) {
 	)
 
 	dataID := fftypes.NewUUID()
-	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).
-		Return([]*fftypes.Message{
-			{
-				Header: fftypes.MessageHeader{
-					ID:        fftypes.NewUUID(),
-					Type:      fftypes.MessageTypeBroadcast,
-					Namespace: "ns1",
-					TxType:    fftypes.TransactionTypeNone,
-				},
-				Data: []*fftypes.DataRef{
-					{ID: dataID},
-				}},
-		}, nil, nil).
+	msg := &fftypes.Message{
+		Header: fftypes.MessageHeader{
+			ID:        fftypes.NewUUID(),
+			Type:      fftypes.MessageTypeBroadcast,
+			Namespace: "ns1",
+			TxType:    fftypes.TransactionTypeNone,
+		},
+		Data: []*fftypes.DataRef{
+			{ID: dataID},
+		}}
+
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything, mock.Anything).
+		Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil, nil).
 		Run(func(args mock.Arguments) {
 			bm.Close()
 		}).
 		Once()
-	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Message{}, nil, nil)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{}, false, nil)
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{}, nil, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{}, false, nil)
 
 	bm.(*batchManager).messageSequencer()
 
@@ -377,19 +381,19 @@ func TestMessageSequencerUpdateMessagesFail(t *testing.T) {
 	)
 
 	dataID := fftypes.NewUUID()
-	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Message{
-		{
-			Header: fftypes.MessageHeader{
-				ID:        fftypes.NewUUID(),
-				TxType:    fftypes.TransactionTypeBatchPin,
-				Type:      fftypes.MessageTypeBroadcast,
-				Namespace: "ns1",
-			},
-			Data: []*fftypes.DataRef{
-				{ID: dataID},
-			}},
-	}, nil, nil)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{{ID: dataID}}, true, nil)
+	msg := &fftypes.Message{
+		Header: fftypes.MessageHeader{
+			ID:        fftypes.NewUUID(),
+			TxType:    fftypes.TransactionTypeBatchPin,
+			Type:      fftypes.MessageTypeBroadcast,
+			Namespace: "ns1",
+		},
+		Data: []*fftypes.DataRef{
+			{ID: dataID},
+		},
+	}
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{{ID: dataID}}, true, nil)
 	mdm.On("UpdateMessageIfCached", mock.Anything, mock.Anything).Return()
 	mdi.On("InsertTransaction", mock.Anything, mock.Anything).Return(nil)
 	mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil) // transaction submit
@@ -432,19 +436,19 @@ func TestMessageSequencerDispatchFail(t *testing.T) {
 	)
 
 	dataID := fftypes.NewUUID()
-	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Message{
-		{
-			Header: fftypes.MessageHeader{
-				ID:        fftypes.NewUUID(),
-				TxType:    fftypes.TransactionTypeBatchPin,
-				Type:      fftypes.MessageTypeBroadcast,
-				Namespace: "ns1",
-			},
-			Data: []*fftypes.DataRef{
-				{ID: dataID},
-			}},
-	}, nil, nil)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{{ID: dataID}}, true, nil)
+	msg := &fftypes.Message{
+		Header: fftypes.MessageHeader{
+			ID:        fftypes.NewUUID(),
+			TxType:    fftypes.TransactionTypeBatchPin,
+			Type:      fftypes.MessageTypeBroadcast,
+			Namespace: "ns1",
+		},
+		Data: []*fftypes.DataRef{
+			{ID: dataID},
+		},
+	}
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{{ID: dataID}}, true, nil)
 	mdi.On("RunAsGroup", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	bm.(*batchManager).messageSequencer()
@@ -472,19 +476,19 @@ func TestMessageSequencerUpdateBatchFail(t *testing.T) {
 	)
 
 	dataID := fftypes.NewUUID()
-	mdi.On("GetMessages", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Message{
-		{
-			Header: fftypes.MessageHeader{
-				ID:        fftypes.NewUUID(),
-				TxType:    fftypes.TransactionTypeBatchPin,
-				Type:      fftypes.MessageTypeBroadcast,
-				Namespace: "ns1",
-			},
-			Data: []*fftypes.DataRef{
-				{ID: dataID},
-			}},
-	}, nil, nil)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(fftypes.DataArray{{ID: dataID}}, true, nil)
+	msg := &fftypes.Message{
+		Header: fftypes.MessageHeader{
+			ID:        fftypes.NewUUID(),
+			TxType:    fftypes.TransactionTypeBatchPin,
+			Type:      fftypes.MessageTypeBroadcast,
+			Namespace: "ns1",
+		},
+		Data: []*fftypes.DataRef{
+			{ID: dataID},
+		},
+	}
+	mdi.On("GetMessageIDs", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.IDAndSequence{{ID: *msg.Header.ID}}, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(msg, fftypes.DataArray{{ID: dataID}}, true, nil)
 	mdi.On("UpsertBatch", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("fizzle"))
 	rag := mdi.On("RunAsGroup", mock.Anything, mock.Anything, mock.Anything)
 	rag.RunFn = func(a mock.Arguments) {
@@ -539,13 +543,8 @@ func TestAssembleMessageDataNilData(t *testing.T) {
 	txHelper := txcommon.NewTransactionHelper(mdi, mdm)
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
 	bm.Close()
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(nil, false, nil)
-	_, err := bm.(*batchManager).assembleMessageData(&fftypes.Message{
-		Header: fftypes.MessageHeader{
-			ID: fftypes.NewUUID(),
-		},
-		Data: fftypes.DataRefs{{ID: nil}},
-	})
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(nil, nil, false, nil)
+	_, _, err := bm.(*batchManager).assembleMessageData(fftypes.NewUUID())
 	assert.Regexp(t, "FF10133", err)
 }
 
@@ -555,16 +554,10 @@ func TestGetMessageDataFail(t *testing.T) {
 	mni := &sysmessagingmocks.LocalNodeInfo{}
 	txHelper := txcommon.NewTransactionHelper(mdi, mdm)
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(nil, false, fmt.Errorf("pop"))
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(nil, nil, false, fmt.Errorf("pop"))
 	bm.Close()
-	_, _ = bm.(*batchManager).assembleMessageData(&fftypes.Message{
-		Header: fftypes.MessageHeader{
-			ID: fftypes.NewUUID(),
-		},
-		Data: fftypes.DataRefs{
-			{ID: fftypes.NewUUID(), Hash: fftypes.NewRandB32()},
-		},
-	})
+	_, _, err := bm.(*batchManager).assembleMessageData(fftypes.NewUUID())
+	assert.Regexp(t, "FF10158", err)
 	mdm.AssertExpectations(t)
 }
 
@@ -574,15 +567,8 @@ func TestGetMessageNotFound(t *testing.T) {
 	mni := &sysmessagingmocks.LocalNodeInfo{}
 	txHelper := txcommon.NewTransactionHelper(mdi, mdm)
 	bm, _ := NewBatchManager(context.Background(), mni, mdi, mdm, txHelper)
-	mdm.On("GetMessageDataCached", mock.Anything, mock.Anything).Return(nil, false, nil)
+	mdm.On("GetMessageWithDataCached", mock.Anything, mock.Anything).Return(nil, nil, false, nil)
 	bm.Close()
-	_, err := bm.(*batchManager).assembleMessageData(&fftypes.Message{
-		Header: fftypes.MessageHeader{
-			ID: fftypes.NewUUID(),
-		},
-		Data: fftypes.DataRefs{
-			{ID: fftypes.NewUUID(), Hash: fftypes.NewRandB32()},
-		},
-	})
+	_, _, err := bm.(*batchManager).assembleMessageData(fftypes.NewUUID())
 	assert.Regexp(t, "FF10133", err)
 }

--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -197,7 +197,7 @@ func (bp *batchProcessor) addWork(newWork *batchWork) (full, overflow bool) {
 
 func (bp *batchProcessor) addFlushedSequences(flushAssembly []*batchWork) {
 	// We need to keep track of the sequences we're flushing, because until we finish our flush
-	// the batch processor might be re-queuing the same messages to use due to rewinds.
+	// the batch processor might be re-queuing the same messages to us due to rewinds.
 
 	// We keep twice the batch size, which might be made up of multiple batches
 	maxFlushedSeqLen := int(2 * bp.conf.BatchMaxSize)

--- a/internal/batch/batch_processor_test.go
+++ b/internal/batch/batch_processor_test.go
@@ -430,3 +430,80 @@ func TestMaskContextsUpdataMessageFail(t *testing.T) {
 
 	mdi.AssertExpectations(t)
 }
+
+func TestDispatchWithPublicBlobUpdates(t *testing.T) {
+	log.SetLevel("debug")
+	config.Reset()
+
+	dataID := fftypes.NewUUID()
+	dispatched := make(chan *DispatchState)
+	mdi, bp := newTestBatchProcessor(func(c context.Context, state *DispatchState) error {
+		state.BlobsPublished = append(state.BlobsPublished, dataID)
+		dispatched <- state
+		return nil
+	})
+	bp.conf.BatchMaxSize = 1
+	bp.conf.txType = fftypes.TransactionTypeUnpinned
+
+	mockRunAsGroupPassthrough(mdi)
+	mdi.On("UpdateData", mock.Anything, dataID, mock.Anything).Return(nil)
+	mdi.On("UpdateMessages", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mdi.On("UpsertBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
+
+	mth := bp.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", mock.Anything, "ns1", fftypes.TransactionTypeUnpinned).Return(fftypes.NewUUID(), nil)
+
+	mdm := bp.data.(*datamocks.Manager)
+	mdm.On("UpdateMessageIfCached", mock.Anything, mock.Anything).Return()
+
+	// Dispatch the work
+	go func() {
+		bp.newWork <- &batchWork{
+			msg: &fftypes.Message{Header: fftypes.MessageHeader{ID: fftypes.NewUUID()}, Sequence: int64(1000)},
+			data: fftypes.DataArray{
+				{ID: dataID, Blob: &fftypes.BlobRef{
+					Public: "public/ref",
+				}},
+			},
+		}
+	}()
+
+	batch := <-dispatched
+	assert.Equal(t, 1, len(batch.Payload.Messages))
+
+	bp.cancelCtx()
+	<-bp.done
+
+	mdi.AssertExpectations(t)
+	mdm.AssertExpectations(t)
+	mth.AssertExpectations(t)
+}
+
+func TestDispatchWithPublicBlobUpdatesFail(t *testing.T) {
+	log.SetLevel("debug")
+	config.Reset()
+
+	mdi, bp := newTestBatchProcessor(func(c context.Context, state *DispatchState) error { return nil })
+	bp.cancelCtx()
+
+	mockRunAsGroupPassthrough(mdi)
+	mdi.On("UpdateData", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	mdi.On("UpdateMessages", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	data := &fftypes.Data{
+		ID: fftypes.NewUUID(),
+		Blob: &fftypes.BlobRef{
+			Public: "test/ref",
+		},
+	}
+	err := bp.markPayloadDispatched(&DispatchState{
+		Payload: fftypes.BatchPayload{
+			Data: fftypes.DataArray{data},
+		},
+		BlobsPublished: []*fftypes.UUID{data.ID},
+	})
+	assert.Regexp(t, "FF10158", err)
+
+	mdi.AssertExpectations(t)
+}

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -124,7 +124,7 @@ func (bm *broadcastManager) Name() string {
 func (bm *broadcastManager) dispatchBatch(ctx context.Context, state *batch.DispatchState) error {
 
 	// Ensure all the blobs are published
-	if err := bm.publishBlobs(ctx, state.Payload.Data); err != nil {
+	if err := bm.publishBlobs(ctx, state.Payload.Data, state); err != nil {
 		return err
 	}
 
@@ -150,7 +150,7 @@ func (bm *broadcastManager) dispatchBatch(ctx context.Context, state *batch.Disp
 	return bm.batchpin.SubmitPinnedBatch(ctx, &state.Persisted, state.Pins)
 }
 
-func (bm *broadcastManager) publishBlobs(ctx context.Context, data fftypes.DataArray) error {
+func (bm *broadcastManager) publishBlobs(ctx context.Context, data fftypes.DataArray, state *batch.DispatchState) error {
 	for _, d := range data {
 		// We only need to send a blob if there is one, and it's not been uploaded to the shared storage
 		if d.Blob != nil && d.Blob.Hash != nil && d.Blob.Public == "" {
@@ -174,6 +174,7 @@ func (bm *broadcastManager) publishBlobs(ctx context.Context, data fftypes.DataA
 			if err != nil {
 				return err
 			}
+			state.BlobsPublished = append(state.BlobsPublished, d.ID)
 			log.L(ctx).Infof("Published blob with hash '%s' for data '%s' to shared storage: '%s'", d.Blob.Hash, d.ID, d.Blob.Public)
 		}
 	}

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -327,13 +327,17 @@ func TestPublishBlobsPublishOk(t *testing.T) {
 		},
 	}
 
-	err := bm.publishBlobs(ctx, fftypes.DataArray{data})
+	bs := &batch.DispatchState{}
+	err := bm.publishBlobs(ctx, fftypes.DataArray{data}, bs)
 	assert.NoError(t, err)
 	assert.Equal(t, "payload-ref1", data.Blob.Public)
 
 	b, err := ioutil.ReadAll(capturedReader)
 	assert.NoError(t, err)
 	assert.Equal(t, "some data", string(b))
+
+	assert.Len(t, bs.BlobsPublished, 1)
+	assert.Equal(t, data.ID, bs.BlobsPublished[0])
 
 	mdi.AssertExpectations(t)
 	mdx.AssertExpectations(t)
@@ -370,7 +374,7 @@ func TestPublishBlobsPublishFail(t *testing.T) {
 				Hash: blob.Hash,
 			},
 		},
-	})
+	}, &batch.DispatchState{})
 	assert.EqualError(t, err, "pop")
 
 	b, err := ioutil.ReadAll(capturedReader)
@@ -406,7 +410,7 @@ func TestPublishBlobsDownloadFail(t *testing.T) {
 				Hash: blob.Hash,
 			},
 		},
-	})
+	}, &batch.DispatchState{})
 	assert.Regexp(t, "FF10240", err)
 
 	mdi.AssertExpectations(t)
@@ -435,7 +439,7 @@ func TestPublishBlobsGetBlobFail(t *testing.T) {
 				Hash: blob.Hash,
 			},
 		},
-	})
+	}, &batch.DispatchState{})
 	assert.Regexp(t, "pop", err)
 
 	mdi.AssertExpectations(t)
@@ -463,7 +467,7 @@ func TestPublishBlobsGetBlobNotFound(t *testing.T) {
 				Hash: blob.Hash,
 			},
 		},
-	})
+	}, &batch.DispatchState{})
 	assert.Regexp(t, "FF10239", err)
 
 	mdi.AssertExpectations(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -351,7 +351,7 @@ func Reset() {
 	viper.SetDefault(string(MessageCacheSize), "50Mb")
 	viper.SetDefault(string(MessageCacheTTL), "5m")
 	viper.SetDefault(string(MessageWriterBatchMaxInserts), 200)
-	viper.SetDefault(string(MessageWriterBatchTimeout), "25ms")
+	viper.SetDefault(string(MessageWriterBatchTimeout), "50ms")
 	viper.SetDefault(string(MessageWriterCount), 5)
 	viper.SetDefault(string(NamespacesDefault), "default")
 	viper.SetDefault(string(NamespacesPredefined), fftypes.JSONObjectArray{{"name": "default", "description": "Default predefined namespace"}})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -333,7 +333,7 @@ func Reset() {
 	viper.SetDefault(string(EventAggregatorOpCorrelationRetries), 3)
 	viper.SetDefault(string(EventDBEventsBufferSize), 100)
 	viper.SetDefault(string(EventDispatcherBufferLength), 5)
-	viper.SetDefault(string(EventDispatcherBatchTimeout), "0")
+	viper.SetDefault(string(EventDispatcherBatchTimeout), "250ms")
 	viper.SetDefault(string(EventDispatcherPollTimeout), "30s")
 	viper.SetDefault(string(EventTransportsEnabled), []string{"websockets", "webhooks"})
 	viper.SetDefault(string(EventTransportsDefault), "websockets")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,8 @@ var (
 	BatchManagerReadPageSize = rootKey("batch.manager.readPageSize")
 	// BatchManagerReadPollTimeout is how long without any notifications of new messages to wait, before doing a page query
 	BatchManagerReadPollTimeout = rootKey("batch.manager.pollTimeout")
+	// BatchManagerMinimumPollTime is the minimum duration between polls, to avoid continual polling at high throughput
+	BatchManagerMinimumPollTime = rootKey("batch.manager.minimumPollTime")
 	// BatchRetryFactor is the retry backoff factor for database operations performed by the batch manager
 	BatchRetryFactor = rootKey("batch.retry.factor")
 	// BatchRetryInitDelay is the retry initial delay for database operations
@@ -305,6 +307,7 @@ func Reset() {
 	viper.SetDefault(string(AssetManagerKeyNormalization), "blockchain_plugin")
 	viper.SetDefault(string(BatchManagerReadPageSize), 100)
 	viper.SetDefault(string(BatchManagerReadPollTimeout), "30s")
+	viper.SetDefault(string(BatchManagerMinimumPollTime), "50ms")
 	viper.SetDefault(string(BatchRetryFactor), 2.0)
 	viper.SetDefault(string(BatchRetryFactor), 2.0)
 	viper.SetDefault(string(BatchRetryInitDelay), "250ms")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -327,7 +327,7 @@ func Reset() {
 	viper.SetDefault(string(DataexchangeType), "https")
 	viper.SetDefault(string(DebugPort), -1)
 	viper.SetDefault(string(EventAggregatorFirstEvent), fftypes.SubOptsFirstEventOldest)
-	viper.SetDefault(string(EventAggregatorBatchSize), 50)
+	viper.SetDefault(string(EventAggregatorBatchSize), 200)
 	viper.SetDefault(string(EventAggregatorBatchTimeout), "250ms")
 	viper.SetDefault(string(EventAggregatorPollTimeout), "30s")
 	viper.SetDefault(string(EventAggregatorRetryFactor), 2.0)

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -37,6 +37,7 @@ type Manager interface {
 	ValidateAll(ctx context.Context, data fftypes.DataArray) (valid bool, err error)
 	GetMessageWithDataCached(ctx context.Context, msgID *fftypes.UUID, options ...CacheReadOption) (msg *fftypes.Message, data fftypes.DataArray, foundAllData bool, err error)
 	GetMessageDataCached(ctx context.Context, msg *fftypes.Message, options ...CacheReadOption) (data fftypes.DataArray, foundAll bool, err error)
+	PeekMessageCache(ctx context.Context, id *fftypes.UUID, options ...CacheReadOption) (msg *fftypes.Message, data fftypes.DataArray)
 	UpdateMessageCache(msg *fftypes.Message, data fftypes.DataArray)
 	UpdateMessageIfCached(ctx context.Context, msg *fftypes.Message)
 	ResolveInlineData(ctx context.Context, msg *NewMessage) error
@@ -215,6 +216,14 @@ func (dm *dataManager) dataLookupAndCache(ctx context.Context, msg *fftypes.Mess
 	}
 	dm.UpdateMessageCache(msg, data)
 	return data, true, nil
+}
+
+func (dm *dataManager) PeekMessageCache(ctx context.Context, id *fftypes.UUID, options ...CacheReadOption) (msg *fftypes.Message, data fftypes.DataArray) {
+	mce := dm.queryMessageCache(ctx, id, options...)
+	if mce != nil {
+		return mce.msg, mce.data
+	}
+	return nil, nil
 }
 
 func (dm *dataManager) queryMessageCache(ctx context.Context, id *fftypes.UUID, options ...CacheReadOption) *messageCacheEntry {

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -229,7 +229,7 @@ func (dm *dataManager) queryMessageCache(ctx context.Context, id *fftypes.UUID, 
 		case CRORequirePublicBlobRefs:
 			for idx, d := range mce.data {
 				if d.Blob != nil && d.Blob.Public == "" {
-					log.L(ctx).Debugf("Cache miss for message %s - data %d (%s) is missing public blob ref", idx, d.ID, mce.msg.Header.ID)
+					log.L(ctx).Debugf("Cache miss for message %s - data %d (%s) is missing public blob ref", mce.msg.Header.ID, idx, d.ID)
 					return nil
 				}
 			}

--- a/internal/data/data_manager_test.go
+++ b/internal/data/data_manager_test.go
@@ -1135,3 +1135,15 @@ func TestWriteNewMessageFailNil(t *testing.T) {
 	err := dm.WriteNewMessage(ctx, &NewMessage{})
 	assert.Regexp(t, "FF10368", err)
 }
+
+func TestWriteNewMessageFailClosed(t *testing.T) {
+
+	dm, ctx, cancel := newTestDataManager(t)
+	defer cancel()
+	dm.messageWriter.close()
+
+	err := dm.WriteNewMessage(ctx, &NewMessage{
+		Message: &fftypes.MessageInOut{},
+	})
+	assert.Regexp(t, "FF10158", err)
+}

--- a/internal/data/data_manager_test.go
+++ b/internal/data/data_manager_test.go
@@ -1082,7 +1082,13 @@ func TestUpdateMessageCacheCRORequirePins(t *testing.T) {
 		Pins:   fftypes.FFStringArray{"pin1"},
 	}
 
+	msg, _ := dm.PeekMessageCache(ctx, msgWithPins.Header.ID)
+	assert.Nil(t, msg)
+
 	dm.UpdateMessageCache(msgNoPins, data)
+
+	msg, _ = dm.PeekMessageCache(ctx, msgWithPins.Header.ID)
+	assert.NotNil(t, msg)
 
 	mce := dm.queryMessageCache(ctx, msgNoPins.Header.ID, CRORequirePins)
 	assert.Nil(t, mce)

--- a/internal/data/message_writer.go
+++ b/internal/data/message_writer.go
@@ -90,9 +90,6 @@ func newMessageWriter(ctx context.Context, di database.Plugin, conf *messageWrit
 func (mw *messageWriter) WriteNewMessage(ctx context.Context, newMsg *NewMessage) error {
 	if mw.conf.workerCount > 0 {
 		// Dispatch to background worker
-		if newMsg.Message == nil {
-			return i18n.NewError(ctx, i18n.MsgNilOrNullObject)
-		}
 		nmi := &writeRequest{
 			newMessage: &newMsg.Message.Message,
 			newData:    newMsg.NewData,

--- a/internal/database/postgres/postgres.go
+++ b/internal/database/postgres/postgres.go
@@ -57,6 +57,7 @@ func (psql *Postgres) Features() sqlcommon.SQLFeatures {
 	features.ExclusiveTableLockSQL = func(table string) string {
 		return fmt.Sprintf(`LOCK TABLE "%s" IN EXCLUSIVE MODE;`, table)
 	}
+	features.MultiRowInsert = true
 	return features
 }
 

--- a/internal/database/sqlcommon/data_sql.go
+++ b/internal/database/sqlcommon/data_sql.go
@@ -198,7 +198,7 @@ func (s *SQLCommon) InsertDataArray(ctx context.Context, dataArray fftypes.DataA
 			for _, data := range dataArray {
 				s.callbacks.UUIDCollectionNSEvent(database.CollectionData, fftypes.ChangeEventTypeCreated, data.Namespace, data.ID)
 			}
-		}, sequences, false)
+		}, sequences, true /* we want the caller to be able to retry with individual upserts */)
 		if err != nil {
 			return err
 		}

--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -504,7 +504,7 @@ func (s *SQLCommon) GetMessages(ctx context.Context, filter database.Filter) (me
 	query, fop, fi, err := s.filterSelect(ctx, "", sq.Select(cols...).From("messages"), filter, msgFilterFieldMap,
 		[]interface{}{
 			&database.SortField{Field: "confirmed", Descending: true, Nulls: database.NullsFirst},
-			"created",
+			&database.SortField{Field: "created", Descending: true},
 		})
 	if err != nil {
 		return nil, nil, err

--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -217,7 +217,7 @@ func (s *SQLCommon) InsertMessages(ctx context.Context, messages []*fftypes.Mess
 				message.Sequence = sequences[i]
 				s.callbacks.OrderedUUIDCollectionNSEvent(database.CollectionMessages, fftypes.ChangeEventTypeCreated, message.Header.Namespace, message.Header.ID, message.Sequence)
 			}
-		}, sequences, false)
+		}, sequences, true /* we want the caller to be able to retry with individual upserts */)
 		if err != nil {
 			return err
 		}

--- a/internal/database/sqlcommon/pin_sql.go
+++ b/internal/database/sqlcommon/pin_sql.go
@@ -74,25 +74,67 @@ func (s *SQLCommon) UpsertPin(ctx context.Context, pin *fftypes.Pin) (err error)
 		log.L(ctx).Debugf("Existing pin returned at sequence %d", pin.Sequence)
 	} else {
 		pinRows.Close()
-		if pin.Sequence, err = s.insertTx(ctx, tx,
-			sq.Insert("pins").
-				Columns(pinColumns...).
-				Values(
-					pin.Masked,
-					pin.Hash,
-					pin.Batch,
-					pin.Index,
-					pin.Signer,
-					pin.Dispatched,
-					pin.Created,
-				),
-			func() {
-				s.callbacks.OrderedCollectionEvent(database.CollectionPins, fftypes.ChangeEventTypeCreated, pin.Sequence)
-			},
-		); err != nil {
+		if err = s.attemptPinInsert(ctx, tx, pin); err != nil {
 			return err
 		}
 
+	}
+
+	return s.commitTx(ctx, tx, autoCommit)
+}
+
+func (s *SQLCommon) attemptPinInsert(ctx context.Context, tx *txWrapper, pin *fftypes.Pin) (err error) {
+	pin.Sequence, err = s.insertTx(ctx, tx,
+		s.setPinInsertValues(sq.Insert("pins").Columns(pinColumns...), pin),
+		func() {
+			log.L(ctx).Debugf("Triggering creation event for pin %d", pin.Sequence)
+			s.callbacks.OrderedCollectionEvent(database.CollectionPins, fftypes.ChangeEventTypeCreated, pin.Sequence)
+		},
+	)
+	return err
+}
+
+func (s *SQLCommon) setPinInsertValues(query sq.InsertBuilder, pin *fftypes.Pin) sq.InsertBuilder {
+	return query.Values(
+		pin.Masked,
+		pin.Hash,
+		pin.Batch,
+		pin.Index,
+		pin.Signer,
+		pin.Dispatched,
+		pin.Created,
+	)
+}
+
+func (s *SQLCommon) InsertPins(ctx context.Context, pins []*fftypes.Pin) error {
+	ctx, tx, autoCommit, err := s.beginOrUseTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.rollbackTx(ctx, tx, autoCommit)
+
+	if s.features.MultiRowInsert {
+		query := sq.Insert("pins").Columns(pinColumns...)
+		for _, pin := range pins {
+			query = s.setPinInsertValues(query, pin)
+		}
+		sequences := make([]int64, len(pins))
+		err := s.insertTxRows(ctx, tx, query, func() {
+			for i, pin := range pins {
+				pin.Sequence = sequences[i]
+				s.callbacks.OrderedCollectionEvent(database.CollectionPins, fftypes.ChangeEventTypeCreated, pin.Sequence)
+			}
+		}, sequences, true /* we want the caller to be able to retry with individual upserts */)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Fall back to individual inserts grouped in a TX
+		for _, pin := range pins {
+			if err := s.attemptPinInsert(ctx, tx, pin); err != nil {
+				return err
+			}
+		}
 	}
 
 	return s.commitTx(ctx, tx, autoCommit)

--- a/internal/database/sqlcommon/pin_sql_test.go
+++ b/internal/database/sqlcommon/pin_sql_test.go
@@ -141,6 +141,61 @@ func TestUpsertPinFailCommit(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestInsertPinsBeginFail(t *testing.T) {
+	s, mock := newMockProvider().init()
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
+	err := s.InsertPins(context.Background(), []*fftypes.Pin{})
+	assert.Regexp(t, "FF10114", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+	s.callbacks.AssertExpectations(t)
+}
+
+func TestInsertPinsMultiRowOK(t *testing.T) {
+	s, mock := newMockProvider().init()
+	s.features.MultiRowInsert = true
+	s.fakePSQLInsert = true
+
+	pin1 := &fftypes.Pin{Hash: fftypes.NewRandB32()}
+	pin2 := &fftypes.Pin{Hash: fftypes.NewRandB32()}
+	s.callbacks.On("OrderedCollectionEvent", database.CollectionPins, fftypes.ChangeEventTypeCreated, int64(1001))
+	s.callbacks.On("OrderedCollectionEvent", database.CollectionPins, fftypes.ChangeEventTypeCreated, int64(1002))
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT.*").WillReturnRows(sqlmock.NewRows([]string{sequenceColumn}).
+		AddRow(int64(1001)).
+		AddRow(int64(1002)),
+	)
+	mock.ExpectCommit()
+	err := s.InsertPins(context.Background(), []*fftypes.Pin{pin1, pin2})
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+	s.callbacks.AssertExpectations(t)
+}
+
+func TestInsertPinsMultiRowFail(t *testing.T) {
+	s, mock := newMockProvider().init()
+	s.features.MultiRowInsert = true
+	s.fakePSQLInsert = true
+	pin1 := &fftypes.Pin{Hash: fftypes.NewRandB32()}
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT.*").WillReturnError(fmt.Errorf("pop"))
+	err := s.InsertPins(context.Background(), []*fftypes.Pin{pin1})
+	assert.Regexp(t, "FF10116", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+	s.callbacks.AssertExpectations(t)
+}
+
+func TestInsertPinsSingleRowFail(t *testing.T) {
+	s, mock := newMockProvider().init()
+	pin1 := &fftypes.Pin{Hash: fftypes.NewRandB32()}
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT.*").WillReturnError(fmt.Errorf("pop"))
+	err := s.InsertPins(context.Background(), []*fftypes.Pin{pin1})
+	assert.Regexp(t, "FF10116", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+	s.callbacks.AssertExpectations(t)
+}
+
 func TestGetPinQueryFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))

--- a/internal/database/sqlcommon/sqlcommon.go
+++ b/internal/database/sqlcommon/sqlcommon.go
@@ -429,12 +429,11 @@ func (s *SQLCommon) commitTx(ctx context.Context, tx *txWrapper, autoCommit bool
 	// Only at this stage do we write to the special events Database table, so we know
 	// regardless of the higher level logic, the events are always written at this point
 	// at the end of the transaction
-	for _, event := range tx.preCommitEvents {
-		if err := s.insertEventPreCommit(ctx, tx, event); err != nil {
+	if len(tx.preCommitEvents) > 0 {
+		if err := s.insertEventsPreCommit(ctx, tx, tx.preCommitEvents); err != nil {
 			s.rollbackTx(ctx, tx, false)
 			return err
 		}
-		l.Infof("Emitted %s event %s ref=%s (sequence=%d)", event.Type, event.ID, event.Reference, event.Sequence)
 	}
 
 	l.Debugf(`SQL-> commit`)

--- a/internal/database/sqlcommon/sqlcommon.go
+++ b/internal/database/sqlcommon/sqlcommon.go
@@ -281,8 +281,8 @@ func (s *SQLCommon) insertTxRows(ctx context.Context, tx *txWrapper, q sq.Insert
 	if err != nil {
 		return i18n.WrapError(ctx, err, i18n.MsgDBQueryBuildFailed)
 	}
-	l.Debugf(`SQL-> insert: %s`, shortenSQL(sqlQuery))
-	l.Tracef(`SQL-> insert args: %+v`, args)
+	l.Debugf(`SQL-> insert %s`, shortenSQL(sqlQuery))
+	l.Tracef(`SQL-> insert query: %s (args: %+v)`, sqlQuery, args)
 	if useQuery {
 		result, err := tx.sqlTX.QueryContext(ctx, sqlQuery, args...)
 		for i := 0; i < len(sequences) && err == nil; i++ {
@@ -329,7 +329,7 @@ func (s *SQLCommon) deleteTx(ctx context.Context, tx *txWrapper, q sq.DeleteBuil
 		return i18n.WrapError(ctx, err, i18n.MsgDBQueryBuildFailed)
 	}
 	l.Debugf(`SQL-> delete: %s`, shortenSQL(sqlQuery))
-	l.Tracef(`SQL-> delete args: %+v`, args)
+	l.Debugf(`SQL-> delete args: %+v`, args)
 	res, err := tx.sqlTX.ExecContext(ctx, sqlQuery, args...)
 	if err != nil {
 		l.Errorf(`SQL delete failed: %s sql=[ %s ]: %s`, err, sqlQuery, err)
@@ -354,7 +354,7 @@ func (s *SQLCommon) updateTx(ctx context.Context, tx *txWrapper, q sq.UpdateBuil
 		return -1, i18n.WrapError(ctx, err, i18n.MsgDBQueryBuildFailed)
 	}
 	l.Debugf(`SQL-> update: %s`, shortenSQL(sqlQuery))
-	l.Tracef(`SQL-> update args: %+v`, args)
+	l.Debugf(`SQL-> update query: %s (args: %+v)`, sqlQuery, args)
 	res, err := tx.sqlTX.ExecContext(ctx, sqlQuery, args...)
 	if err != nil {
 		l.Errorf(`SQL update failed: %s sql=[ %s ]`, err, sqlQuery)

--- a/internal/database/sqlcommon/sqlcommon.go
+++ b/internal/database/sqlcommon/sqlcommon.go
@@ -52,6 +52,8 @@ type txWrapper struct {
 	tableLocks      []string
 }
 
+// shortenSQL grabs the first three words of a SQL statement, for minimal debug logging (SQL statements can be huge
+// even without args in the example of a multi-row insert - so we reserve full logging for trace level only.)
 func shortenSQL(sqlString string) string {
 	buff := strings.Builder{}
 	spaceCount := 0

--- a/internal/database/sqlcommon/sqlcommon.go
+++ b/internal/database/sqlcommon/sqlcommon.go
@@ -329,7 +329,7 @@ func (s *SQLCommon) deleteTx(ctx context.Context, tx *txWrapper, q sq.DeleteBuil
 		return i18n.WrapError(ctx, err, i18n.MsgDBQueryBuildFailed)
 	}
 	l.Debugf(`SQL-> delete: %s`, shortenSQL(sqlQuery))
-	l.Debugf(`SQL-> delete args: %+v`, args)
+	l.Tracef(`SQL-> delete query: %s args: %+v`, sqlQuery, args)
 	res, err := tx.sqlTX.ExecContext(ctx, sqlQuery, args...)
 	if err != nil {
 		l.Errorf(`SQL delete failed: %s sql=[ %s ]: %s`, err, sqlQuery, err)
@@ -354,7 +354,7 @@ func (s *SQLCommon) updateTx(ctx context.Context, tx *txWrapper, q sq.UpdateBuil
 		return -1, i18n.WrapError(ctx, err, i18n.MsgDBQueryBuildFailed)
 	}
 	l.Debugf(`SQL-> update: %s`, shortenSQL(sqlQuery))
-	l.Debugf(`SQL-> update query: %s (args: %+v)`, sqlQuery, args)
+	l.Tracef(`SQL-> update query: %s (args: %+v)`, sqlQuery, args)
 	res, err := tx.sqlTX.ExecContext(ctx, sqlQuery, args...)
 	if err != nil {
 		l.Errorf(`SQL update failed: %s sql=[ %s ]`, err, sqlQuery)

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -291,8 +291,8 @@ func (ag *aggregator) processPins(ctx context.Context, pins []*fftypes.Pin, stat
 		}
 	}
 
-	err = ag.eventPoller.commitOffset(ctx, pins[len(pins)-1].Sequence)
-	return err
+	ag.eventPoller.commitOffset(pins[len(pins)-1].Sequence)
+	return nil
 }
 
 func (ag *aggregator) checkOnchainConsistency(ctx context.Context, msg *fftypes.Message, pin *fftypes.Pin) (valid bool, err error) {

--- a/internal/events/aggregator_batch_state_test.go
+++ b/internal/events/aggregator_batch_state_test.go
@@ -36,8 +36,10 @@ func TestFlushPinsFail(t *testing.T) {
 
 	bs.MarkMessageDispatched(ag.ctx, fftypes.NewUUID(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
-			ID: fftypes.NewUUID(),
+			ID:     fftypes.NewUUID(),
+			Topics: fftypes.FFStringArray{"topic1"},
 		},
+		Pins: fftypes.FFStringArray{"pin1"},
 	}, 0)
 
 	err := bs.flushPins(ag.ctx)

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"testing"
 
 	"github.com/hyperledger/firefly/internal/config"
@@ -2205,26 +2204,4 @@ func TestMigrateManifestFail(t *testing.T) {
 	})
 
 	assert.Nil(t, manifest)
-}
-
-func TestExtractBatchMessagePin(t *testing.T) {
-	ag, cancel := newTestAggregator()
-	defer cancel()
-
-	b, err := ioutil.ReadFile("/tmp/4ba80bc9-28c3-494a-84a0-a6ae2d647f96.batch.json")
-	assert.NoError(t, err)
-	var bp fftypes.BatchPersisted
-	err = json.Unmarshal(b, &bp)
-	assert.NoError(t, err)
-
-	var manifest *fftypes.BatchManifest
-	err = bp.Manifest.Unmarshal(context.Background(), &manifest)
-	assert.NoError(t, err)
-
-	totalBatchPins, msgEntry, msgBaseIndex := ag.extractBatchMessagePin(manifest, 100)
-	assert.Equal(t, int64(len(manifest.Messages)), totalBatchPins)
-	assert.Equal(t, "86f4a5c8-e7ad-4df1-8af9-ff5f8f579827", msgEntry.ID.String())
-	assert.Equal(t, int64(100), msgBaseIndex)
-
-	// b7a08c51-ef24-4afd-8da2-f85568ae8208 was the one that we dispatched for 100
 }

--- a/internal/events/batch_pin_complete_test.go
+++ b/internal/events/batch_pin_complete_test.go
@@ -140,7 +140,7 @@ func TestBatchPinCompleteOkBroadcast(t *testing.T) {
 	mdi.On("InsertEvent", mock.Anything, mock.MatchedBy(func(e *fftypes.Event) bool {
 		return e.Type == fftypes.EventTypeBlockchainEventReceived
 	})).Return(nil).Times(2)
-	mdi.On("UpsertPin", mock.Anything, mock.Anything).Return(nil).Once()
+	mdi.On("InsertPins", mock.Anything, mock.Anything).Return(nil).Once()
 	mdi.On("UpsertBatch", mock.Anything, mock.Anything).Return(nil).Once()
 	mbi := &blockchainmocks.Plugin{}
 
@@ -198,6 +198,7 @@ func TestBatchPinCompleteOkPrivate(t *testing.T) {
 
 	mdi := em.database.(*databasemocks.Plugin)
 	mdi.On("RunAsGroup", mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertPins", mock.Anything, mock.Anything).Return(fmt.Errorf("These pins have been seen before")) // simulate replay fallback
 	mdi.On("UpsertPin", mock.Anything, mock.Anything).Return(nil)
 	mbi := &blockchainmocks.Plugin{}
 
@@ -764,6 +765,7 @@ func TestPersistContextsFail(t *testing.T) {
 	defer cancel()
 
 	mdi := em.database.(*databasemocks.Plugin)
+	mdi.On("InsertPins", mock.Anything, mock.Anything).Return(fmt.Errorf("duplicate pins"))
 	mdi.On("UpsertPin", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := em.persistContexts(em.ctx, &blockchain.BatchPin{

--- a/internal/events/batch_pin_complete_test.go
+++ b/internal/events/batch_pin_complete_test.go
@@ -75,7 +75,7 @@ func sampleBatch(t *testing.T, batchType fftypes.BatchType, txType fftypes.Trans
 	}
 	err := msg.Seal(context.Background())
 	assert.NoError(t, err)
-	batch.Hash = batch.Payload.Hash()
+	batch.Hash = fftypes.HashString(batch.Manifest().String())
 	return batch
 }
 

--- a/internal/events/dx_callbacks_test.go
+++ b/internal/events/dx_callbacks_test.go
@@ -116,7 +116,15 @@ func TestMessageReceiveOkBadBatchIgnored(t *testing.T) {
 	em, cancel := newTestEventManager(t)
 	defer cancel()
 
-	_, b := sampleBatchTransfer(t, fftypes.TransactionTypeTokenPool)
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypePrivate, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	batch.Payload.TX.Type = fftypes.TransactionTypeTokenPool
+	b, _ := json.Marshal(&fftypes.TransportWrapper{
+		Batch: batch,
+		Group: &fftypes.Group{
+			Hash: fftypes.NewRandB32(),
+		},
+	})
 
 	org1 := newTestOrg("org1")
 	node1 := newTestNode("node1", org1)

--- a/internal/events/event_poller.go
+++ b/internal/events/event_poller.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,15 +29,16 @@ import (
 )
 
 type eventPoller struct {
-	ctx           context.Context
-	database      database.Plugin
-	shoulderTaps  chan bool
-	eventNotifier *eventNotifier
-	closed        chan struct{}
-	offsetID      int64
-	pollingOffset int64
-	mux           sync.Mutex
-	conf          *eventPollerConf
+	ctx             context.Context
+	database        database.Plugin
+	shoulderTaps    chan bool
+	eventNotifier   *eventNotifier
+	closed          chan struct{}
+	offsetCommitted chan int64
+	offsetID        int64
+	pollingOffset   int64
+	mux             sync.Mutex
+	conf            *eventPollerConf
 }
 
 type newEventsHandler func(events []fftypes.LocallySequenced) (bool, error)
@@ -62,12 +63,13 @@ type eventPollerConf struct {
 
 func newEventPoller(ctx context.Context, di database.Plugin, en *eventNotifier, conf *eventPollerConf) *eventPoller {
 	ep := &eventPoller{
-		ctx:           log.WithLogField(ctx, "role", fmt.Sprintf("ep[%s:%s]", conf.namespace, conf.offsetName)),
-		database:      di,
-		shoulderTaps:  make(chan bool, 1),
-		eventNotifier: en,
-		closed:        make(chan struct{}),
-		conf:          conf,
+		ctx:             log.WithLogField(ctx, "role", fmt.Sprintf("ep[%s:%s]", conf.namespace, conf.offsetName)),
+		database:        di,
+		shoulderTaps:    make(chan bool, 1),
+		offsetCommitted: make(chan int64, 1),
+		eventNotifier:   en,
+		closed:          make(chan struct{}),
+		conf:            conf,
 	}
 	if ep.conf.maybeRewind == nil {
 		ep.conf.maybeRewind = func() (bool, int64) { return false, -1 }
@@ -121,6 +123,7 @@ func (ep *eventPoller) start() {
 	}
 	go ep.newEventNotifications()
 	go ep.eventLoop()
+	go ep.offsetCommitLoop()
 }
 
 func (ep *eventPoller) rewindPollingOffset(offset int64) {
@@ -138,21 +141,20 @@ func (ep *eventPoller) getPollingOffset() int64 {
 	return ep.pollingOffset
 }
 
-func (ep *eventPoller) commitOffset(ctx context.Context, offset int64) error {
+func (ep *eventPoller) commitOffset(offset int64) {
 	// Next polling cycle should start one higher than this offset
+	ep.mux.Lock()
 	ep.pollingOffset = offset
+	ep.mux.Unlock()
 
-	// Must be called from the event polling routine
-	l := log.L(ctx)
 	// No persistence for ephemeral (non-durable) subscriptions
 	if !ep.conf.ephemeral {
-		u := database.OffsetQueryFactory.NewUpdate(ep.ctx).Set("current", ep.pollingOffset)
-		if err := ep.database.UpdateOffset(ctx, ep.offsetID, u); err != nil {
-			return err
+		// We do this in the background, as it is an expensive full DB commit
+		select {
+		case ep.offsetCommitted <- offset:
+		default:
 		}
 	}
-	l.Debugf("Event polling offset committed %d", ep.pollingOffset)
-	return nil
 }
 
 func (ep *eventPoller) readPage() ([]fftypes.LocallySequenced, error) {
@@ -187,7 +189,10 @@ func (ep *eventPoller) readPage() ([]fftypes.LocallySequenced, error) {
 func (ep *eventPoller) eventLoop() {
 	l := log.L(ep.ctx)
 	l.Debugf("Started event detector")
-	defer close(ep.closed)
+	defer func() {
+		close(ep.closed)
+		close(ep.offsetCommitted)
+	}()
 
 	for {
 		// Read messages from the DB - in an error condition we retry until success, or a closed context
@@ -216,6 +221,23 @@ func (ep *eventPoller) eventLoop() {
 				return
 			}
 		}
+	}
+}
+
+func (ep *eventPoller) offsetCommitLoop() {
+	l := log.L(ep.ctx)
+	for range ep.offsetCommitted {
+		_ = ep.conf.retry.Do(ep.ctx, "process events", func(attempt int) (retry bool, err error) {
+			ep.mux.Lock()
+			pollingOffset := ep.pollingOffset
+			ep.mux.Unlock()
+			u := database.OffsetQueryFactory.NewUpdate(ep.ctx).Set("current", pollingOffset)
+			if err := ep.database.UpdateOffset(ep.ctx, ep.offsetID, u); err != nil {
+				return true, err
+			}
+			l.Debugf("Event polling offset committed %d", pollingOffset)
+			return false, nil
+		})
 	}
 }
 

--- a/internal/events/persist_batch.go
+++ b/internal/events/persist_batch.go
@@ -24,6 +24,11 @@ import (
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
 
+type messageAndData struct {
+	message *fftypes.Message
+	data    fftypes.DataArray
+}
+
 func (em *eventManager) persistBatchFromBroadcast(ctx context.Context /* db TX context*/, batch *fftypes.Batch, onchainHash *fftypes.Bytes32) (valid bool, err error) {
 
 	if !onchainHash.Equals(batch.Hash) {
@@ -42,6 +47,11 @@ func (em *eventManager) persistBatch(ctx context.Context /* db TX context*/, bat
 
 	if batch.ID == nil || batch.Payload.TX.ID == nil {
 		l.Errorf("Invalid batch '%s'. Missing ID or transaction ID (%v)", batch.ID, batch.Payload.TX.ID)
+		return nil, false, nil // This is not retryable. skip this batch
+	}
+
+	if len(batch.Payload.Messages) == 0 || len(batch.Payload.Data) == 0 {
+		l.Errorf("Invalid batch '%s'. Missing messages (%d) or data (%d)", batch.ID, len(batch.Payload.Messages), len(batch.Payload.Data))
 		return nil, false, nil // This is not retryable. skip this batch
 	}
 
@@ -80,138 +90,196 @@ func (em *eventManager) persistBatch(ctx context.Context /* db TX context*/, bat
 		return nil, false, err // a persistence failure here is considered retryable (so returned)
 	}
 
-	valid, err = em.persistBatchContent(ctx, batch)
+	valid, err = em.validateAndPersistBatchContent(ctx, batch)
 	if err != nil || !valid {
 		return nil, valid, err
 	}
 	return persistedBatch, valid, err
 }
 
-func (em *eventManager) persistBatchContent(ctx context.Context, batch *fftypes.Batch) (valid bool, err error) {
-
-	optimization := em.getOptimization(ctx, batch)
+func (em *eventManager) validateAndPersistBatchContent(ctx context.Context, batch *fftypes.Batch) (valid bool, err error) {
 
 	// Insert the data entries
 	dataByID := make(map[fftypes.UUID]*fftypes.Data)
 	for i, data := range batch.Payload.Data {
-		if valid, err = em.persistBatchData(ctx, batch, i, data, optimization); !valid || err != nil {
-			return valid, err
+		if valid = em.validateBatchData(ctx, batch, i, data); !valid {
+			return false, nil
 		}
 		dataByID[*data.ID] = data
 	}
 
 	// Insert the message entries
 	for i, msg := range batch.Payload.Messages {
-		if valid, err = em.persistBatchMessage(ctx, batch, i, msg, optimization); !valid || err != nil {
-			return valid, err
+		if valid = em.validateBatchMessage(ctx, batch, i, msg); !valid {
+			return false, nil
 		}
-		dataInBatch := true
+	}
+
+	// We require that the batch contains exactly the set of data that is in the messages - no more or less.
+	// While this means an edge case inefficiencly of re-transmission of data when sent in multiple messages,
+	// that is outweighed by the efficiency it allows in the insertion logic in the majority case.
+	matchedData := make(map[fftypes.UUID]bool)
+	matchedMsgs := make([]*messageAndData, len(batch.Payload.Messages))
+	for iMsg, msg := range batch.Payload.Messages {
 		msgData := make(fftypes.DataArray, len(msg.Data))
 		for di, dataRef := range msg.Data {
 			msgData[di] = dataByID[*dataRef.ID]
 			if msgData[di] == nil || !msgData[di].Hash.Equals(dataRef.Hash) {
-				log.L(ctx).Debugf("Message '%s' in batch '%s' - data not in-line in batch id='%s' hash='%s'", msg.Header.ID, batch.ID, dataRef.ID, dataRef.Hash)
-				dataInBatch = false
-				break
+				log.L(ctx).Errorf("Message '%s' in batch '%s' - data not in-line in batch id='%s' hash='%s'", msg.Header.ID, batch.ID, dataRef.ID, dataRef.Hash)
+				return false, nil
 			}
+			matchedData[*dataRef.ID] = true
 		}
-		if dataInBatch {
-			// We can push the complete message into the cache straight away
-			em.data.UpdateMessageCache(msg, msgData)
+		matchedMsgs[iMsg] = &messageAndData{
+			message: msg,
+			data:    msgData,
 		}
 	}
-
-	return true, nil
-}
-
-func (em *eventManager) getOptimization(ctx context.Context, batch *fftypes.Batch) database.UpsertOptimization {
-	localNode := em.ni.GetNodeUUID(ctx)
-	if batch.Node == nil {
-		// This is from a node that hasn't yet completed registration, so we can't optimize
-		return database.UpsertOptimizationSkip
-	} else if localNode != nil && localNode.Equals(batch.Node) {
-		// We sent the batch, so we should already have all the messages and data locally - optimize the DB operations for that
-		return database.UpsertOptimizationExisting
+	if len(matchedData) != len(dataByID) {
+		log.L(ctx).Errorf("Batch '%s' contains %d unique data, but %d are referenced from messages", batch.ID, len(dataByID), len(matchedData))
+		return false, nil
 	}
-	// We didn't send the batch, so all the data should be new - optimize the DB operations for that
-	return database.UpsertOptimizationNew
+
+	return em.persistBatchContent(ctx, batch, matchedMsgs)
 }
 
-func (em *eventManager) persistBatchData(ctx context.Context /* db TX context*/, batch *fftypes.Batch, i int, data *fftypes.Data, optimization database.UpsertOptimization) (bool, error) {
-	return em.persistReceivedData(ctx, i, data, "batch", batch.ID, optimization)
-}
-
-func (em *eventManager) persistReceivedData(ctx context.Context /* db TX context*/, i int, data *fftypes.Data, mType string, mID *fftypes.UUID, optimization database.UpsertOptimization) (bool, error) {
+func (em *eventManager) validateBatchData(ctx context.Context, batch *fftypes.Batch, i int, data *fftypes.Data) bool {
 
 	l := log.L(ctx)
-	l.Tracef("%s '%s' data %d: %+v", mType, mID, i, data)
+	l.Tracef("Batch '%s' data %d: %+v", batch.ID, i, data)
 
 	if data == nil {
-		l.Errorf("null data entry %d in %s '%s'", i, mType, mID)
-		return false, nil // skip data entry
+		l.Errorf("null data entry %d in batch '%s'", i, batch.ID)
+		return false
 	}
 
 	hash, err := data.CalcHash(ctx)
 	if err != nil {
-		log.L(ctx).Errorf("Invalid data entry %d in %s '%s': %s", i, mType, mID, err)
-		return false, nil //
+		log.L(ctx).Errorf("Invalid data entry %d in batch '%s': %s", i, batch.ID, err)
+		return false
 	}
 	if data.Hash == nil || *data.Hash != *hash {
-		log.L(ctx).Errorf("Invalid data entry %d in %s '%s': Hash=%v Expected=%v", i, mType, mID, data.Hash, hash)
-		return false, nil // skip data entry
+		log.L(ctx).Errorf("Invalid data entry %d in batch '%s': Hash=%v Expected=%v", i, batch.ID, data.Hash, hash)
+		return false
 	}
 
-	// Insert the data, ensuring the hash doesn't change
-	if err := em.database.UpsertData(ctx, data, optimization); err != nil {
-		if err == database.HashMismatch {
-			log.L(ctx).Errorf("Invalid data entry %d in %s '%s'. Hash mismatch with existing record with same UUID '%s' Hash=%s", i, mType, mID, data.ID, data.Hash)
-			return false, nil // This is not retryable. skip this data entry
-		}
-		log.L(ctx).Errorf("Failed to insert data entry %d in %s '%s': %s", i, mType, mID, err)
-		return false, err // a persistence failure here is considered retryable (so returned)
-	}
-
-	return true, nil
+	return true
 }
 
-func (em *eventManager) persistBatchMessage(ctx context.Context /* db TX context*/, batch *fftypes.Batch, i int, msg *fftypes.Message, optimization database.UpsertOptimization) (bool, error) {
-	if msg != nil {
-		if msg.Header.Author != batch.Author || msg.Header.Key != batch.Key {
-			log.L(ctx).Errorf("Mismatched key/author '%s'/'%s' on message entry %d in batch '%s'", msg.Header.Key, msg.Header.Author, i, batch.ID)
-			return false, nil // skip entry
-		}
-		msg.BatchID = batch.ID
-	}
+func (em *eventManager) validateBatchMessage(ctx context.Context, batch *fftypes.Batch, i int, msg *fftypes.Message) bool {
 
-	return em.persistReceivedMessage(ctx, i, msg, "batch", batch.ID, optimization)
-}
-
-func (em *eventManager) persistReceivedMessage(ctx context.Context /* db TX context*/, i int, msg *fftypes.Message, mType string, mID *fftypes.UUID, optimization database.UpsertOptimization) (bool, error) {
 	l := log.L(ctx)
-	l.Tracef("%s '%s' message %d: %+v", mType, mID, i, msg)
-
 	if msg == nil {
-		l.Errorf("null message entry %d in %s '%s'", i, mType, mID)
-		return false, nil // skip entry
+		l.Errorf("null message entry %d in batch '%s'", i, batch.ID)
+		return false
 	}
+
+	if msg.Header.Author != batch.Author || msg.Header.Key != batch.Key {
+		log.L(ctx).Errorf("Mismatched key/author '%s'/'%s' on message entry %d in batch '%s'", msg.Header.Key, msg.Header.Author, i, batch.ID)
+		return false
+	}
+	msg.BatchID = batch.ID
+
+	l.Tracef("Batch '%s' message %d: %+v", batch.ID, i, msg)
 
 	err := msg.Verify(ctx)
 	if err != nil {
-		l.Errorf("Invalid message entry %d in %s '%s': %s", i, mType, mID, err)
-		return false, nil // skip message entry
+		l.Errorf("Invalid message entry %d in batch '%s': %s", i, batch.ID, err)
+		return false
 	}
-
-	// Insert the message, ensuring the hash doesn't change.
-	// We do not mark it as confirmed at this point, that's the job of the aggregator.
+	// Set the state to pending, for the insertion stage
 	msg.State = fftypes.MessageStatePending
-	if err = em.database.UpsertMessage(ctx, msg, optimization); err != nil {
-		if err == database.HashMismatch {
-			l.Errorf("Invalid message entry %d in %s '%s'. Hash mismatch with existing record with same UUID '%s' Hash=%s", i, mType, mID, msg.Header.ID, msg.Hash)
-			return false, nil // This is not retryable. skip this data entry
+
+	return true
+}
+
+func (em *eventManager) sentByUs(ctx context.Context, batch *fftypes.Batch) bool {
+	localNode := em.ni.GetNodeUUID(ctx)
+	if batch.Node == nil {
+		// This is from a node that hasn't yet completed registration, so we can't optimize
+		return false
+	} else if batch.Node.Equals(localNode) {
+		// We sent the batch, so we should already have all the messages and data locally
+		return true
+	}
+	// We didn't send the batch, so all the data should be new - optimize the DB operations for that
+	return false
+}
+
+func (em *eventManager) verifyAlreadyStored(ctx context.Context, batch *fftypes.Batch) (valid bool, err error) {
+	for _, msg := range batch.Payload.Messages {
+		msgLocal, _, _, err := em.data.GetMessageWithDataCached(ctx, msg.Header.ID)
+		if err != nil {
+			return false, err
 		}
-		l.Errorf("Failed to insert message entry %d in %s '%s': %s", i, mType, mID, err)
-		return false, err // a persistence failure here is considered retryable (so returned)
+		if msgLocal == nil {
+			log.L(ctx).Errorf("Message entry %s in batch sent by this node, was not found", msg.Header.ID)
+			return false, nil
+		}
+		if !msgLocal.Hash.Equals(msg.Hash) {
+			log.L(ctx).Errorf("Message entry %s hash mismatch with already stored. Local=%s BatchMsg=%s", msg.Header.ID, msgLocal.Hash, msg.Hash)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (em *eventManager) persistBatchContent(ctx context.Context, batch *fftypes.Batch, matchedMsgs []*messageAndData) (valid bool, err error) {
+
+	// We want to insert the messages and data in the most efficient way we can.
+	// If we are sure we wrote the batch, then we do a cached lookup of each in turn - which is efficient
+	// because all of those should be in the cache as we wrote them recently.
+	if em.sentByUs(ctx, batch) {
+		allStored, err := em.verifyAlreadyStored(ctx, batch)
+		if err != nil {
+			return false, err
+		}
+		if allStored {
+			return true, nil
+		}
+		// Fall through otherwise
+		log.L(ctx).Warnf("Batch %s was sent by our UUID, but the content was not already stored. Assuming node has been reset", batch.ID)
 	}
 
+	// Otherwise try a one-shot insert of all the data, on the basis it's likely unique
+	err = em.database.InsertDataArray(ctx, batch.Payload.Data)
+	if err != nil {
+		log.L(ctx).Debugf("Batch data insert optimization failed for batch '%s': %s", batch.ID, err)
+		// Fall back to individual upserts
+		for i, data := range batch.Payload.Data {
+			if err := em.database.UpsertData(ctx, data, database.UpsertOptimizationExisting); err != nil {
+				if err == database.HashMismatch {
+					log.L(ctx).Errorf("Invalid data entry %d in batch '%s'. Hash mismatch with existing record with same UUID '%s' Hash=%s", i, batch.ID, data.ID, data.Hash)
+					return false, nil
+				}
+				log.L(ctx).Errorf("Failed to insert data entry %d in batch '%s': %s", i, batch.ID, err)
+				return false, err
+			}
+		}
+	}
+
+	// Then the same one-shot insert of all the mesages, on the basis they are likely unique (even if
+	// one of the data elements wasn't unique). Likely reasons for exceptions here are idempotent replay,
+	// or a root broadcast where "em.sentByUs" returned false, but we actually sent it.
+	err = em.database.InsertMessages(ctx, batch.Payload.Messages)
+	if err != nil {
+		log.L(ctx).Debugf("Batch message insert optimization failed for batch '%s': %s", batch.ID, err)
+		// Fall back to individual upserts
+		for i, msg := range batch.Payload.Messages {
+			if err = em.database.UpsertMessage(ctx, msg, database.UpsertOptimizationExisting); err != nil {
+				if err == database.HashMismatch {
+					log.L(ctx).Errorf("Invalid message entry %d in batch'%s'. Hash mismatch with existing record with same UUID '%s' Hash=%s", i, batch.ID, msg.Header.ID, msg.Hash)
+					return false, nil // This is not retryable. skip this data entry
+				}
+				log.L(ctx).Errorf("Failed to insert message entry %d in batch '%s': %s", i, batch.ID, err)
+				return false, err // a persistence failure here is considered retryable (so returned)
+			}
+		}
+	}
+
+	// If all is well, update the cache before we return
+	for _, mm := range matchedMsgs {
+		em.data.UpdateMessageCache(mm.message, mm.data)
+	}
 	return true, nil
 }

--- a/internal/events/persist_batch_test.go
+++ b/internal/events/persist_batch_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly/mocks/databasemocks"
+	"github.com/hyperledger/firefly/mocks/datamocks"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
@@ -97,46 +98,36 @@ func TestPersistBatchFromBroadcastNoCacheDataNotInBatch(t *testing.T) {
 	mdi.On("UpsertBatch", em.ctx, mock.Anything).Return(nil)
 	mdi.On("UpsertMessage", em.ctx, mock.Anything, database.UpsertOptimizationSkip).Return(nil)
 
-	batch := &fftypes.Batch{
-		BatchHeader: fftypes.BatchHeader{
-			ID: fftypes.NewUUID(),
-			SignerRef: fftypes.SignerRef{
-				Author: "did:firefly:org/12345",
-				Key:    "0x12345",
-			},
-		},
-		Payload: fftypes.BatchPayload{
-			TX: fftypes.TransactionRef{
-				ID:   fftypes.NewUUID(),
-				Type: fftypes.TransactionTypeBatchPin,
-			},
-			Messages: []*fftypes.Message{
-				{
-					Header: fftypes.MessageHeader{
-						ID:   fftypes.NewUUID(),
-						Type: fftypes.MessageTypeDefinition,
-						SignerRef: fftypes.SignerRef{
-							Author: "did:firefly:org/12345",
-							Key:    "0x12345",
-						},
-						TxType: fftypes.TransactionTypeBatchPin,
-					},
-					Data: fftypes.DataRefs{
-						{
-							ID:   fftypes.NewUUID(),
-							Hash: fftypes.NewRandB32(),
-						},
-					},
-				},
-			},
-			Data: nil,
-		},
-	}
-	batch.Payload.Messages[0].Seal(em.ctx)
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	data.ID = fftypes.NewUUID()
+	_ = data.Seal(em.ctx, nil)
 	batch.Hash = fftypes.HashString(batch.Manifest().String())
 
 	valid, err := em.persistBatchFromBroadcast(em.ctx, batch, batch.Hash)
-	assert.True(t, valid)
+	assert.False(t, valid)
+	assert.NoError(t, err)
+
+}
+
+func TestPersistBatchFromBroadcastExtraDataInBatch(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mdi.On("UpsertBatch", em.ctx, mock.Anything).Return(nil)
+	mdi.On("UpsertMessage", em.ctx, mock.Anything, database.UpsertOptimizationSkip).Return(nil)
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	data2 := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test2"`)}
+	_ = data2.Seal(em.ctx, nil)
+	batch.Payload.Data = append(batch.Payload.Data, data2)
+	batch.Hash = fftypes.HashString(batch.Manifest().String())
+
+	valid, err := em.persistBatchFromBroadcast(em.ctx, batch, batch.Hash)
+	assert.False(t, valid)
 	assert.NoError(t, err)
 
 }
@@ -146,31 +137,8 @@ func TestPersistBatchNilMessageEntryop(t *testing.T) {
 	em, cancel := newTestEventManager(t)
 	defer cancel()
 
-	mdi := em.database.(*databasemocks.Plugin)
-	mdi.On("UpsertBatch", em.ctx, mock.Anything).Return(nil)
-
-	batch := &fftypes.Batch{
-		BatchHeader: fftypes.BatchHeader{
-			ID: fftypes.NewUUID(),
-			SignerRef: fftypes.SignerRef{
-				Author: "did:firefly:org/12345",
-				Key:    "0x12345",
-			},
-		},
-		Payload: fftypes.BatchPayload{
-			TX: fftypes.TransactionRef{
-				ID:   fftypes.NewUUID(),
-				Type: fftypes.TransactionTypeBatchPin,
-			},
-			Messages: []*fftypes.Message{nil},
-			Data:     nil,
-		},
-	}
-	batch.Hash = fftypes.HashString(batch.Manifest().String())
-
-	valid, err := em.persistBatchFromBroadcast(em.ctx, batch, batch.Hash)
+	valid := em.validateBatchMessage(em.ctx, &fftypes.Batch{}, 0, nil)
 	assert.False(t, valid)
-	assert.NoError(t, err)
 
 }
 
@@ -188,5 +156,140 @@ func TestPersistBatchFromBroadcastBadHash(t *testing.T) {
 	ok, err := em.persistBatchFromBroadcast(em.ctx, batch, fftypes.NewRandB32())
 	assert.NoError(t, err)
 	assert.False(t, ok)
+
+}
+
+func TestPersistBatchContentSendByUsOK(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	batch.Node = testNodeID
+
+	mdm := em.data.(*datamocks.Manager)
+	mdm.On("GetMessageWithDataCached", em.ctx, batch.Payload.Messages[0].Header.ID).Return(batch.Payload.Messages[0], batch.Payload.Data, true, nil)
+
+	ok, err := em.persistBatchContent(em.ctx, batch, []*messageAndData{})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	mdm.AssertExpectations(t)
+}
+
+func TestPersistBatchContentSentByNil(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	batch.Node = nil
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mdi.On("InsertDataArray", mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertMessages", mock.Anything, mock.Anything).Return(nil)
+
+	ok, err := em.persistBatchContent(em.ctx, batch, []*messageAndData{})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistBatchContentSentByUsNotFoundFallback(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	batch.Node = testNodeID
+
+	mdm := em.data.(*datamocks.Manager)
+	mdm.On("GetMessageWithDataCached", em.ctx, batch.Payload.Messages[0].Header.ID).Return(nil, nil, false, nil)
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mdi.On("InsertDataArray", mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertMessages", mock.Anything, mock.Anything).Return(nil)
+
+	ok, err := em.persistBatchContent(em.ctx, batch, []*messageAndData{})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	mdm.AssertExpectations(t)
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistBatchContentSentByUsFoundMismatch(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	batch.Node = testNodeID
+
+	mdm := em.data.(*datamocks.Manager)
+	mdm.On("GetMessageWithDataCached", em.ctx, batch.Payload.Messages[0].Header.ID).Return(&fftypes.Message{
+		Header: fftypes.MessageHeader{
+			ID: fftypes.NewUUID(),
+		},
+	}, nil, true, nil)
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mdi.On("InsertDataArray", mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertMessages", mock.Anything, mock.Anything).Return(fmt.Errorf("optimization miss"))
+	mdi.On("UpsertMessage", mock.Anything, mock.Anything, database.UpsertOptimizationExisting).Return(database.HashMismatch)
+
+	ok, err := em.persistBatchContent(em.ctx, batch, []*messageAndData{})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	mdm.AssertExpectations(t)
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistBatchContentSentByUsFoundError(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+	batch.Node = testNodeID
+
+	mdm := em.data.(*datamocks.Manager)
+	mdm.On("GetMessageWithDataCached", em.ctx, batch.Payload.Messages[0].Header.ID).Return(nil, nil, false, fmt.Errorf("pop"))
+
+	ok, err := em.persistBatchContent(em.ctx, batch, []*messageAndData{})
+	assert.Regexp(t, "pop", err)
+	assert.False(t, ok)
+
+	mdm.AssertExpectations(t)
+
+}
+
+func TestPersistBatchContentDataHashMismatch(t *testing.T) {
+
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+
+	data := &fftypes.Data{ID: fftypes.NewUUID(), Value: fftypes.JSONAnyPtr(`"test"`)}
+	batch := sampleBatch(t, fftypes.BatchTypeBroadcast, fftypes.TransactionTypeBatchPin, fftypes.DataArray{data})
+
+	mdi := em.database.(*databasemocks.Plugin)
+	mdi.On("InsertDataArray", mock.Anything, mock.Anything).Return(fmt.Errorf("optimization miss"))
+	mdi.On("UpsertData", mock.Anything, mock.Anything, database.UpsertOptimizationExisting).Return(database.HashMismatch)
+
+	ok, err := em.persistBatchContent(em.ctx, batch, []*messageAndData{})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	mdi.AssertExpectations(t)
 
 }

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -291,5 +291,5 @@ var (
 	MsgFailedToRetrieve             = ffm("FF10372", "Failed to retrieve %s %s", 500)
 	MsgBlobMissingPublic            = ffm("FF10373", "Blob for data %s missing public payload reference while flushing batch", 500)
 	MsgDBMultiRowConfigError        = ffm("FF10374", "Database invalid configuration - using multi-row insert on DB plugin that does not support query syntax for input")
-	MsgDBNoSequence                 = ffm("FF10375", "Failed to retrieve sequence for insert row %d", 500)
+	MsgDBNoSequence                 = ffm("FF10375", "Failed to retrieve sequence for insert row %d (could mean duplicate insert)", 500)
 )

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -74,6 +74,7 @@ type privateMessaging struct {
 	maxBatchPayloadLength int64
 	metrics               metrics.Manager
 	operations            operations.Manager
+	orgFirstNodes         map[fftypes.UUID]*fftypes.Identity
 }
 
 func NewPrivateMessaging(ctx context.Context, di database.Plugin, im identity.Manager, dx dataexchange.Plugin, bi blockchain.Plugin, ba batch.Manager, dm data.Manager, sa syncasync.Bridge, bp batchpin.Submitter, mm metrics.Manager, om operations.Manager) (Manager, error) {
@@ -106,6 +107,7 @@ func NewPrivateMessaging(ctx context.Context, di database.Plugin, im identity.Ma
 		maxBatchPayloadLength: config.GetByteSize(config.PrivateMessagingBatchPayloadLimit),
 		metrics:               mm,
 		operations:            om,
+		orgFirstNodes:         make(map[fftypes.UUID]*fftypes.Identity),
 	}
 	pm.groupManager.groupCache = ccache.New(
 		// We use a LRU cache with a size-aware max

--- a/internal/privatemessaging/recipients.go
+++ b/internal/privatemessaging/recipients.go
@@ -56,6 +56,24 @@ func (pm *privateMessaging) resolveRecipientList(ctx context.Context, in *fftype
 	return err
 }
 
+func (pm *privateMessaging) getFirstNodeForOrg(ctx context.Context, identity *fftypes.Identity) (*fftypes.Identity, error) {
+	node := pm.orgFirstNodes[*identity.ID]
+	if node == nil && identity.Type == fftypes.IdentityTypeOrg {
+		fb := database.IdentityQueryFactory.NewFilterLimit(ctx, 1)
+		filter := fb.And(
+			fb.Eq("parent", identity.ID),
+			fb.Eq("type", fftypes.IdentityTypeNode),
+		)
+		nodes, _, err := pm.database.GetIdentities(ctx, filter)
+		if err != nil || len(nodes) == 0 {
+			return nil, err
+		}
+		node = nodes[0]
+		pm.orgFirstNodes[*identity.ID] = node
+	}
+	return node, nil
+}
+
 func (pm *privateMessaging) resolveNode(ctx context.Context, identity *fftypes.Identity, nodeInput string) (node *fftypes.Identity, err error) {
 	retryable := true
 	if nodeInput != "" {
@@ -64,19 +82,10 @@ func (pm *privateMessaging) resolveNode(ctx context.Context, identity *fftypes.I
 		// Find any node owned by this organization
 		inputIdentityDebugInfo := fmt.Sprintf("%s (%s)", identity.DID, identity.ID)
 		for identity != nil && node == nil {
-			var nodes []*fftypes.Identity
-			if identity.Type == fftypes.IdentityTypeOrg {
-				fb := database.IdentityQueryFactory.NewFilterLimit(ctx, 1)
-				filter := fb.And(
-					fb.Eq("parent", identity.ID),
-					fb.Eq("type", fftypes.IdentityTypeNode),
-				)
-				nodes, _, err = pm.database.GetIdentities(ctx, filter)
-			}
+			node, err = pm.getFirstNodeForOrg(ctx, identity)
 			switch {
-			case err == nil && len(nodes) > 0:
+			case err == nil && node != nil:
 				// This is an org, and it owns a node
-				node = nodes[0]
 			case err == nil && identity.Parent != nil:
 				// This identity has a parent, maybe that org owns a node
 				identity, err = pm.identity.CachedIdentityLookupByID(ctx, identity.Parent)

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -1193,6 +1193,29 @@ func (_m *Plugin) GetMessageByID(ctx context.Context, id *fftypes.UUID) (*fftype
 	return r0, r1
 }
 
+// GetMessageIDs provides a mock function with given fields: ctx, filter
+func (_m *Plugin) GetMessageIDs(ctx context.Context, filter database.Filter) ([]*fftypes.IDAndSequence, error) {
+	ret := _m.Called(ctx, filter)
+
+	var r0 []*fftypes.IDAndSequence
+	if rf, ok := ret.Get(0).(func(context.Context, database.Filter) []*fftypes.IDAndSequence); ok {
+		r0 = rf(ctx, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*fftypes.IDAndSequence)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, database.Filter) error); ok {
+		r1 = rf(ctx, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMessages provides a mock function with given fields: ctx, filter
 func (_m *Plugin) GetMessages(ctx context.Context, filter database.Filter) ([]*fftypes.Message, *database.FilterResult, error) {
 	ret := _m.Called(ctx, filter)

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2291,6 +2291,20 @@ func (_m *Plugin) InsertOperation(ctx context.Context, operation *fftypes.Operat
 	return r0
 }
 
+// InsertPins provides a mock function with given fields: ctx, pins
+func (_m *Plugin) InsertPins(ctx context.Context, pins []*fftypes.Pin) error {
+	ret := _m.Called(ctx, pins)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*fftypes.Pin) error); ok {
+		r0 = rf(ctx, pins)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // InsertTransaction provides a mock function with given fields: ctx, data
 func (_m *Plugin) InsertTransaction(ctx context.Context, data *fftypes.Transaction) error {
 	ret := _m.Called(ctx, data)

--- a/mocks/datamocks/manager.go
+++ b/mocks/datamocks/manager.go
@@ -193,6 +193,38 @@ func (_m *Manager) HydrateBatch(ctx context.Context, persistedBatch *fftypes.Bat
 	return r0, r1
 }
 
+// PeekMessageCache provides a mock function with given fields: ctx, id, options
+func (_m *Manager) PeekMessageCache(ctx context.Context, id *fftypes.UUID, options ...data.CacheReadOption) (*fftypes.Message, fftypes.DataArray) {
+	_va := make([]interface{}, len(options))
+	for _i := range options {
+		_va[_i] = options[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, id)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *fftypes.Message
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, ...data.CacheReadOption) *fftypes.Message); ok {
+		r0 = rf(ctx, id, options...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.Message)
+		}
+	}
+
+	var r1 fftypes.DataArray
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID, ...data.CacheReadOption) fftypes.DataArray); ok {
+		r1 = rf(ctx, id, options...)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(fftypes.DataArray)
+		}
+	}
+
+	return r0, r1
+}
+
 // ResolveInlineData provides a mock function with given fields: ctx, msg
 func (_m *Manager) ResolveInlineData(ctx context.Context, msg *data.NewMessage) error {
 	ret := _m.Called(ctx, msg)

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -96,6 +96,9 @@ type iMessageCollection interface {
 	// GetMessages - List messages, reverse sorted (newest first) by Confirmed then Created, with pagination, and simple must filters
 	GetMessages(ctx context.Context, filter Filter) (message []*fftypes.Message, res *FilterResult, err error)
 
+	// GetMessageIDs - Retrieves messages, but only querying the messages ID (no other fields)
+	GetMessageIDs(ctx context.Context, filter Filter) (ids []*fftypes.IDAndSequence, err error)
+
 	// GetMessagesForData - List messages where there is a data reference to the specified ID
 	GetMessagesForData(ctx context.Context, dataID *fftypes.UUID, filter Filter) (message []*fftypes.Message, res *FilterResult, err error)
 }

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -185,6 +185,9 @@ type iOffsetCollection interface {
 }
 
 type iPinCollection interface {
+	// InsertPins - Inserts a list of pins - fails if they already exist, so caller can fall back to UpsertPin individually
+	InsertPins(ctx context.Context, pins []*fftypes.Pin) (err error)
+
 	// UpsertPin - Will insert a pin at the end of the sequence, unless the batch+hash+index sequence already exists
 	UpsertPin(ctx context.Context, parked *fftypes.Pin) (err error)
 

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -77,7 +77,7 @@ type iMessageCollection interface {
 	//                 must match the hash of the record that is being inserted.
 	UpsertMessage(ctx context.Context, message *fftypes.Message, optimization UpsertOptimization) (err error)
 
-	// InsertMessages performs a batch insert of messages assured to be new records
+	// InsertMessages performs a batch insert of messages assured to be new records - fails if they already exist, so caller can fall back to upsert individually
 	InsertMessages(ctx context.Context, messages []*fftypes.Message) (err error)
 
 	// UpdateMessage - Update message
@@ -109,7 +109,7 @@ type iDataCollection interface {
 	//              must match the hash of the record that is being inserted.
 	UpsertData(ctx context.Context, data *fftypes.Data, optimization UpsertOptimization) (err error)
 
-	// InsertDataArray performs a batch insert of data assured to be new records
+	// InsertDataArray performs a batch insert of data assured to be new records - fails if they already exist, so caller can fall back to upsert individually
 	InsertDataArray(ctx context.Context, data fftypes.DataArray) (err error)
 
 	// UpdateData - Update data
@@ -188,7 +188,7 @@ type iOffsetCollection interface {
 }
 
 type iPinCollection interface {
-	// InsertPins - Inserts a list of pins - fails if they already exist, so caller can fall back to UpsertPin individually
+	// InsertPins - Inserts a list of pins - fails if they already exist, so caller can fall back to upsert individually
 	InsertPins(ctx context.Context, pins []*fftypes.Pin) (err error)
 
 	// UpsertPin - Will insert a pin at the end of the sequence, unless the batch+hash+index sequence already exists

--- a/pkg/fftypes/batch.go
+++ b/pkg/fftypes/batch.go
@@ -91,7 +91,7 @@ type BatchPersisted struct {
 type BatchPayload struct {
 	TX       TransactionRef `json:"tx"`
 	Messages []*Message     `json:"messages"`
-	Data     []*Data        `json:"data"`
+	Data     DataArray      `json:"data"`
 }
 
 func (bm *BatchManifest) String() string {

--- a/pkg/fftypes/id_and_sequence.go
+++ b/pkg/fftypes/id_and_sequence.go
@@ -1,0 +1,23 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fftypes
+
+// IDAndSequence is a combination of a UUID and a stored sequence
+type IDAndSequence struct {
+	ID       UUID
+	Sequence int64
+}

--- a/pkg/fftypes/message_test.go
+++ b/pkg/fftypes/message_test.go
@@ -85,8 +85,6 @@ func TestVerifyTXType(t *testing.T) {
 
 	msg.Header.TxType = TransactionTypeTokenPool
 	err = msg.Seal(context.Background())
-	assert.NoError(t, err)
-	err = msg.Verify(context.Background())
 	assert.Regexp(t, "FF10343", err)
 }
 

--- a/pkg/fftypes/pin.go
+++ b/pkg/fftypes/pin.go
@@ -37,11 +37,11 @@ package fftypes
 // This is because the sequence must be in the order the pins arrive.
 //
 type Pin struct {
-	Sequence   int64    `json:"sequence,omitempty"`
+	Sequence   int64    `json:"sequence"`
 	Masked     bool     `json:"masked,omitempty"`
 	Hash       *Bytes32 `json:"hash,omitempty"`
 	Batch      *UUID    `json:"batch,omitempty"`
-	Index      int64    `json:"index,omitempty"`
+	Index      int64    `json:"index"`
 	Dispatched bool     `json:"dispatched,omitempty"`
 	Signer     string   `json:"signer,omitempty"`
 	Created    *FFTime  `json:"created,omitempty"`

--- a/pkg/fftypes/stringarray.go
+++ b/pkg/fftypes/stringarray.go
@@ -87,7 +87,7 @@ func (sa FFStringArray) String() string {
 	return strings.Join([]string(sa), ",")
 }
 
-func (sa FFStringArray) Validate(ctx context.Context, fieldName string, isName bool) error {
+func (sa FFStringArray) Validate(ctx context.Context, fieldName string, isName bool, maxItems int) error {
 	var totalLength int
 	dupCheck := make(map[string]bool)
 	for i, n := range sa {
@@ -106,7 +106,7 @@ func (sa FFStringArray) Validate(ctx context.Context, fieldName string, isName b
 			}
 		}
 	}
-	if isName && len(sa) > FFStringNameItemsMax {
+	if maxItems > 0 && len(sa) > maxItems {
 		return i18n.NewError(ctx, i18n.MsgTooManyItems, fieldName, FFStringNameItemsMax, len(sa))
 	}
 	if totalLength > FFStringArrayStandardMax {

--- a/pkg/fftypes/stringarray_test.go
+++ b/pkg/fftypes/stringarray_test.go
@@ -30,25 +30,25 @@ func TestFFStringArrayVerifyTooLong(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		na[i] = fmt.Sprintf("item_%d", i)
 	}
-	err := na.Validate(context.Background(), "field1", true)
+	err := na.Validate(context.Background(), "field1", true, FFStringNameItemsMax)
 	assert.Regexp(t, `FF10227.*field1`, err)
 }
 
 func TestFFStringArrayVerifyDuplicate(t *testing.T) {
 	na := FFStringArray{"value1", "value2", "value1"}
-	err := na.Validate(context.Background(), "field1", true)
+	err := na.Validate(context.Background(), "field1", true, FFStringNameItemsMax)
 	assert.Regexp(t, `FF10228.*field1`, err)
 }
 
 func TestFFStringArrayVerifyBadName(t *testing.T) {
 	na := FFStringArray{"!valid"}
-	err := na.Validate(context.Background(), "field1", true)
+	err := na.Validate(context.Background(), "field1", true, FFStringNameItemsMax)
 	assert.Regexp(t, `FF10131.*field1\[0\]`, err)
 }
 
 func TestFFStringArrayVerifyBadNonName(t *testing.T) {
 	na := FFStringArray{"!valid"}
-	err := na.Validate(context.Background(), "field1", false)
+	err := na.Validate(context.Background(), "field1", false, FFStringNameItemsMax)
 	assert.Regexp(t, `FF10335.*field1\[0\]`, err)
 }
 
@@ -58,7 +58,7 @@ func TestFFStringArrayVerifyTooLongTotal(t *testing.T) {
 		longstr.WriteRune('a')
 	}
 	na := FFStringArray{longstr.String()}
-	err := na.Validate(context.Background(), "field1", false)
+	err := na.Validate(context.Background(), "field1", false, FFStringNameItemsMax)
 	assert.Regexp(t, `FF10188.*field1`, err)
 }
 

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -75,6 +75,7 @@ func (suite *TokensTestSuite) TestE2EFungibleTokensAsync() {
 			Operator: suite.testState.org2key.Value,
 			Approved: true,
 		},
+		Pool: poolName,
 	}
 	approvalOut := TokenApproval(suite.T(), suite.testState.client1, approval, false)
 


### PR DESCRIPTION
Set of incremental test+fix changes, based on analysis of flame graphs against runs.

- https://github.com/hyperledger/firefly/pull/599/commits/fce2ea693d709afae52477c195d4a84f36bb8f05
  - Use multiple value insert for pins.
- https://github.com/hyperledger/firefly/pull/599/commits/041005cc257c9d2023181037e3f1a7ed35797388
  - Increase the message writer timeout, accepting 50ms latency vs. benefits of more writes per commit
- https://github.com/hyperledger/firefly/pull/599/commits/4e0a86d8e584b958ff25d9ac25d19d47899b81cd
  - Delay individual events for up to 250ms when read-ahead is enabled, to reduce polling overhead
- https://github.com/hyperledger/firefly/pull/599/commits/5c4d55b990ca448ad393627d77146fe4faebb28f
    - Better debug logging for cache misses
- https://github.com/hyperledger/firefly/pull/599/commits/364e8ae6c37b9f423485c2c9059213d6de395600
  - Only query id+sequence when reading pages in batch manager. The full message is almost always in the cache when we're assembling a batch, so there's no need to query the full message+datarefs from the database.
- https://github.com/hyperledger/firefly/pull/599/commits/33c244c8313fe4425ce0a02400368fef298860be
  - Prevent new msg cache overwritting batch cache of message. We have to write the cache first before the DB update, as we have no idea how quickly the batch assembly will happen - and we can overwrite its updates if we do it after
- https://github.com/hyperledger/firefly/pull/599/commits/a0232b72fada999a2b0a90b9e0386b71402b2838
  - Better debug for cases when we have blocking due to missed pins
- https://github.com/hyperledger/firefly/pull/599/commits/8d6be5560db75b12cd1e11fc569d831a68a65079
  - Update message sequence from query of just the IDs+sequences
- https://github.com/hyperledger/firefly/pull/599/commits/8f63fc9185604773c6d973078f2b4c16e64d47eb
  - Add a minimum poll time to the batch manager, so it doesn't thrash rewinding as commits come in
- https://github.com/hyperledger/firefly/pull/599/commits/21789a0a207f7772033cdd43fcf5bc515cb395f9
  - The log formatter we have (which is great for other reasons) does a regex on every message, if you don't have a `prefix` key - so set one to the node name
- https://github.com/hyperledger/firefly/pull/599/commits/ff877bd614854cf7624b8c602983429d48b30d29
  - Cache first nodes for each parent org to avoid DB queries on every message
- https://github.com/hyperledger/firefly/pull/599/commits/d1dea98dfdf0aa5f4ea7cfa5be7737d3ea389888
  - Significant changes to how batch persistence works, to optimize the DB queries. Means that under normal circumstances, the sender only writes once (in batch assembly), and the receiver only writes once (in batch persist).
- https://github.com/hyperledger/firefly/pull/599/commits/edfaede213a7b384a4fac5ed8683285de5689c12
  - One DB operation to update all the pins within a batch, using a list of Batch+ID combinations
- https://github.com/hyperledger/firefly/pull/599/commits/7f1fb77c071393e7d04e60b9c0c591bd62c6d9a7
  - Enhancement to include the nonce in the `pins` array on a message (reducing the max topics for each message to 10), to aid debugging in the case of stuck contexts
- https://github.com/hyperledger/firefly/pull/599/commits/0d5b479d1d79d643536c4a918f3acb0d45726fdb
  - Commit offset updates to the DB asyncronously from the polling loop
  - Aggregator batch size to match input batch size
  - Fix descending sorting by default on created time to match confirmed descending sorting (which takes precedenced)
- https://github.com/hyperledger/firefly/pull/599/commits/80ed63861da18c4c9ca87d6433859220b0d6c9e5
  - Write back to the DB when the broadcast dispatch adds public references to blobs

Instead we now just query the ID+Sequence, and then read the rest from the cache