### PR TITLE
Add index on message_id for token transfers

### DIFF
--- a/db/migrations/postgres/000076_add_tokentransfer_message_index.down.sql
+++ b/db/migrations/postgres/000076_add_tokentransfer_message_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX tokentransfer_messageid;
+
+COMMIT;

--- a/db/migrations/postgres/000076_add_tokentransfer_message_index.up.sql
+++ b/db/migrations/postgres/000076_add_tokentransfer_message_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX tokentransfer_messageid ON tokentransfer(message_id);
+
+COMMIT;

--- a/db/migrations/sqlite/000076_add_tokentransfer_message_index.down.sql
+++ b/db/migrations/sqlite/000076_add_tokentransfer_message_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX tokentransfer_messageid;

--- a/db/migrations/sqlite/000076_add_tokentransfer_message_index.up.sql
+++ b/db/migrations/sqlite/000076_add_tokentransfer_message_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX tokentransfer_messageid ON tokentransfer(message_id);


### PR DESCRIPTION
Found a very expensive DB query for this message - which is a transfer broadcast:
```
{"log":"[2022-03-28T18:28:15.165Z] DEBUG node_0: Aggregating pin 0000628232 batch=30699806-5fc3-441e-b05f-8d2c9d28fc5e msg=7e41907b-5d34-41c0-87a5-61ccafaf9885 pinIndex=1 msgBaseIndex=1 hash=37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f masked=false dbtx=Z5gQrpfP role=aggregator\n","stream":"stderr","time":"2022-03-28T18:28:15.16525934Z"}
{"log":"[2022-03-28T18:28:15.165Z] DEBUG node_0: Cache hit for message 7e41907b-5d34-41c0-87a5-61ccafaf9885 dbtx=Z5gQrpfP role=aggregator\n","stream":"stderr","time":"2022-03-28T18:28:15.16527267Z"}
{"log":"[2022-03-28T18:28:15.165Z] DEBUG node_0: Attempt dispatch msg=7e41907b-5d34-41c0-87a5-61ccafaf9885 broadcastContexts=[37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f] privatePins= dbtx=Z5gQrpfP role=aggregator\n","stream":"stderr","time":"2022-03-28T18:28:15.16527981Z"}
{"log":"[2022-03-28T18:28:15.165Z] DEBUG node_0: SQL-\u003e query: SELECT type, local_id, dbtx=Z5gQrpfP role=aggregator\n","stream":"stderr","time":"2022-03-28T18:28:15.165441134Z"}
{"log":"[2022-03-28T18:28:15.839Z] DEBUG node_0: SQL\u003c- query dbtx=Z5gQrpfP role=aggregator\n","stream":"stderr","time":"2022-03-28T18:28:15.839742326Z"}
```

`18:28:15.165Z` -> `18:28:15.839Z` - so 700ms ish

This query looks to be the culprit, as we do not have an index:
https://github.com/hyperledger/firefly/blob/282d6237e1c6840c2f27fb87ec8ddd95e32a9536/internal/events/aggregator.go#L492-L498