### PR TITLE
[fetchreferences2] Adding event enrichment for all event types

### DIFF
--- a/internal/database/sqlcommon/namespace_sql.go
+++ b/internal/database/sqlcommon/namespace_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -137,7 +137,6 @@ func (s *SQLCommon) namespaceResult(ctx context.Context, row *sql.Rows) (*fftype
 }
 
 func (s *SQLCommon) GetNamespace(ctx context.Context, name string) (message *fftypes.Namespace, err error) {
-
 	rows, _, err := s.query(ctx,
 		sq.Select(namespaceColumns...).
 			From("namespaces").
@@ -150,6 +149,30 @@ func (s *SQLCommon) GetNamespace(ctx context.Context, name string) (message *fft
 
 	if !rows.Next() {
 		log.L(ctx).Debugf("Namespace '%s' not found", name)
+		return nil, nil
+	}
+
+	namespace, err := s.namespaceResult(ctx, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespace, nil
+}
+
+func (s *SQLCommon) GetNamespaceByID(ctx context.Context, id *fftypes.UUID) (ns *fftypes.Namespace, err error) {
+	rows, _, err := s.query(ctx,
+		sq.Select(namespaceColumns...).
+			From("namespaces").
+			Where(sq.Eq{"id": id}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		log.L(ctx).Debugf("Namespace ID '%s' not found", id)
 		return nil, nil
 	}
 

--- a/internal/txcommon/event_enrich.go
+++ b/internal/txcommon/event_enrich.go
@@ -46,6 +46,54 @@ func (t *transactionHelper) EnrichEvent(ctx context.Context, event *fftypes.Even
 			return nil, err
 		}
 		e.BlockchainEvent = be
+	case fftypes.EventTypeContractAPIConfirmed:
+		contractAPI, err := t.database.GetContractAPIByID(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.ContractAPI = contractAPI
+	case fftypes.EventTypeContractInterfaceConfirmed:
+		contractInterface, err := t.database.GetFFIByID(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.ContractInterface = contractInterface
+	case fftypes.EventTypeDatatypeConfirmed:
+		dt, err := t.database.GetDatatypeByID(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.Datatype = dt
+	case fftypes.EventTypeIdentityConfirmed, fftypes.EventTypeIdentityUpdated:
+		identity, err := t.database.GetIdentityByID(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.Identity = identity
+	case fftypes.EventTypeNamespaceConfirmed:
+		ns, err := t.database.GetNamespaceByID(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.NamespaceDetails = ns
+	case fftypes.EventTypePoolConfirmed:
+		tokenPool, err := t.database.GetTokenPoolByID(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.TokenPool = tokenPool
+	case fftypes.EventTypeApprovalConfirmed, fftypes.EventTypeApprovalOpFailed:
+		approval, err := t.database.GetTokenApproval(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.TokenApproval = approval
+	case fftypes.EventTypeTransferConfirmed, fftypes.EventTypeTransferOpFailed:
+		transfer, err := t.database.GetTokenTransfer(ctx, event.Reference)
+		if err != nil {
+			return nil, err
+		}
+		e.TokenTransfer = transfer
 	}
 	return e, nil
 }

--- a/internal/txcommon/event_enrich_test.go
+++ b/internal/txcommon/event_enrich_test.go
@@ -200,3 +200,449 @@ func TestEnrichBlockchainEventFail(t *testing.T) {
 	_, err := txHelper.EnrichEvent(ctx, event)
 	assert.EqualError(t, err, "pop")
 }
+
+func TestEnrichContractAPISubmitted(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetContractAPIByID", mock.Anything, ref1).Return(&fftypes.ContractAPI{
+		ID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeContractAPIConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.ContractAPI.ID)
+}
+
+func TestEnrichContractAPItFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetContractAPIByID", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeContractAPIConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichContractInterfaceSubmitted(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetFFIByID", mock.Anything, ref1).Return(&fftypes.FFI{
+		ID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeContractInterfaceConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.ContractInterface.ID)
+}
+
+func TestEnrichContractInterfacetFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetFFIByID", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeContractInterfaceConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichDatatypeConfirmed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetDatatypeByID", mock.Anything, ref1).Return(&fftypes.Datatype{
+		ID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeDatatypeConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.Datatype.ID)
+}
+
+func TestEnrichDatatypeConfirmedFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetDatatypeByID", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeDatatypeConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichIdentityConfirmed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetIdentityByID", mock.Anything, ref1).Return(&fftypes.Identity{
+		IdentityBase: fftypes.IdentityBase{
+			ID: ref1,
+		},
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeIdentityConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.Identity.IdentityBase.ID)
+}
+
+func TestEnrichIdentityConfirmedFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetIdentityByID", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeIdentityConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichNamespaceConfirmed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetNamespaceByID", mock.Anything, ref1).Return(&fftypes.Namespace{
+		ID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeNamespaceConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.NamespaceDetails.ID)
+}
+
+func TestEnrichNamespaceConfirmedFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetNamespaceByID", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeNamespaceConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichTokenPoolConfirmed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenPoolByID", mock.Anything, ref1).Return(&fftypes.TokenPool{
+		ID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypePoolConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.TokenPool.ID)
+}
+
+func TestEnrichTokenPoolConfirmedFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenPoolByID", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypePoolConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichTokenApprovalConfirmed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenApproval", mock.Anything, ref1).Return(&fftypes.TokenApproval{
+		LocalID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeApprovalConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.TokenApproval.LocalID)
+}
+
+func TestEnrichTokenApprovalFailed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenApproval", mock.Anything, ref1).Return(&fftypes.TokenApproval{
+		LocalID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeApprovalOpFailed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.TokenApproval.LocalID)
+}
+
+func TestEnrichTokenApprovalConfirmedFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenApproval", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeApprovalConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestEnrichTokenTransferConfirmed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenTransfer", mock.Anything, ref1).Return(&fftypes.TokenTransfer{
+		LocalID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeTransferConfirmed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.TokenTransfer.LocalID)
+}
+
+func TestEnrichTokenTransferFailed(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenTransfer", mock.Anything, ref1).Return(&fftypes.TokenTransfer{
+		LocalID: ref1,
+	}, nil)
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeTransferOpFailed,
+		Reference: ref1,
+	}
+
+	enriched, err := txHelper.EnrichEvent(ctx, event)
+	assert.NoError(t, err)
+	assert.Equal(t, ref1, enriched.TokenTransfer.LocalID)
+}
+
+func TestEnrichTokenTransferConfirmedFail(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mdm := &datamocks.Manager{}
+	txHelper := NewTransactionHelper(mdi, mdm)
+	ctx := context.Background()
+
+	// Setup the IDs
+	ref1 := fftypes.NewUUID()
+	ev1 := fftypes.NewUUID()
+
+	// Setup enrichment
+	mdi.On("GetTokenTransfer", mock.Anything, ref1).Return(nil, fmt.Errorf("pop"))
+
+	event := &fftypes.Event{
+		ID:        ev1,
+		Type:      fftypes.EventTypeTransferConfirmed,
+		Reference: ref1,
+	}
+
+	_, err := txHelper.EnrichEvent(ctx, event)
+	assert.EqualError(t, err, "pop")
+}

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -1303,6 +1303,29 @@ func (_m *Plugin) GetNamespace(ctx context.Context, name string) (*fftypes.Names
 	return r0, r1
 }
 
