### PR TITLE
Assign nonces more efficiently, with minimal DB ops

### DIFF
--- a/db/migrations/postgres/000078_add_nonce_author.down.sql
+++ b/db/migrations/postgres/000078_add_nonce_author.down.sql
@@ -5,7 +5,6 @@ DROP INDEX nonces_hash;
 ALTER TABLE nonces RENAME COLUMN "hash" TO "context";
 ALTER TABLE nonces ADD COLUMN group_hash CHAR(64);
 ALTER TABLE nonces ADD COLUMN topic VARCHAR(64);
-ALTER TABLE nonces ADD COLUMN
 
 CREATE INDEX nonces_context ON nonces(context);
 CREATE INDEX nonces_group ON nonces(group_hash);

--- a/db/migrations/postgres/000078_add_nonce_author.down.sql
+++ b/db/migrations/postgres/000078_add_nonce_author.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+DROP INDEX nonces_hash;
+
+ALTER TABLE nonces RENAME COLUMN "hash" TO "context";
+ALTER TABLE nonces ADD COLUMN group_hash CHAR(64);
+ALTER TABLE nonces ADD COLUMN topic VARCHAR(64);
+ALTER TABLE nonces ADD COLUMN
+
+CREATE INDEX nonces_context ON nonces(context);
+CREATE INDEX nonces_group ON nonces(group_hash);
+
+COMMIT;

--- a/db/migrations/postgres/000078_add_nonce_author.up.sql
+++ b/db/migrations/postgres/000078_add_nonce_author.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+DROP INDEX nonces_context;
+DROP INDEX nonces_group;
+
+ALTER TABLE nonces RENAME COLUMN "context" TO "hash";
+ALTER TABLE nonces DROP COLUMN "group_hash";
+ALTER TABLE nonces DROP COLUMN "topic";
+
+CREATE INDEX nonces_hash ON nonces(hash);
+
+COMMIT;

--- a/db/migrations/sqlite/000078_add_nonce_author.down.sql
+++ b/db/migrations/sqlite/000078_add_nonce_author.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX nonces_hash;
+
+ALTER TABLE nonces RENAME COLUMN "hash" TO "context";
+ALTER TABLE nonces ADD COLUMN group_hash CHAR(64);
+ALTER TABLE nonces ADD COLUMN topic VARCHAR(64);
+
+CREATE INDEX nonces_context ON nonces(context);
+CREATE INDEX nonces_group ON nonces(group_hash);

--- a/db/migrations/sqlite/000078_add_nonce_author.up.sql
+++ b/db/migrations/sqlite/000078_add_nonce_author.up.sql
@@ -1,0 +1,8 @@
+DROP INDEX nonces_context;
+DROP INDEX nonces_group;
+
+ALTER TABLE nonces RENAME COLUMN "context" TO "hash";
+ALTER TABLE nonces DROP COLUMN "group_hash";
+ALTER TABLE nonces DROP COLUMN "topic";
+
+CREATE INDEX nonces_hash ON nonces(hash);

--- a/internal/batch/batch_manager_test.go
+++ b/internal/batch/batch_manager_test.go
@@ -195,8 +195,8 @@ func TestE2EDispatchPrivateUnpinned(t *testing.T) {
 
 		h = sha256.New()
 		nonceBytes, _ = hex.DecodeString(
-			"746f70696332" + "44dc0861e69d9bab17dd5e90a8898c2ea156ad04e5fabf83119cc010486e6c1b" + "6469643a66697265666c793a6f72672f61626364" + "000000000000303a",
-		/*|   topic2  |    | ---- group id -------------------------------------------------|   |author'"did:firefly:org/abcd'            |  |i64 nonce (12346) */
+			"746f70696332" + "44dc0861e69d9bab17dd5e90a8898c2ea156ad04e5fabf83119cc010486e6c1b" + "6469643a66697265666c793a6f72672f61626364" + "0000000000003039",
+		/*|   topic2  |    | ---- group id -------------------------------------------------|   |author'"did:firefly:org/abcd'            |  |i64 nonce (12345) */
 		/*|               context                                                           |   |          sender + nonce             */
 		) // little endian 12345 in 8 byte hex
 		h.Write(nonceBytes)
@@ -253,12 +253,10 @@ func TestE2EDispatchPrivateUnpinned(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("( id IN ['%s'] ) && ( state == 'ready' )", msg.Header.ID.String()), fi.String())
 		return true
 	}), mock.Anything).Return(nil)
