### PR TITLE
Add helper at /apis/{apiName}/listen

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -778,6 +778,158 @@ paths:
           description: Success
         default:
           description: ""
+  /namespaces/{ns}/apis/{apiName}/listen/{eventPath}:
+    post:
+      description: 'TODO: Description'
+      operationId: postContractAPIListen
+      parameters:
+      - description: 'TODO: Description'
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: 'TODO: Description'
+        in: path
+        name: apiName
+        required: true
+        schema:
+          type: string
+      - description: 'TODO: Description'
+        in: path
+        name: eventPath
+        required: true
+        schema:
+          type: string
+      - description: Server-side request timeout (millseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 120s
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                location:
+                  description: A blockchain specific contract identifier. For example
+                    an Ethereum contract address, or a Fabric chaincode name and channel
+                  type: string
+                name:
+                  description: A descriptive name for the listener
+                  type: string
+                options:
+                  description: Options that control how the listener subscribes to
+                    events from the underlying blockchain
+                  properties:
+                    firstEvent:
+                      description: A blockchain specific string, such as a block number,
+                        to start listening from. The special strings 'oldest' and
+                        'newest' are supported by all blockchain connectors. Default
+                        is 'newest'
+                      type: string
+                  type: object
+                topic:
+                  description: A topic to set on the FireFly event that is emitted
+                    each time a blockchain event is detected from the blockchain.
+                    Setting this topic on a number of listeners allows applications
+                    to easily subscribe to all events they need
+                  type: string
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  created:
+                    description: The creation time of the listener
+                  event:
+                    description: The definition of the event, either provided in-line
+                      when creating the listener, or extracted from the referenced
+                      FFI
+                    properties:
+                      description:
+                        description: A description of the smart contract event
+                        type: string
+                      name:
+                        description: The name of the event
+                        type: string
+                      params:
+                        description: An array of event parameter/argument definitions
+                        items:
+                          description: An array of event parameter/argument definitions
+                          properties:
+                            name:
+                              description: The name of the parameter. Note that parameters
+                                must be ordered correctly on the FFI, according to
+                                the order in the blockchain smart contract
+                              type: string
+                            schema:
+                              description: FireFly uses an extended subset of JSON
+                                Schema to describe parameters, similar to OpenAPI/Swagger.
+                                Converters are available for native blockchain interface
+                                definitions / type systems - such as an Ethereum ABI.
+                                See the documentation for more detail
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  id:
+                    description: The UUID of the smart contract listener
+                  interface:
+                    description: A reference to an existing FFI, containing pre-registered
+                      type information for the event
+                    properties:
+                      id:
+                        description: The UUID of the FireFly interface
+                      name:
+                        description: The name of the FireFly interface
+                        type: string
+                      version:
+                        description: The version of the FireFly interface
+                        type: string
+                    type: object
+                  location:
+                    description: A blockchain specific contract identifier. For example
+                      an Ethereum contract address, or a Fabric chaincode name and
+                      channel
+                    type: string
+                  name:
+                    description: A descriptive name for the listener
+                    type: string
+                  namespace:
+                    description: The namespace of the listener, which defines the
+                      namespace of all blockchain events detected by this listener
+                    type: string
+                  options:
+                    description: Options that control how the listener subscribes
+                      to events from the underlying blockchain
+                    properties:
+                      firstEvent:
+                        description: A blockchain specific string, such as a block
+                          number, to start listening from. The special strings 'oldest'
+                          and 'newest' are supported by all blockchain connectors.
+                          Default is 'newest'
+                        type: string
+                    type: object
+                  protocolId:
+                    description: An ID assigned by the blockchain connector to this
+                      listener
+                    type: string
+                  topic:
+                    description: A topic to set on the FireFly event that is emitted
+                      each time a blockchain event is detected from the blockchain.
+                      Setting this topic on a number of listeners allows applications
+                      to easily subscribe to all events they need
+                    type: string
+                type: object
+          description: Success
+        default:
+          description: ""
   /namespaces/{ns}/apis/{apiName}/query/{methodPath}:
     post:
       description: 'TODO: Description'

--- a/internal/apiserver/route_post_contract_api_listen.go
+++ b/internal/apiserver/route_post_contract_api_listen.go
@@ -1,0 +1,46 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/hyperledger/firefly/internal/config"
+	"github.com/hyperledger/firefly/internal/i18n"
+	"github.com/hyperledger/firefly/internal/oapispec"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+)
+
+var postContractAPIListen = &oapispec.Route{
+	Name:   "postContractAPIListen",
+	Path:   "namespaces/{ns}/apis/{apiName}/listen/{eventPath}",
+	Method: http.MethodPost,
+	PathParams: []*oapispec.PathParam{
+		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
+		{Name: "apiName", Description: i18n.MsgTBD},
+		{Name: "eventPath", Description: i18n.MsgTBD},
+	},
+	QueryParams:     []*oapispec.QueryParam{},
+	FilterFactory:   nil,
+	Description:     i18n.MsgTBD,
+	JSONInputValue:  func() interface{} { return &fftypes.ContractListener{} },
+	JSONOutputValue: func() interface{} { return &fftypes.ContractListener{} },
+	JSONOutputCodes: []int{http.StatusOK},
+	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
+		return getOr(r.Ctx).Contracts().AddContractAPIListener(r.Ctx, r.PP["ns"], r.PP["apiName"], r.PP["eventPath"], r.Input.(*fftypes.ContractListener))
+	},
+}

