### PR TITLE
Re-read configuration on restart of orchestrator

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -126,6 +126,12 @@ func run() error {
 		case <-orchestratorCtx.Done():
 			log.L(ctx).Infof("Restarting due to configuration change")
 			o.WaitStop()
+			// Re-read the configuration
+			config.Reset()
+			if err := config.ReadConfig(cfgFile); err != nil {
+				cancelCtx()
+				return err
+			}
 		case err := <-errChan:
 			cancelCtx()
 			return err


### PR DESCRIPTION
Now that we are using more standard deployment of Ethereum contracts in the FireFly CLI, where a unique Eth address is generated each time, we need to set that configuration.

Rather than having configuration like this that's only in the DB, this PR proposes we re-read the configuration after the reset to pick up patched YAML configuration containing the instance address.

We still need to use the `preInit` trick in the CLI to let it start in a zombie mode so Docker compose is happy, while we're using EthConnect to deploy the contract, but the only thing we use the DB config patch for is to unset this flag (which is true already today).