### PR TITLE
Created timestamp index on events shouldn't be unique

### DIFF
--- a/db/migrations/postgres/000011_create_events_table.up.sql
+++ b/db/migrations/postgres/000011_create_events_table.up.sql
@@ -9,6 +9,6 @@ CREATE TABLE events (
 );
 
 CREATE UNIQUE INDEX events_id ON events(id);
-CREATE UNIQUE INDEX events_created ON events(created);
+CREATE INDEX events_created ON events(created);
 
 COMMIT;

--- a/db/migrations/sqlite/000011_create_events_table.up.sql
+++ b/db/migrations/sqlite/000011_create_events_table.up.sql
@@ -8,5 +8,5 @@ CREATE TABLE events (
 );
 
 CREATE UNIQUE INDEX events_id ON events(id);
-CREATE UNIQUE INDEX events_created ON events(created);
+CREATE INDEX events_created ON events(created);
 


### PR DESCRIPTION
Saw the below error in a long-run test, where an attempt to insert an event resulted in no rows being added in PSQL with `ON CONFLICT DO NOTHING RETURNING seq`. I found there's an index that is set to `UNIQUE` on the `created` timestamp, and while a clash there is unlikely it's definitely possible.

```
{"log":"[2022-03-27T20:45:44.100Z]  WARN node_0: SQL! transaction rollback dbtx=WLXd2cMS httpreq=GJpFajph req=w6nJtbSg\n","stream":"stderr","time":"2022-03-27T20:45:44.102693254Z"}
{"log":"[2022-03-27T20:45:44.102Z]  INFO node_0: \u003c-- POST /api/v1/namespaces/default/contracts/invoke [500] (19.62ms): FF10116: Database insert failed: FF10375: Failed to retrieve sequence for insert row 1 (could mean duplicate insert) httpreq=GJpFajph req=w6nJtbSg\n","stream":"stderr","time":"2022-03-27T20:45:44.10280407Z"}
```