### PR TITLE
[blockchainevents-charts] support for blockchain event charting

### DIFF
--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -577,7 +577,7 @@ type OrderedUUIDCollectionNS CollectionName
 const (
 	CollectionMessages         OrderedUUIDCollectionNS = "messages"
 	CollectionEvents           OrderedUUIDCollectionNS = "events"
-	CollectionBlockchainEvents OrderedUUIDCollectionNS = "contractevents"
+	CollectionBlockchainEvents OrderedUUIDCollectionNS = "blockchainevents"
 )
 
 // OrderedCollection is a collection that is ordered, and that sequence is the only key


### PR DESCRIPTION
Adding support for blockchain event charting, so that the new UI can include blockchain event histograms.
This was a bigger change than expected since blockchain events have no `type` field, and are also timestamped by a `timestamp` field rather than a `created` field. This resulted in a `getHistogramNoTypes()` method and a `getHistogramWithTypes()` method.
