### PR TITLE
Restart stack and re-run E2E tests in daily integration job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,7 @@ jobs:
           BLOCKCHAIN_PROVIDER: ${{ matrix.blockchain-provider }}
           DATABASE_TYPE: ${{ matrix.database-type }}
           BUILD_FIREFLY: false
+          RESTART: true
         run: ./test/e2e/run.sh
 
       - name: Archive container logs

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -102,3 +102,14 @@ export STACK_FILE
 
 go clean -testcache && go test -v . -run $TEST_SUITE
 checkOk $?
+
+if [ "$RESTART" == "true" ]; then
+  $CLI stop $STACK_NAME
+  checkOk $?
+
+  $CLI start $STACK_NAME
+  checkOk $?
+
+  go clean -testcache && go test -v . -run $TEST_SUITE
+  checkOk $?
+fi


### PR DESCRIPTION
This does not affect the PR test runs - only the daily integration test job - or if a `RESTART` environment variable is set to `true`.

Resolves https://github.com/hyperledger/firefly/issues/566