--- a/internal/apiserver/route_post_contract_api_listen_test.go
+++ b/internal/apiserver/route_post_contract_api_listen_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/firefly/mocks/contractmocks"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestPostContractAPIListen(t *testing.T) {
+	o, r := newTestAPIServer()
+	mcm := &contractmocks.Manager{}
+	o.On("Contracts").Return(mcm)
+	input := fftypes.Datatype{}
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(&input)
+	req := httptest.NewRequest("POST", "/api/v1/namespaces/ns1/apis/banana/listen/peeled", &buf)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	mcm.On("AddContractAPIListener", mock.Anything, "ns1", "banana", "peeled", mock.AnythingOfType("*fftypes.ContractListener")).Return(&fftypes.ContractListener{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 200, res.Result().StatusCode)
+}

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -87,6 +87,7 @@ var routes = []*oapispec.Route{
 	patchUpdateIdentity,
 	postContractAPIInvoke,
 	postContractAPIQuery,
+	postContractAPIListen,
 	postContractInterfaceGenerate,
 	postContractInterfaceInvoke,
 	postContractInterfaceQuery,

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -17,6 +17,29 @@ type Manager struct {
 	mock.Mock
 }
 
+// AddContractAPIListener provides a mock function with given fields: ctx, ns, apiName, eventPath, listener
+func (_m *Manager) AddContractAPIListener(ctx context.Context, ns string, apiName string, eventPath string, listener *fftypes.ContractListener) (*fftypes.ContractListener, error) {
+	ret := _m.Called(ctx, ns, apiName, eventPath, listener)
+
+	var r0 *fftypes.ContractListener
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *fftypes.ContractListener) *fftypes.ContractListener); ok {
+		r0 = rf(ctx, ns, apiName, eventPath, listener)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.ContractListener)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, *fftypes.ContractListener) error); ok {
+		r1 = rf(ctx, ns, apiName, eventPath, listener)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AddContractListener provides a mock function with given fields: ctx, ns, listener
 func (_m *Manager) AddContractListener(ctx context.Context, ns string, listener *fftypes.ContractListenerInput) (*fftypes.ContractListener, error) {
 	ret := _m.Called(ctx, ns, listener)

--- a/pkg/fftypes/contract_listener.go
+++ b/pkg/fftypes/contract_listener.go
@@ -26,13 +26,13 @@ import (
 
 type ContractListener struct {
 	ID         *UUID                    `ffstruct:"ContractListener" json:"id,omitempty" ffexcludeinput:"true"`
-	Interface  *FFIReference            `ffstruct:"ContractListener" json:"interface,omitempty"`
+	Interface  *FFIReference            `ffstruct:"ContractListener" json:"interface,omitempty" ffexcludeinput:"postContractAPIListen"`
 	Namespace  string                   `ffstruct:"ContractListener" json:"namespace,omitempty" ffexcludeinput:"true"`
 	Name       string                   `ffstruct:"ContractListener" json:"name,omitempty"`
 	ProtocolID string                   `ffstruct:"ContractListener" json:"protocolId,omitempty" ffexcludeinput:"true"`
 	Location   *JSONAny                 `ffstruct:"ContractListener" json:"location,omitempty"`
 	Created    *FFTime                  `ffstruct:"ContractListener" json:"created,omitempty" ffexcludeinput:"true"`
-	Event      *FFISerializedEvent      `ffstruct:"ContractListener" json:"event,omitempty"`
+	Event      *FFISerializedEvent      `ffstruct:"ContractListener" json:"event,omitempty" ffexcludeinput:"postContractAPIListen"`
 	Topic      string                   `ffstruct:"ContractListener" json:"topic,omitempty"`
 	Options    *ContractListenerOptions `ffstruct:"ContractListener" json:"options,omitempty"`
 }


### PR DESCRIPTION
This existed in the past and was removed due to perceived redundancy. However, it _would_ allow creating contract listeners with a single step if you know only the API name and not the underlying FFI ID (currently creating a listener in that case is a 2-step process, to go from API to FFI and then create the listener).

Note that this exists in parallel to the other RPC-style endpoints at `/apis/{apiName}/query` and `/apis/{apiName}/invoke`. It's worth discussing if a similar API should be added next to `/contracts/interfaces/{interfaceId}/query` and `/contracts/interfaces/{interfaceId}/invoke` (or possibly discussing the opposite, ie if _those_ should be pruned as redundant).