### PR TITLE
Update our cache for event enrichment on message confirm

### DIFF
--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -40,6 +40,7 @@ type Manager interface {
 	PeekMessageCache(ctx context.Context, id *fftypes.UUID, options ...CacheReadOption) (msg *fftypes.Message, data fftypes.DataArray)
 	UpdateMessageCache(msg *fftypes.Message, data fftypes.DataArray)
 	UpdateMessageIfCached(ctx context.Context, msg *fftypes.Message)
+	UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state fftypes.MessageState, confirmed *fftypes.FFTime)
 	ResolveInlineData(ctx context.Context, msg *NewMessage) error
 	WriteNewMessage(ctx context.Context, newMsg *NewMessage) error
 	VerifyNamespaceExists(ctx context.Context, ns string) error
@@ -277,6 +278,14 @@ func (dm *dataManager) UpdateMessageIfCached(ctx context.Context, msg *fftypes.M
 	mce := dm.queryMessageCache(ctx, msg.Header.ID)
 	if mce != nil {
 		dm.UpdateMessageCache(msg, mce.data)
+	}
+}
+
+func (dm *dataManager) UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state fftypes.MessageState, confirmed *fftypes.FFTime) {
+	mce := dm.queryMessageCache(ctx, id)
+	if mce != nil {
+		mce.msg.State = state
+		mce.msg.Confirmed = confirmed
 	}
 }
 

--- a/internal/data/data_manager_test.go
+++ b/internal/data/data_manager_test.go
@@ -1098,6 +1098,11 @@ func TestUpdateMessageCacheCRORequirePins(t *testing.T) {
 		mce = dm.queryMessageCache(ctx, msgNoPins.Header.ID, CRORequirePins)
 	}
 
+	now := fftypes.Now()
+	dm.UpdateMessageStateIfCached(ctx, msgWithPins.Header.ID, fftypes.MessageStateConfirmed, now)
+	assert.Equal(t, fftypes.MessageStateConfirmed, msgWithPins.State)
+	assert.Equal(t, now, msgWithPins.Confirmed)
+
 }
 
 func TestUpdateMessageCacheCRORequireBatchID(t *testing.T) {

--- a/internal/events/aggregator_batch_state_test.go
+++ b/internal/events/aggregator_batch_state_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly/mocks/databasemocks"
+	"github.com/hyperledger/firefly/mocks/datamocks"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -50,14 +51,17 @@ func TestFlushPinsFailUpdateMessages(t *testing.T) {
 	ag, cancel := newTestAggregator()
 	defer cancel()
 	bs := newBatchState(ag)
+	msgID := fftypes.NewUUID()
 
 	mdi := ag.database.(*databasemocks.Plugin)
 	mdi.On("UpdatePins", ag.ctx, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateMessages", ag.ctx, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	mdm := ag.data.(*datamocks.Manager)
+	mdm.On("UpdateMessageStateIfCached", ag.ctx, msgID, fftypes.MessageStateConfirmed, mock.Anything).Return()
 
 	bs.MarkMessageDispatched(ag.ctx, fftypes.NewUUID(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
-			ID:     fftypes.NewUUID(),
+			ID:     msgID,
 			Topics: fftypes.FFStringArray{"topic1"},
 		},
 		Pins: fftypes.FFStringArray{"pin1"},

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -210,6 +210,7 @@ func TestAggregationMaskedZeroNonceMatch(t *testing.T) {
 	// Validate the message is ok
 	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID, data.CRORequirePins).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
 	mdm.On("ValidateAll", ag.ctx, mock.Anything).Return(true, nil)
+	mdm.On("UpdateMessageStateIfCached", ag.ctx, mock.Anything, fftypes.MessageStateConfirmed, mock.Anything).Return()
 	// Insert the confirmed event
 	mdi.On("InsertEvent", ag.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
 		return *e.Reference == *msgID && e.Type == fftypes.EventTypeMessageConfirmed
@@ -334,6 +335,7 @@ func TestAggregationMaskedNextSequenceMatch(t *testing.T) {
 	// Validate the message is ok
 	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID, data.CRORequirePins).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
 	mdm.On("ValidateAll", ag.ctx, mock.Anything).Return(true, nil)
+	mdm.On("UpdateMessageStateIfCached", ag.ctx, mock.Anything, fftypes.MessageStateConfirmed, mock.Anything).Return()
 	// Insert the confirmed event
 	mdi.On("InsertEvent", ag.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
 		return *e.Reference == *msgID && e.Type == fftypes.EventTypeMessageConfirmed
@@ -433,6 +435,7 @@ func TestAggregationBroadcast(t *testing.T) {
 	// Validate the message is ok
 	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID, data.CRORequirePublicBlobRefs).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
 	mdm.On("ValidateAll", ag.ctx, mock.Anything).Return(true, nil)
+	mdm.On("UpdateMessageStateIfCached", ag.ctx, mock.Anything, fftypes.MessageStateConfirmed, mock.Anything).Return()
 	// Insert the confirmed event
 	mdi.On("InsertEvent", ag.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
 		return *e.Reference == *msgID && e.Type == fftypes.EventTypeMessageConfirmed
@@ -527,6 +530,7 @@ func TestAggregationMigratedBroadcast(t *testing.T) {
 	// Validate the message is ok
 	mdm.On("GetMessageWithDataCached", ag.ctx, batch.Payload.Messages[0].Header.ID, data.CRORequirePublicBlobRefs).Return(batch.Payload.Messages[0], fftypes.DataArray{}, true, nil)
 	mdm.On("ValidateAll", ag.ctx, mock.Anything).Return(true, nil)
+	mdm.On("UpdateMessageStateIfCached", ag.ctx, mock.Anything, fftypes.MessageStateConfirmed, mock.Anything).Return()
 	// Insert the confirmed event
 	mdi.On("InsertEvent", ag.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
 		return *e.Reference == *msgID && e.Type == fftypes.EventTypeMessageConfirmed

--- a/mocks/datamocks/manager.go
+++ b/mocks/datamocks/manager.go
@@ -226,6 +226,11 @@ func (_m *Manager) UpdateMessageIfCached(ctx context.Context, msg *fftypes.Messa
 	_m.Called(ctx, msg)
 }
 
+// UpdateMessageStateIfCached provides a mock function with given fields: ctx, id, state, confirmed
+func (_m *Manager) UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state fftypes.FFEnum, confirmed *fftypes.FFTime) {
+	_m.Called(ctx, id, state, confirmed)
+}
+
 // UploadBLOB provides a mock function with given fields: ctx, ns, inData, blob, autoMeta
 func (_m *Manager) UploadBLOB(ctx context.Context, ns string, inData *fftypes.DataRefOrValue, blob *fftypes.Multipart, autoMeta bool) (*fftypes.Data, error) {
 	ret := _m.Called(ctx, ns, inData, blob, autoMeta)


### PR DESCRIPTION
Noticed in the UI that confirmed messages on the Timeline view are showing as `Pending` - which is because they are using the cache rather than an explicit query against the DB. This PR updates the cache when messages are batched, or confirmed.