### PR TITLE
Change messages_data join table indexes for data_id lookup

### DIFF
--- a/db/migrations/postgres/000079_add_messages_data_newindexes.down.sql
+++ b/db/migrations/postgres/000079_add_messages_data_newindexes.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX messages_data_message;
+DROP INDEX messages_data_data;
+
+CREATE UNIQUE INDEX messages_data_idx ON messages_data(message_id, data_id);
+
+COMMIT;

--- a/db/migrations/postgres/000079_add_messages_data_newindexes.up.sql
+++ b/db/migrations/postgres/000079_add_messages_data_newindexes.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX messages_data_idx;
+
+CREATE INDEX messages_data_message ON messages_data(message_id);
+CREATE INDEX messages_data_data ON messages_data(data_id);
+
+COMMIT;

--- a/db/migrations/sqlite/000079_add_messages_data_newindexes.down.sql
+++ b/db/migrations/sqlite/000079_add_messages_data_newindexes.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX messages_data_message;
+DROP INDEX messages_data_data;
+
+CREATE UNIQUE INDEX messages_data_idx ON messages_data(message_id, data_id);

--- a/db/migrations/sqlite/000079_add_messages_data_newindexes.up.sql
+++ b/db/migrations/sqlite/000079_add_messages_data_newindexes.up.sql
@@ -1,0 +1,4 @@
+DROP INDEX messages_data_idx;
+
+CREATE INDEX messages_data_message ON messages_data(message_id);
+CREATE INDEX messages_data_data ON messages_data(data_id);


### PR DESCRIPTION
In long runs, we can see this query becomes very inefficient when a large amount of data has built up in the system:

https://github.com/hyperledger/firefly/blob/b7937f7571b9f913eab607fd67ec10020d879d1d/internal/events/aggregator.go#L609-L618

```
[2022-03-31T11:48:27.754Z] DEBUG node_1: SQL-> query: SELECT m.id, m.cid, dbtx=0MOmScfF role=event-manager
[2022-03-31T11:48:28.965Z] DEBUG node_1: SQL<- query dbtx=0MOmScfF role=event-manager
```

The original intention of this index was it would add a some (unnecessary in my view at this point) additional protection against data ID uniqueness within a message (already enforced strongly in code), while allowing a lookup in either direction to be efficient:

https://github.com/hyperledger/firefly/blob/b7937f7571b9f913eab607fd67ec10020d879d1d/db/migrations/postgres/000003_create_message_data_join_table.up.sql#L9

However, the results clearly indicate to me it's only helping with lookup in the `message_id` based lookups - and not the `data_id` based lookups. So this PR proposes we replace it with two separate and simple indexes.