### PR TITLE
[charts-isCapped] adding isCapped key to charts response

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1235,6 +1235,8 @@ paths:
                 properties:
                   count:
                     type: string
+                  isCapped:
+                    type: boolean
                   timestamp: {}
                   types:
                     items:

--- a/internal/database/sqlcommon/chart_sql.go
+++ b/internal/database/sqlcommon/chart_sql.go
@@ -143,6 +143,7 @@ func (s *SQLCommon) GetChartHistogram(ctx context.Context, ns string, intervals 
 			Count:     total,
 			Timestamp: intervals[i].StartTime,
 			Types:     histTypes,
+			IsCapped:  total == config.GetString(config.DatabaseMaxChartRows),
 		}
 
 		// If the bucket has types, add their counts

--- a/internal/database/sqlcommon/chart_sql_test.go
+++ b/internal/database/sqlcommon/chart_sql_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hyperledger/firefly/internal/config"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ var (
 	emptyHistogramResult = []*fftypes.ChartHistogram{
 		{
 			Count:     "0",
+			IsCapped:  false,
 			Timestamp: fftypes.UnixTime(1000000000),
 			Types:     make([]*fftypes.ChartHistogramType, 0),
 		},
@@ -38,6 +40,24 @@ var (
 	expectedHistogramResult = []*fftypes.ChartHistogram{
 		{
 			Count:     "10",
+			IsCapped:  false,
+			Timestamp: fftypes.UnixTime(1000000000),
+			Types: []*fftypes.ChartHistogramType{
+				{
+					Count: "5",
+					Type:  "typeA",
+				},
+				{
+					Count: "5",
+					Type:  "typeB",
+				},
+			},
+		},
+	}
+	expectedHistogramResultIsCapped = []*fftypes.ChartHistogram{
+		{
+			Count:     "10",
+			IsCapped:  true,
 			Timestamp: fftypes.UnixTime(1000000000),
 			Types: []*fftypes.ChartHistogramType{
 				{
@@ -54,6 +74,7 @@ var (
 	expectedHistogramResultNoTypes = []*fftypes.ChartHistogram{
 		{
 			Count:     "10",
+			IsCapped:  false,
 			Timestamp: fftypes.UnixTime(1000000000),
 			Types:     make([]*fftypes.ChartHistogramType, 0),
 		},
@@ -85,8 +106,8 @@ func TestGetChartHistogramInvalidCollectionName(t *testing.T) {
 }
 
 func TestGetChartHistogramValidCollectionNameWithTypes(t *testing.T) {
+	s, mock := newMockProvider().init()
 	for i := range validCollectionsWithTypes {
-		s, mock := newMockProvider().init()
 		mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "type"}).
 			AddRow(fftypes.UnixTime(1000000000), "typeA").
 			AddRow(fftypes.UnixTime(1000000000), "typeA").
@@ -102,9 +123,38 @@ func TestGetChartHistogramValidCollectionNameWithTypes(t *testing.T) {
 		histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName(validCollectionsWithTypes[i]))
 
 		assert.NoError(t, err)
-		assert.Equal(t, histogram[0].Count, expectedHistogramResult[0].Count)
-		assert.Equal(t, histogram[0].Timestamp, expectedHistogramResult[0].Timestamp)
-		assert.ElementsMatch(t, histogram[0].Types, expectedHistogramResult[0].Types)
+		assert.Equal(t, expectedHistogramResult[0].Count, histogram[0].Count)
+		assert.Equal(t, expectedHistogramResult[0].IsCapped, histogram[0].IsCapped)
+		assert.Equal(t, expectedHistogramResult[0].Timestamp, histogram[0].Timestamp)
+		assert.ElementsMatch(t, expectedHistogramResult[0].Types, histogram[0].Types)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	}
+}
+
+func TestGetChartHistogramValidCollectionNameWithTypesAndCapped(t *testing.T) {
+	s, mock := newMockProvider().init()
+	config.Reset()
+	config.Set(config.DatabaseMaxChartRows, 10)
+	for i := range validCollectionsWithTypes {
+		mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"timestamp", "type"}).
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeA").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB").
+			AddRow(fftypes.UnixTime(1000000000), "typeB"))
+
+		histogram, err := s.GetChartHistogram(context.Background(), "ns1", mockHistogramInterval, database.CollectionName(validCollectionsWithTypes[i]))
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedHistogramResultIsCapped[0].Count, histogram[0].Count)
+		assert.Equal(t, expectedHistogramResultIsCapped[0].IsCapped, histogram[0].IsCapped)
+		assert.Equal(t, expectedHistogramResultIsCapped[0].Timestamp, histogram[0].Timestamp)
+		assert.ElementsMatch(t, histogram[0].Types, expectedHistogramResultIsCapped[0].Types)
 		assert.NoError(t, mock.ExpectationsWereMet())
 	}
 }

--- a/pkg/fftypes/charthistogram.go
+++ b/pkg/fftypes/charthistogram.go
@@ -27,6 +27,8 @@ const (
 type ChartHistogram struct {
 	// Count for entire timestamp in histogram
 	Count string `json:"count"`
+	// IsCapped if one or more buckets are limited by config.DatabaseMaxChartRows
+	IsCapped bool `json:"isCapped"`
 	// Timestamp of bucket
 	Timestamp *FFTime `json:"timestamp"`
 	// Types list of histogram types and their count


### PR DESCRIPTION
New Response:
```json
[
    {
        "count": "0",
        "isCapped": false,
        "timestamp": "2022-04-06T23:21:00Z",
        "types": []
    },
    {
        "count": "100",
        "isCapped": true,
        "timestamp": "2022-04-07T00:57:00Z",
        "types": [
            {
                "count": "1",
                "type": "token_pool_confirmed"
            },
            {
                "count": "37",
                "type": "message_confirmed"
            },
            {
                "count": "12",
                "type": "token_transfer_confirmed"
            },
            {
                "count": "25",
                "type": "transaction_submitted"
            },
            {
                "count": "25",
                "type": "blockchain_event_received"
            }
        ]
    }
]
```