-	ugcn := mdi.On("UpsertNonceNext", mock.Anything, mock.Anything).Return(nil)
-	nextNonce := int64(12345)
-	ugcn.RunFn = func(a mock.Arguments) {
-		a[1].(*fftypes.Nonce).Nonce = nextNonce
-		nextNonce++
-	}
+	mdi.On("GetNonce", mock.Anything, mock.Anything).Return(&fftypes.Nonce{
+		Nonce: int64(12344),
+	}, nil).Twice()
+	mdi.On("UpdateNonce", mock.Anything, mock.Anything).Return(nil)
 	mdi.On("InsertTransaction", mock.Anything, mock.Anything).Return(nil)
 	mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil) // transaction submit
 

--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -494,7 +494,7 @@ func (bp *batchProcessor) maskContexts(ctx context.Context, state *DispatchState
 			}
 		}
 	}
-	return contextsOrPins, bp.flushNonceState(ctx, state)
+	return contextsOrPins, nil
 }
 
 func (bp *batchProcessor) flushNonceState(ctx context.Context, state *DispatchState) error {
@@ -547,6 +547,10 @@ func (bp *batchProcessor) sealBatch(state *DispatchState) (err error) {
 			if bp.conf.txType == fftypes.TransactionTypeBatchPin {
 				// Generate a new Transaction, which will be used to record status of the associated transaction as it happens
 				if state.Pins, err = bp.maskContexts(ctx, state); err != nil {
+					return err
+				}
+				// Flush the state for all allocated nonces to the database
+				if err = bp.flushNonceState(ctx, state); err != nil {
 					return err
 				}
 			}

--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -539,6 +539,8 @@ func (bp *batchProcessor) flushNonceState(ctx context.Context, state *DispatchSt
 func (bp *batchProcessor) sealBatch(state *DispatchState) (err error) {
 	err = bp.retry.Do(bp.ctx, "batch persist", func(attempt int) (retry bool, err error) {
 		return true, bp.database.RunAsGroup(bp.ctx, func(ctx context.Context) (err error) {
+
+			// Clear state from any previous retry. We need to do fresh queries against the DB for nonces.
 			state.noncesAssigned = make(map[fftypes.Bytes32]int64)
 			state.msgPins = make(map[fftypes.UUID]fftypes.FFStringArray)
 

--- a/internal/database/sqlcommon/nonce_sql_test.go
+++ b/internal/database/sqlcommon/nonce_sql_test.go
@@ -38,36 +38,32 @@ func TestNoncesE2EWithDB(t *testing.T) {
 
 	// Create a new nonce entry
 	nonceZero := &fftypes.Nonce{
-		Context: fftypes.NewRandB32(),
-		Group:   fftypes.NewRandB32(),
-		Topic:   "topic12345",
+		Hash: fftypes.NewRandB32(),
 	}
-	err := s.UpsertNonceNext(ctx, nonceZero)
+	err := s.InsertNonce(ctx, nonceZero)
 	assert.NoError(t, err)
 
 	// Check we get the exact same nonce back
-	nonceRead, err := s.GetNonce(ctx, nonceZero.Context)
+	nonceRead, err := s.GetNonce(ctx, nonceZero.Hash)
 	assert.NoError(t, err)
 	assert.NotNil(t, nonceRead)
 	nonceJson, _ := json.Marshal(&nonceZero)
 	nonceReadJson, _ := json.Marshal(&nonceRead)
 	assert.Equal(t, string(nonceJson), string(nonceReadJson))
 
-	// Update the nonce (this is testing what's possible at the database layer,
-	// and does not account for the verification that happens at the higher level)
-	var nonceUpdated fftypes.Nonce
-	nonceUpdated = *nonceZero
+	// Update the nonce
+	nonceUpdated := fftypes.Nonce{
+		Hash:  nonceZero.Hash,
+		Nonce: 12345,
+	}
 
-	// Increment a couple of times
-	err = s.UpsertNonceNext(context.Background(), &nonceUpdated)
+	// Update nonce
+	err = s.UpdateNonce(context.Background(), &nonceUpdated)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(1), nonceUpdated.Nonce)
-	err = s.UpsertNonceNext(context.Background(), &nonceUpdated)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(2), nonceUpdated.Nonce)
+	assert.Equal(t, int64(12345), nonceUpdated.Nonce)
 
 	// Check we get the exact same data back
-	nonceRead, err = s.GetNonce(ctx, nonceUpdated.Context)
+	nonceRead, err = s.GetNonce(ctx, nonceUpdated.Hash)
 	assert.NoError(t, err)
 	nonceJson, _ = json.Marshal(&nonceUpdated)
 	nonceReadJson, _ = json.Marshal(&nonceRead)
@@ -76,10 +72,8 @@ func TestNoncesE2EWithDB(t *testing.T) {
 	// Query back the nonce
 	fb := database.NonceQueryFactory.NewFilter(ctx)
 	filter := fb.And(
-		fb.Eq("context", nonceUpdated.Context),
+		fb.Eq("hash", nonceUpdated.Hash),
 		fb.Eq("nonce", nonceUpdated.Nonce),
-		fb.Eq("group", nonceUpdated.Group),
-		fb.Eq("topic", nonceUpdated.Topic),
 	)
 	nonceRes, res, err := s.GetNonces(ctx, filter.Count(true))
 	assert.NoError(t, err)
@@ -89,7 +83,7 @@ func TestNoncesE2EWithDB(t *testing.T) {
 	assert.Equal(t, string(nonceJson), string(nonceReadJson))
 
 	// Test delete
-	err = s.DeleteNonce(ctx, nonceUpdated.Context)
+	err = s.DeleteNonce(ctx, nonceUpdated.Hash)
 	assert.NoError(t, err)
 	nonces, _, err := s.GetNonces(ctx, filter)
 	assert.NoError(t, err)
@@ -97,52 +91,38 @@ func TestNoncesE2EWithDB(t *testing.T) {
 
 }
 
-func TestUpsertNonceFailBegin(t *testing.T) {
+func TestInsertNonceFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
-	err := s.UpsertNonceNext(context.Background(), &fftypes.Nonce{})
+	err := s.InsertNonce(context.Background(), &fftypes.Nonce{})
 	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpsertNonceFailSelect(t *testing.T) {
+func TestInsertNonceFailInsert(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
-	mock.ExpectRollback()
-	err := s.UpsertNonceNext(context.Background(), &fftypes.Nonce{Context: fftypes.NewRandB32()})
-	assert.Regexp(t, "FF10115", err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestUpsertNonceFailInsert(t *testing.T) {
-	s, mock := newMockProvider().init()
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{}))
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
-	err := s.UpsertNonceNext(context.Background(), &fftypes.Nonce{Context: fftypes.NewRandB32()})
+	err := s.InsertNonce(context.Background(), &fftypes.Nonce{Hash: fftypes.NewRandB32()})
 	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpsertNonceFailScan(t *testing.T) {
+func TestUpdateNonceFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{}).AddRow())
-	mock.ExpectRollback()
-	err := s.UpsertNonceNext(context.Background(), &fftypes.Nonce{Context: fftypes.NewRandB32()})
-	assert.Regexp(t, "FF10121", err)
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
+	err := s.UpdateNonce(context.Background(), &fftypes.Nonce{})
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpsertNonceFailUpdate(t *testing.T) {
+func TestUpdateNonceFailUpdate(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"nonce", "sequence"}).AddRow(int64(12345), int64(11111)))
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
-	err := s.UpsertNonceNext(context.Background(), &fftypes.Nonce{Context: fftypes.NewRandB32()})
+	err := s.UpdateNonce(context.Background(), &fftypes.Nonce{Hash: fftypes.NewRandB32()})
 	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -157,7 +137,7 @@ func TestGetNonceSelectFail(t *testing.T) {
 
 func TestGetNonceNotFound(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"context", "nonce", "group_hash", "topic"}))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"hash", "nonce", "group_hash", "topic"}))
 	msg, err := s.GetNonce(context.Background(), fftypes.NewRandB32())
 	assert.NoError(t, err)
 	assert.Nil(t, msg)
@@ -166,7 +146,7 @@ func TestGetNonceNotFound(t *testing.T) {
 
 func TestGetNonceScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"context"}).AddRow("only one"))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"hash"}).AddRow("only one"))
 	_, err := s.GetNonce(context.Background(), fftypes.NewRandB32())
 	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -175,7 +155,7 @@ func TestGetNonceScanFail(t *testing.T) {
 func TestGetNonceQueryFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
-	f := database.NonceQueryFactory.NewFilter(context.Background()).Eq("context", "")
+	f := database.NonceQueryFactory.NewFilter(context.Background()).Eq("hash", "")
 	_, _, err := s.GetNonces(context.Background(), f)
 	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -183,15 +163,15 @@ func TestGetNonceQueryFail(t *testing.T) {
 
 func TestGetNonceBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
-	f := database.NonceQueryFactory.NewFilter(context.Background()).Eq("context", map[bool]bool{true: false})
+	f := database.NonceQueryFactory.NewFilter(context.Background()).Eq("hash", map[bool]bool{true: false})
 	_, _, err := s.GetNonces(context.Background(), f)
-	assert.Regexp(t, "FF10149.*context", err)
+	assert.Regexp(t, "FF10149.*hash", err)
 }
 
 func TestGetNonceReadMessageFail(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"context"}).AddRow("only one"))
