### PR TITLE
[charts-config] chart buckets are now capped at a configurable max

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,8 @@ var (
 	DataexchangeType = rootKey("dataexchange.type")
 	// DatabaseType the type of the database interface plugin to use
 	DatabaseType = rootKey("database.type")
+	// DatabaseMaxChartRows the maximum rows to fetch for each histogram bucket
+	DatabaseMaxChartRows = rootKey("database.maxChartRows")
 	// TokensList is the root key containing a list of supported token connectors
 	TokensList = rootKey("tokens")
 	// DebugPort a HTTP port on which to enable the go debugger
@@ -365,6 +367,7 @@ func Reset() {
 	viper.SetDefault(string(CorsEnabled), true)
 	viper.SetDefault(string(CorsMaxAge), 600)
 	viper.SetDefault(string(DataexchangeType), "ffdx")
+	viper.SetDefault(string(DatabaseMaxChartRows), 100)
 	viper.SetDefault(string(DebugPort), -1)
 	viper.SetDefault(string(DownloadWorkerCount), 10)
 	viper.SetDefault(string(DownloadRetryMaxAttempts), 100)

--- a/internal/database/sqlcommon/chart_sql.go
+++ b/internal/database/sqlcommon/chart_sql.go
@@ -19,53 +19,14 @@ package sqlcommon
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strconv"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/hyperledger/firefly/internal/config"
 	"github.com/hyperledger/firefly/internal/i18n"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 )
-
-func (s *SQLCommon) getCaseQueriesByInterval(ns string, intervals []fftypes.ChartHistogramInterval) (caseQueries []sq.CaseBuilder) {
-	for _, interval := range intervals {
-		caseQueries = append(caseQueries, sq.Case().
-			When(
-				sq.And{
-					// Querying by 'timestamp' field for blockchain events
-					// If more tables are supported that have no "type" field,
-					// and a different date field name,
-					// this method will need to be refactored
-					sq.GtOrEq{"timestamp": interval.StartTime},
-					sq.Lt{"timestamp": interval.EndTime},
-					sq.Eq{"namespace": ns},
-				},
-				"1",
-			).
-			Else("0"))
-	}
-
-	return caseQueries
-}
-
-func (s *SQLCommon) getCaseQueriesByType(ns string, dataTypes []string, interval fftypes.ChartHistogramInterval, typeColName string) (caseQueries []sq.CaseBuilder) {
-	for _, dataType := range dataTypes {
-		caseQueries = append(caseQueries, sq.Case().
-			When(
-				sq.And{
-					sq.GtOrEq{"created": interval.StartTime},
-					sq.Lt{"created": interval.EndTime},
-					sq.Eq{typeColName: dataType},
-					sq.Eq{"namespace": ns},
-				},
-				"1",
-			).
-			Else("0"))
-	}
-
-	return caseQueries
-}
 
 func (s *SQLCommon) getTableNameFromCollection(ctx context.Context, collection database.CollectionName) (tableName string, fieldMap map[string]string, err error) {
 	switch collection {
@@ -86,149 +47,57 @@ func (s *SQLCommon) getTableNameFromCollection(ctx context.Context, collection d
 	}
 }
 
-func (s *SQLCommon) getDistinctTypesFromTable(ctx context.Context, tableName string, fieldMap map[string]string) ([]string, error) {
-	if _, ok := fieldMap["type"]; !ok {
-		return []string{}, nil
-	}
-	qb := sq.Select(fieldMap["type"]).Distinct().From(tableName)
-
-	rows, _, err := s.query(ctx, qb.From(tableName))
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var dataTypes []string
-	for rows.Next() {
-		var dataType string
-		err := rows.Scan(&dataType)
-		if err != nil {
-			return []string{}, i18n.WrapError(ctx, err, i18n.MsgDBReadErr, tableName)
-		}
-		dataTypes = append(dataTypes, dataType)
-	}
-	rows.Close()
-
-	return dataTypes, nil
-}
-
-func (s *SQLCommon) getBucketTotal(typeBuckets []*fftypes.ChartHistogramType) (string, error) {
-	total := 0
-	for _, typeBucket := range typeBuckets {
-		typeBucketInt, err := strconv.Atoi(typeBucket.Count)
-		if err != nil {
-			return "", err
-		}
-		total += typeBucketInt
-	}
-	return strconv.Itoa(total), nil
-}
-
-func (s *SQLCommon) histogramResultWithTypes(ctx context.Context, rows *sql.Rows, cols []*fftypes.ChartHistogramType, tableName string) ([]*fftypes.ChartHistogramType, error) {
-	results := []interface{}{}
-
-	for i := range cols {
-		results = append(results, &cols[i].Count)
-	}
-	err := rows.Scan(results...)
-	if err != nil {
-		return nil, i18n.NewError(ctx, i18n.MsgDBReadErr, tableName)
-	}
-
-	return cols, nil
-}
-
-func (s *SQLCommon) histogramResultNoType(ctx context.Context, rows *sql.Rows, cols []*fftypes.ChartHistogram, tableName string) ([]*fftypes.ChartHistogram, error) {
-	results := []interface{}{}
-
-	for i := range cols {
-		results = append(results, &cols[i].Count)
-	}
-	err := rows.Scan(results...)
-	if err != nil {
-		return nil, i18n.NewError(ctx, i18n.MsgDBReadErr, tableName)
-	}
-
-	return cols, nil
-}
-
-func (s *SQLCommon) getHistogramNoTypes(ctx context.Context, ns string, intervals []fftypes.ChartHistogramInterval, tableName string) (histogramList []*fftypes.ChartHistogram, err error) {
-	qb := sq.Select()
-
-	for i, caseQuery := range s.getCaseQueriesByInterval(ns, intervals) {
-		query, args, _ := caseQuery.ToSql()
-
-		histogramList = append(histogramList, &fftypes.ChartHistogram{
-			Count:     "0",
-			Timestamp: intervals[i].StartTime,
-			Types:     make([]*fftypes.ChartHistogramType, 0),
-		})
-
-		qb = qb.Column(sq.Alias(sq.Expr("SUM("+query+")", args...), fmt.Sprintf("case_%d", i)))
-
-	}
-
-	rows, _, err := s.query(ctx, qb.From(tableName))
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	if !rows.Next() {
-		return histogramList, nil
-	}
-
-	return s.histogramResultNoType(ctx, rows, histogramList, tableName)
-}
-
-func (s *SQLCommon) getHistogramWithTypes(ctx context.Context, ns string, intervals []fftypes.ChartHistogramInterval, dataTypes []string, fieldMap map[string]string, tableName string) (histogramList []*fftypes.ChartHistogram, err error) {
+func (s *SQLCommon) getSelectStatements(ns string, tableName string, intervals []fftypes.ChartHistogramInterval, timestampKey string, sql sq.SelectBuilder) (queries []sq.SelectBuilder) {
 	for _, interval := range intervals {
-		qb := sq.Select()
-		histogramTypes := make([]*fftypes.ChartHistogramType, 0)
-
-		for i, caseQuery := range s.getCaseQueriesByType(ns, dataTypes, interval, fieldMap["type"]) {
-			query, args, _ := caseQuery.ToSql()
-			histogramTypes = append(histogramTypes, &fftypes.ChartHistogramType{
-				Count: "",
-				Type:  dataTypes[i],
-			})
-
-			qb = qb.Column(sq.Alias(sq.Expr("SUM("+query+")", args...), fmt.Sprintf("case_%d", i)))
-		}
-
-		rows, _, err := s.query(ctx, qb.From(tableName))
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-
-		if rows.Next() {
-			hist, err := s.histogramResultWithTypes(ctx, rows, histogramTypes, tableName)
-			rows.Close()
-			if err != nil {
-				return nil, err
-			}
-
-			total, err := s.getBucketTotal(hist)
-			if err != nil {
-				return nil, err
-			}
-
-			histogramList = append(histogramList, &fftypes.ChartHistogram{
-				Count:     total,
-				Timestamp: interval.StartTime,
-				Types:     hist,
-			})
-		} else {
-			histogramList = append(histogramList, &fftypes.ChartHistogram{
-				Count:     "0",
-				Timestamp: interval.StartTime,
-				Types:     make([]*fftypes.ChartHistogramType, 0),
-			})
-		}
+		queries = append(queries, sql.
+			From(tableName).
+			Where(
+				sq.And{
+					sq.GtOrEq{timestampKey: interval.StartTime},
+					sq.Lt{timestampKey: interval.EndTime},
+					sq.Eq{"namespace": ns},
+				}).
+			OrderBy(timestampKey).
+			Limit(uint64(config.GetInt(config.DatabaseMaxChartRows))))
 	}
 
-	return histogramList, nil
+	return queries
+}
+
+func (s *SQLCommon) histogramResult(ctx context.Context, tableName string, rows *sql.Rows, onlyTimestamp bool) (map[string]int, string, error) {
+	total := 0
+	if onlyTimestamp {
+		countMap := map[string]int{}
+		for rows.Next() {
+			var timestamp string
+			err := rows.Scan(&timestamp)
+			if err != nil {
+				return nil, "", i18n.NewError(ctx, i18n.MsgDBReadErr, tableName)
+			}
+			total++
+		}
+		return countMap, strconv.Itoa(total), nil
+	}
+
+	typeMap := map[string]int{}
+	for rows.Next() {
+		var timestamp string
+		var typeStr string
+		err := rows.Scan(&timestamp, &typeStr)
+		if err != nil {
+			return nil, "", i18n.NewError(ctx, i18n.MsgDBReadErr, tableName)
+		}
+
+		if _, ok := typeMap[typeStr]; !ok {
+			typeMap[typeStr] = 1
+		} else {
+			typeMap[typeStr]++
+		}
+
+		total++
+	}
+
+	return typeMap, strconv.Itoa(total), nil
 }
 
 func (s *SQLCommon) GetChartHistogram(ctx context.Context, ns string, intervals []fftypes.ChartHistogramInterval, collection database.CollectionName) (histogramList []*fftypes.ChartHistogram, err error) {
@@ -237,23 +106,57 @@ func (s *SQLCommon) GetChartHistogram(ctx context.Context, ns string, intervals 
 		return nil, err
 	}
 
-	dataTypes, err := s.getDistinctTypesFromTable(ctx, tableName, fieldMap)
-	if err != nil {
-		return nil, err
+	// Timestamp column name
+	timestampKey := "created"
+	if tableName == "blockchainevents" {
+		// Blockchain Events have a `timestamp` column name
+		timestampKey = "timestamp"
 	}
 
-	if len(dataTypes) > 0 {
-		histogramList, err = s.getHistogramWithTypes(ctx, ns, intervals, dataTypes, fieldMap, tableName)
+	// Number of columns to read.
+	// Some tables don't have a `type` field and therefore
+	// a `type` field will not be queried
+	onlyTimestamp := true
+	cols := []string{timestampKey}
+	if typeStr, ok := fieldMap["type"]; ok {
+		cols = append(cols, typeStr)
+		onlyTimestamp = false
+	}
+
+	queries := s.getSelectStatements(ns, tableName, intervals, timestampKey, sq.Select(cols...))
+
+	for i, query := range queries {
+		// Query bucket's data
+		rows, _, err := s.query(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+
+		data, total, err := s.histogramResult(ctx, tableName, rows, onlyTimestamp)
 		if err != nil {
 			return nil, err
 		}
 
-		return histogramList, nil
-	}
+		histTypes := make([]*fftypes.ChartHistogramType, 0)
+		histBucket := fftypes.ChartHistogram{
+			Count:     total,
+			Timestamp: intervals[i].StartTime,
+			Types:     histTypes,
+		}
 
-	histogramList, err = s.getHistogramNoTypes(ctx, ns, intervals, tableName)
-	if err != nil {
-		return nil, err
+		// If the bucket has types, add their counts
+		if !onlyTimestamp {
+			for k, v := range data {
+				histBucket.Types = append(histBucket.Types,
+					&fftypes.ChartHistogramType{
+						Count: strconv.Itoa(v),
+						Type:  k,
+					})
+			}
+		}
+
+		histogramList = append(histogramList, &histBucket)
 	}
 
 	return histogramList, nil

--- a/internal/database/sqlcommon/chart_sql_test.go
+++ b/internal/database/sqlcommon/chart_sql_test.go
@@ -87,8 +87,17 @@ func TestGetChartHistogramInvalidCollectionName(t *testing.T) {
 func TestGetChartHistogramValidCollectionNameWithTypes(t *testing.T) {
 	for i := range validCollectionsWithTypes {
 		s, mock := newMockProvider().init()
-		mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("typeA").AddRow("typeB"))
-		mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "case_1"}).AddRow("5", "5"))
+		mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "type"}).
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB"))
 
 		histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName(validCollectionsWithTypes[i]))
 
@@ -101,7 +110,17 @@ func TestGetChartHistogramValidCollectionNameWithTypes(t *testing.T) {
 func TestGetChartHistogramValidCollectionNameNoTypes(t *testing.T) {
 	for i := range validCollectionsNoTypes {
 		s, mock := newMockProvider().init()
-		mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0"}).AddRow("10"))
+		mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp"}).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)).
+			AddRow(fftypes.UnixTime(1000000000)))
 
 		histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName(validCollectionsNoTypes[i]))
 		assert.NoError(t, err)
@@ -112,7 +131,6 @@ func TestGetChartHistogramValidCollectionNameNoTypes(t *testing.T) {
 
 func TestGetChartHistogramsQueryFail(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("typeA").AddRow("typeB"))
 	mock.ExpectQuery("SELECT *").WillReturnError(fmt.Errorf("pop"))
 
 	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
@@ -120,27 +138,30 @@ func TestGetChartHistogramsQueryFail(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGetChartHistogramsQueryFailNoTypes(t *testing.T) {
+func TestGetChartHistogramScanFailInvalidRowTypeOnlyTimestamp(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT *").WillReturnError(fmt.Errorf("pop"))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp"}).
+		AddRow(nil))
 
 	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("blockchainevents"))
-	assert.Regexp(t, "FF10115", err)
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGetChartHistogramQueryFailBadDistinctTypes(t *testing.T) {
+func TestGetChartHistogramScanFailTooManyColsOnlyTimestamp(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnError(fmt.Errorf("pop"))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "unexpected_col"}).
+		AddRow(fftypes.UnixTime(1000000000), "test"))
 
-	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
-	assert.Regexp(t, "FF10115", err)
+	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("blockchainevents"))
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetChartHistogramScanFailInvalidRowType(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow(nil).AddRow("typeB"))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "type"}).
+		AddRow(fftypes.UnixTime(1000000000), nil))
 
 	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
 	assert.Regexp(t, "FF10121", err)
