### PR TITLE
Fix IF EXISTS check on transactions_id INDEX migration

### DIFF
--- a/db/migrations/postgres/000077_add_transactions_id_index.up.sql
+++ b/db/migrations/postgres/000077_add_transactions_id_index.up.sql
@@ -1,8 +1,8 @@
 BEGIN;
 
 -- We created an invalid index in versions v0.14.1 and earlier - replace it if it exists here
--- For PostgreSQL we use an IF EXISTS here and removed the invalid creation from the earlier migration, for new envs
-DROP INDEX transactions_id IF EXISTS;
+-- We use an IF EXISTS here, as we no longer create the invalid index for new environments
+DROP INDEX IF EXISTS transactions_id;
 CREATE UNIQUE INDEX transactions_id ON transactions(id);
 
 COMMIT;

--- a/db/migrations/sqlite/000005_create_transactions_table.up.sql
+++ b/db/migrations/sqlite/000005_create_transactions_table.up.sql
@@ -12,7 +12,6 @@ CREATE TABLE transactions (
   info        TEXT
 );
 
-CREATE UNIQUE INDEX transactions_id ON transactions(id);
 CREATE INDEX transactions_created ON transactions(created);
 CREATE INDEX transactions_protocol_id ON transactions(protocol_id);
 CREATE INDEX transactions_ref ON transactions(ref);

--- a/db/migrations/sqlite/000077_add_transactions_id_index.up.sql
+++ b/db/migrations/sqlite/000077_add_transactions_id_index.up.sql
@@ -1,2 +1,5 @@
-DROP INDEX transactions_id;
+-- We created an invalid index in versions v0.14.1 and earlier - replace it if it exists here
+-- We use an IF EXISTS here, as we no longer create the invalid index for new environments
+DROP INDEX IF EXISTS transactions_id;
+
 CREATE UNIQUE INDEX transactions_id ON transactions(id);

--- a/internal/events/dx_callbacks.go
+++ b/internal/events/dx_callbacks.go
@@ -143,7 +143,7 @@ func (em *eventManager) privateBatchReceived(peerID string, batch *fftypes.Batch
 	})
 	// Poke the aggregator to do its stuff - after we have committed the transaction so the pins are visible
 	if err == nil && batch.Payload.TX.Type == fftypes.TransactionTypeBatchPin {
-		log.L(em.ctx).Errorf("Rewinding for persisted private batch %s", batch.ID)
+		log.L(em.ctx).Debugf("Rewinding for persisted private batch %s", batch.ID)
 		em.aggregator.rewindBatches <- *batch.ID
 	}
 	return manifest, err

--- a/internal/events/ss_callbacks.go
+++ b/internal/events/ss_callbacks.go
@@ -58,7 +58,7 @@ func (em *eventManager) SharedStorageBatchDownloaded(ss sharedstorage.Plugin, ns
 	}
 
 	// Rewind the aggregator to this batch - after the DB updates are complete
-	log.L(em.ctx).Errorf("Rewinding for downloaded broadcast batch %s", batch.ID)
+	log.L(em.ctx).Debugf("Rewinding for downloaded broadcast batch %s", batch.ID)
 	em.aggregator.rewindBatches <- *batch.ID
 	return batch.ID, nil
 }


### PR DESCRIPTION
- Fixes migration
- Fixes a log entry that was at the wrong level