-	f := database.NonceQueryFactory.NewFilter(context.Background()).Eq("topic", "")
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"hash"}).AddRow("only one"))
+	f := database.NonceQueryFactory.NewFilter(context.Background()).Eq("hash", "")
 	_, _, err := s.GetNonces(context.Background(), f)
 	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2323,6 +2323,20 @@ func (_m *Plugin) InsertNextPin(ctx context.Context, nextpin *fftypes.NextPin) e
 	return r0
 }
 
+// InsertNonce provides a mock function with given fields: ctx, nonce
+func (_m *Plugin) InsertNonce(ctx context.Context, nonce *fftypes.Nonce) error {
+	ret := _m.Called(ctx, nonce)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Nonce) error); ok {
+		r0 = rf(ctx, nonce)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // InsertOperation provides a mock function with given fields: ctx, operation, hooks
 func (_m *Plugin) InsertOperation(ctx context.Context, operation *fftypes.Operation, hooks ...database.PostCompletionHook) error {
 	_va := make([]interface{}, len(hooks))
@@ -2547,6 +2561,20 @@ func (_m *Plugin) UpdateNextPin(ctx context.Context, sequence int64, update data
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, int64, database.Update) error); ok {
 		r0 = rf(ctx, sequence, update)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateNonce provides a mock function with given fields: ctx, nonce
+func (_m *Plugin) UpdateNonce(ctx context.Context, nonce *fftypes.Nonce) error {
+	ret := _m.Called(ctx, nonce)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Nonce) error); ok {
+		r0 = rf(ctx, nonce)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2827,20 +2855,6 @@ func (_m *Plugin) UpsertNamespace(ctx context.Context, data *fftypes.Namespace, 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Namespace, bool) error); ok {
 		r0 = rf(ctx, data, allowExisting)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpsertNonceNext provides a mock function with given fields: ctx, _a1
-func (_m *Plugin) UpsertNonceNext(ctx context.Context, _a1 *fftypes.Nonce) error {
-	ret := _m.Called(ctx, _a1)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Nonce) error); ok {
-		r0 = rf(ctx, _a1)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -314,8 +314,11 @@ type iGroupCollection interface {
 }
 
 type iNonceCollection interface {
-	// UpsertNonceNext - Upsert a context, assigning zero if not found, or the next nonce if it is
-	UpsertNonceNext(ctx context.Context, context *fftypes.Nonce) (err error)
+	// InsertNonce - Inserts a new nonce. Caller (batch processor) is responsible for ensuring it is the only active thread charge of assigning nonces to this context
+	InsertNonce(ctx context.Context, nonce *fftypes.Nonce) (err error)
+
+	// UpdateNonce - Updates an existing nonce. Caller (batch processor) is responsible for ensuring it is the only active thread charge of assigning nonces to this context
+	UpdateNonce(ctx context.Context, nonce *fftypes.Nonce) (err error)
 
 	// GetNonce - Get a context by hash
 	GetNonce(ctx context.Context, hash *fftypes.Bytes32) (message *fftypes.Nonce, err error)
@@ -865,10 +868,8 @@ var GroupQueryFactory = &queryFields{
 
 // NonceQueryFactory filter fields for nodes
 var NonceQueryFactory = &queryFields{
-	"context": &StringField{},
-	"nonce":   &Int64Field{},
-	"group":   &Bytes32Field{},
-	"topic":   &StringField{},
+	"hash":  &StringField{},
+	"nonce": &Int64Field{},
 }
 
 // NextPinQueryFactory filter fields for nodes

--- a/pkg/fftypes/nonce.go
+++ b/pkg/fftypes/nonce.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -16,12 +16,9 @@
 
 package fftypes
 
-// Nonce is this local node's state record for the context of a group+topic combination.
-// It records the node's latest allocated sequence number for the context.
-// A context is a hash of a GroupID and a topic, concattenated together
+// Nonce is this local node's state record for the context of a group+topic+author combination.
+// The Hash is the state of the hash before the nonce is added on to make it unique to the message.
 type Nonce struct {
-	Context *Bytes32 `json:"hash"`
-	Nonce   int64    `json:"nonce"`
-	Group   *Bytes32 `json:"group,omitempty"`
-	Topic   string   `json:"topic"`
+	Hash  *Bytes32 `json:"hash"`
+	Nonce int64    `json:"nonce"`
 }


### PR DESCRIPTION
This PR addresses two problems:

1) Currently when we are flushing a batch, we perform a DB read+update individually. This is very inefficient when you have a large number of messages for the same topic+group combination in the same batch. Instead we can keep a track in memory of the nonce increments, and flush them one time at the end of the dispatch.

2) I found while investigating (1) that we were not including the `author` of the message in the calculation of which Nonce we assigned from the DB. This is a bug. e.g. if you sent a message on `topicA` in a group with both `bob` and `sally` using author `bob`, then sent another message _from the same node_ as `sally` on the same `topicA` - then `sally` would get the wrong nonce.

As per the comments, some consideration has been made to ensure we take allocation of nonces seriously. Two key scenarios:

- Double assigning a nonce to a message: If we crashed after allocating a nonce in sending a batch, then after restart included the same messages back into a _new_ batch then we need to **re-use the same nonce** rather than allocating a new one.
- Failing to assign a nonce due to DB retry: If we span round the `sealBatch` logic once, then got a DB error and retried, the nonces we notionally assigned to the messages would not have been flushed to disk (we flush the nonces to the DB right at the end of this logic, and all DB plugins today have atomic TXs). This means when we retry we need to do the allocation again.

The above scenarios is why we check that the `msg.Pins` array hasn't been assigned, and only assign it after we've exited the retry loop.