@@ -149,37 +170,17 @@ func TestGetChartHistogramScanFailInvalidRowType(t *testing.T) {
 
 func TestGetChartHistogramScanFailTooManyCols(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("typeA").AddRow("typeB"))
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "case_1", "unexpected_col"}).AddRow("one", "two", "three"))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "type", "unexpected_col"}).
+		AddRow(fftypes.UnixTime(1000000000), "typeA", "test"))
 
 	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
 	assert.Regexp(t, "FF10121", err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestGetChartHistogramScanFailTooManyColsNoTypes(t *testing.T) {
-	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "unexpected"}).AddRow("10", "abc"))
-
-	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("blockchainevents"))
-	assert.Regexp(t, "FF10121", err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestGetChartHistogramFailStringToIntConversion(t *testing.T) {
-	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("typeA").AddRow("typeB"))
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "case_1"}).AddRow("5", "NotInt"))
-
-	_, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
-	assert.Error(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetChartHistogramSuccessNoRows(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("typeA").AddRow("typeB"))
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "case_1"}))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "type"}))
 
 	histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
 	assert.NoError(t, err)
@@ -187,35 +188,13 @@ func TestGetChartHistogramSuccessNoRows(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGetChartHistogramSuccessNoRowsNoTypes(t *testing.T) {
+func TestGetChartHistogramSuccessNoRowsOnlyTimestamp(t *testing.T) {
 	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "case_1"}))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp"}))
 
 	histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("blockchainevents"))
 	assert.NoError(t, err)
 
 	assert.Equal(t, emptyHistogramResult, histogram)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestGetChartHistogramSuccessNoTypes(t *testing.T) {
-	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0"}).AddRow("10"))
-
-	histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("blockchainevents"))
-	assert.NoError(t, err)
-	assert.Equal(t, expectedHistogramResultNoTypes, histogram)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestGetChartHistogramSuccess(t *testing.T) {
-	s, mock := newMockProvider().init()
-	mock.ExpectQuery("SELECT DISTINCT .*").WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("typeA").AddRow("typeB"))
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"case_0", "case_1"}).AddRow("5", "5"))
-
-	histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName("messages"))
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedHistogramResult, histogram)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
Previously, histogram buckets were created with a `CASE` query. This lead to performance issues when a large amount of data was queried from the database. 

This new method sets a max amount of rows to be queried in each bucket, with a default of 100 rows. 

The data structure and expected response is unchanged.