+// GetNamespaceByID provides a mock function with given fields: ctx, id
+func (_m *Plugin) GetNamespaceByID(ctx context.Context, id *fftypes.UUID) (*fftypes.Namespace, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *fftypes.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID) *fftypes.Namespace); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.Namespace)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNamespaces provides a mock function with given fields: ctx, filter
 func (_m *Plugin) GetNamespaces(ctx context.Context, filter database.Filter) ([]*fftypes.Namespace, *database.FilterResult, error) {
 	ret := _m.Called(ctx, filter)

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -67,6 +67,9 @@ type iNamespaceCollection interface {
 	// GetNamespace - Get an namespace by name
 	GetNamespace(ctx context.Context, name string) (offset *fftypes.Namespace, err error)
 
+	// GetNamespaceByID - Get a namespace by ID
+	GetNamespaceByID(ctx context.Context, id *fftypes.UUID) (offset *fftypes.Namespace, err error)
+
 	// GetNamespaces - Get namespaces
 	GetNamespaces(ctx context.Context, filter Filter) (offset []*fftypes.Namespace, res *FilterResult, err error)
 }

--- a/pkg/fftypes/event.go
+++ b/pkg/fftypes/event.go
@@ -69,9 +69,17 @@ type Event struct {
 // EnrichedEvent adds the referred object to an event
 type EnrichedEvent struct {
 	Event
-	Message         *Message         `json:"message,omitempty"`
-	Transaction     *Transaction     `json:"transaction,omitempty"`
-	BlockchainEvent *BlockchainEvent `json:"blockchainevent,omitempty"`
+	BlockchainEvent   *BlockchainEvent `json:"blockchainevent,omitempty"`
+	ContractAPI       *ContractAPI     `json:"contractAPI,omitempty"`
+	ContractInterface *FFI             `json:"contractInterface,omitempty"`
+	Datatype          *Datatype        `json:"datatype,omitempty"`
+	Identity          *Identity        `json:"identity,omitempty"`
+	Message           *Message         `json:"message,omitempty"`
+	NamespaceDetails  *Namespace       `json:"namespaceDetails,omitempty"`
+	TokenApproval     *TokenApproval   `json:"tokenApproval,omitempty"`
+	TokenPool         *TokenPool       `json:"tokenPool,omitempty"`
+	Transaction       *Transaction     `json:"transaction,omitempty"`
+	TokenTransfer     *TokenTransfer   `json:"tokenTransfer,omitempty"`
 }
 
 // EventDelivery adds the referred object to an event, as well as details of the subscription that caused the event to


### PR DESCRIPTION
`GET /events?fetchreferences` now returns enriched events for all event types:

```go
type EnrichedEvent struct {
	Event
	BlockchainEvent   *BlockchainEvent `json:"blockchainevent,omitempty"`
	ContractAPI       *ContractAPI     `json:"contractAPI,omitempty"`
	ContractInterface *FFI             `json:"contractInterface,omitempty"`
	Datatype          *Datatype        `json:"datatype,omitempty"`
	Identity          *Identity        `json:"identity,omitempty"`
	Message           *Message         `json:"message,omitempty"`
	NamespaceDetails  *Namespace       `json:"namespaceDetails,omitempty"`
	TokenApproval     *TokenApproval   `json:"tokenApproval,omitempty"`
	TokenPool         *TokenPool       `json:"tokenPool,omitempty"`
	Transaction       *Transaction     `json:"transaction,omitempty"`
	TokenTransfer     *TokenTransfer   `json:"tokenTransfer,omitempty"`
}
```