### PR TITLE
Status plugins

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -13785,6 +13785,70 @@ paths:
                           type: object
                         type: array
                     type: object
+                  plugins:
+                    description: Information about plugins configured on this node
+                    properties:
+                      blockchain:
+                        description: The blockchain plugins on this node
+                        items:
+                          description: The blockchain plugins on this node
+                          properties:
+                            connection:
+                              description: The name of the plugin
+                              type: string
+                          type: object
+                        type: array
+                      dataExchange:
+                        description: The data exchange plugins on this node
+                        items:
+                          description: The data exchange plugins on this node
+                          properties:
+                            connection:
+                              description: The name of the plugin
+                              type: string
+                          type: object
+                        type: array
+                      database:
+                        description: The database plugins on this node
+                        items:
+                          description: The database plugins on this node
+                          properties:
+                            connection:
+                              description: The name of the plugin
+                              type: string
+                          type: object
+                        type: array
+                      identity:
+                        description: The identity plugins on this node
+                        items:
+                          description: The identity plugins on this node
+                          properties:
+                            connection:
+                              description: The name of the plugin
+                              type: string
+                          type: object
+                        type: array
+                      sharedStorage:
+                        description: The shared storage plugins on this node
+                        items:
+                          description: The shared storage plugins on this node
+                          properties:
+                            connection:
+                              description: The name of the plugin
+                              type: string
+                          type: object
+                        type: array
+                      tokens:
+                        description: The token plugins on this node
+                        items:
+                          description: The token plugins on this node
+                          properties:
+                            connection:
+                              description: The name of the plugin
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                 type: object
           description: Success
         default:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -13793,8 +13793,11 @@ paths:
                         items:
                           description: The blockchain plugins on this node
                           properties:
-                            connection:
+                            name:
                               description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
                               type: string
                           type: object
                         type: array
@@ -13803,8 +13806,11 @@ paths:
                         items:
                           description: The data exchange plugins on this node
                           properties:
-                            connection:
+                            name:
                               description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
                               type: string
                           type: object
                         type: array
@@ -13813,8 +13819,24 @@ paths:
                         items:
                           description: The database plugins on this node
                           properties:
-                            connection:
+                            name:
                               description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
+                              type: string
+                          type: object
+                        type: array
+                      events:
+                        description: The event plugins on this node
+                        items:
+                          description: The event plugins on this node
+                          properties:
+                            name:
+                              description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
                               type: string
                           type: object
                         type: array
@@ -13823,8 +13845,11 @@ paths:
                         items:
                           description: The identity plugins on this node
                           properties:
-                            connection:
+                            name:
                               description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
                               type: string
                           type: object
                         type: array
@@ -13833,8 +13858,11 @@ paths:
                         items:
                           description: The shared storage plugins on this node
                           properties:
-                            connection:
+                            name:
                               description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
                               type: string
                           type: object
                         type: array
@@ -13843,8 +13871,11 @@ paths:
                         items:
                           description: The token plugins on this node
                           properties:
-                            connection:
+                            name:
                               description: The name of the plugin
+                              type: string
+                            pluginType:
+                              description: The type of the plugin
                               type: string
                           type: object
                         type: array

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -369,6 +369,7 @@ var (
 	NodeStatusNode = ffm("NodeStatus.node", "Details of the local node")
 	NodeStatusOrg  = ffm("NodeStatus.org", "Details of the organization identity that operates this node")
 	NodeDefaults   = ffm("NodeStatus.defaults", "Information about defaults configured on this node that appplications might need to query on startup")
+	NodePlugins    = ffm("NodeStatus.plugins", "Information about plugins configured on this node")
 
 	// NodeStatusNode field descriptions
 	NodeStatusNodeName       = ffm("NodeStatusNode.name", "The name of this node, as specified in the local configuration")
@@ -384,6 +385,17 @@ var (
 
 	// NodeStatusDefaults field descriptions
 	NodeStatusDefaultsNamespace = ffm("NodeStatusDefaults.namespace", "The default namespace on this node")
+
+	// NodeStatusPlugins field descriptions
+	NodeStatusPluginsBlockchain    = ffm("NodeStatusPlugins.blockchain", "The blockchain plugins on this node")
+	NodeStatusPluginsDatabase      = ffm("NodeStatusPlugins.database", "The database plugins on this node")
+	NodeStatusPluginsDataExchange  = ffm("NodeStatusPlugins.dataExchange", "The data exchange plugins on this node")
+	NodeStatusPluginsIdentity      = ffm("NodeStatusPlugins.identity", "The identity plugins on this node")
+	NodeStatusPluginsSharedStorage = ffm("NodeStatusPlugins.sharedStorage", "The shared storage plugins on this node")
+	NodeStatusPluginsTokens        = ffm("NodeStatusPlugins.tokens", "The token plugins on this node")
+
+	// NodeStatusPlugin field descriptions
+	NodeStatusPlugin = ffm("NodeStatusPlugin.connection", "The name of the plugin")
 
 	// BatchManagerStatus field descriptions
 	BatchManagerStatusProcessors = ffm("BatchManagerStatus.processors", "An array of currently active batch processors")

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -390,12 +390,14 @@ var (
 	NodeStatusPluginsBlockchain    = ffm("NodeStatusPlugins.blockchain", "The blockchain plugins on this node")
 	NodeStatusPluginsDatabase      = ffm("NodeStatusPlugins.database", "The database plugins on this node")
 	NodeStatusPluginsDataExchange  = ffm("NodeStatusPlugins.dataExchange", "The data exchange plugins on this node")
+	Events                         = ffm("NodeStatusPlugins.events", "The event plugins on this node")
 	NodeStatusPluginsIdentity      = ffm("NodeStatusPlugins.identity", "The identity plugins on this node")
 	NodeStatusPluginsSharedStorage = ffm("NodeStatusPlugins.sharedStorage", "The shared storage plugins on this node")
 	NodeStatusPluginsTokens        = ffm("NodeStatusPlugins.tokens", "The token plugins on this node")
 
 	// NodeStatusPlugin field descriptions
-	NodeStatusPlugin = ffm("NodeStatusPlugin.connection", "The name of the plugin")
+	NodeStatusPluginName = ffm("NodeStatusPlugin.name", "The name of the plugin")
+	NodeStatusPluginType = ffm("NodeStatusPlugin.pluginType", "The type of the plugin")
 
 	// BatchManagerStatus field descriptions
 	BatchManagerStatusProcessors = ffm("BatchManagerStatus.processors", "An array of currently active batch processors")

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -78,6 +78,8 @@ type EventManager interface {
 	TokensTransferred(ti tokens.Plugin, transfer *tokens.TokenTransfer) error
 	TokensApproved(ti tokens.Plugin, approval *tokens.TokenApproval) error
 
+	GetPlugins() []*fftypes.NodeStatusPlugin
+
 	// Internal events
 	sysmessaging.SystemEvents
 }
@@ -247,4 +249,17 @@ func (em *eventManager) DeleteDurableSubscription(ctx context.Context, subDef *f
 
 func (em *eventManager) AddSystemEventListener(ns string, el system.EventListener) error {
 	return em.internalEvents.AddListener(ns, el)
+}
+
+func (em *eventManager) GetPlugins() []*fftypes.NodeStatusPlugin {
+	eventsArray := make([]*fftypes.NodeStatusPlugin, 0)
+	plugins := em.subManager.transports
+
+	for _, plugin := range plugins {
+		eventsArray = append(eventsArray, &fftypes.NodeStatusPlugin{
+			PluginType: plugin.Name(),
+		})
+	}
+
+	return eventsArray
 }

--- a/internal/events/event_manager_test.go
+++ b/internal/events/event_manager_test.go
@@ -406,3 +406,21 @@ func TestAddInternalListener(t *testing.T) {
 
 	cbs.AssertExpectations(t)
 }
+
+func TestGetPlugins(t *testing.T) {
+	em, _ := newTestEventManager(t)
+
+	expectedPlugins := []*fftypes.NodeStatusPlugin{
+		{
+			PluginType: "websockets",
+		},
+		{
+			PluginType: "webhooks",
+		},
+		{
+			PluginType: "system",
+		},
+	}
+
+	assert.ElementsMatch(t, em.GetPlugins(), expectedPlugins)
+}

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -30,36 +30,38 @@ import (
 func (or *orchestrator) getPlugins() fftypes.NodeStatusPlugins {
 	// Tokens can have more than one name, so they must be iterated over
 	tokensArray := make([]*fftypes.NodeStatusPlugin, 0)
-	for name := range or.tokens {
+	for name, plugin := range or.tokens {
 		tokensArray = append(tokensArray, &fftypes.NodeStatusPlugin{
-			Connection: name,
+			Name:       name,
+			PluginType: plugin.Name(),
 		})
 	}
 
 	return fftypes.NodeStatusPlugins{
 		Blockchain: []*fftypes.NodeStatusPlugin{
 			{
-				Connection: or.blockchain.Name(),
+				PluginType: or.blockchain.Name(),
 			},
 		},
 		Database: []*fftypes.NodeStatusPlugin{
 			{
-				Connection: or.database.Name(),
+				PluginType: or.database.Name(),
 			},
 		},
 		DataExchange: []*fftypes.NodeStatusPlugin{
 			{
-				Connection: or.dataexchange.Name(),
+				PluginType: or.dataexchange.Name(),
 			},
 		},
+		Events: or.events.GetPlugins(),
 		Identity: []*fftypes.NodeStatusPlugin{
 			{
-				Connection: or.identityPlugin.Name(),
+				PluginType: or.identityPlugin.Name(),
 			},
 		},
 		SharedStorage: []*fftypes.NodeStatusPlugin{
 			{
-				Connection: or.sharedstorage.Name(),
+				PluginType: or.sharedstorage.Name(),
 			},
 		},
 		Tokens: tokensArray,

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -27,6 +27,45 @@ import (
 	"github.com/hyperledger/firefly/pkg/log"
 )
 
+func (or *orchestrator) getPlugins() fftypes.NodeStatusPlugins {
+	// Tokens can have more than one name, so they must be iterated over
+	tokensArray := make([]*fftypes.NodeStatusPlugin, 0)
+	for name := range or.tokens {
+		tokensArray = append(tokensArray, &fftypes.NodeStatusPlugin{
+			Connection: name,
+		})
+	}
+
+	return fftypes.NodeStatusPlugins{
+		Blockchain: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: or.blockchain.Name(),
+			},
+		},
+		Database: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: or.database.Name(),
+			},
+		},
+		DataExchange: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: or.dataexchange.Name(),
+			},
+		},
+		Identity: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: or.identityPlugin.Name(),
+			},
+		},
+		SharedStorage: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: or.sharedstorage.Name(),
+			},
+		},
+		Tokens: tokensArray,
+	}
+}
+
 func (or *orchestrator) GetNodeUUID(ctx context.Context) (node *fftypes.UUID) {
 	if or.node != nil {
 		return or.node
@@ -60,6 +99,7 @@ func (or *orchestrator) GetStatus(ctx context.Context) (status *fftypes.NodeStat
 		Defaults: fftypes.NodeStatusDefaults{
 			Namespace: config.GetString(coreconfig.NamespacesDefault),
 		},
+		Plugins: or.getPlugins(),
 	}
 
 	if org != nil {

--- a/internal/orchestrator/status_test.go
+++ b/internal/orchestrator/status_test.go
@@ -29,6 +29,41 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+var (
+	pluginsResult = fftypes.NodeStatusPlugins{
+		Blockchain: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: "mock-bi",
+			},
+		},
+		Database: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: "mock-di",
+			},
+		},
+		DataExchange: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: "mock-dx",
+			},
+		},
+		Identity: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: "mock-ii",
+			},
+		},
+		SharedStorage: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: "mock-ps",
+			},
+		},
+		Tokens: []*fftypes.NodeStatusPlugin{
+			{
+				Connection: "token",
+			},
+		},
+	}
+)
+
 func TestGetStatusRegistered(t *testing.T) {
 	or := newTestOrchestrator()
 
@@ -77,6 +112,14 @@ func TestGetStatusRegistered(t *testing.T) {
 	assert.True(t, status.Node.Registered)
 	assert.Equal(t, *nodeID, *status.Node.ID)
 	assert.Equal(t, "0x12345", status.Org.Verifiers[0].Value)
+
+	// Plugins
+	assert.ElementsMatch(t, pluginsResult.Blockchain, status.Plugins.Blockchain)
+	assert.ElementsMatch(t, pluginsResult.Database, status.Plugins.Database)
+	assert.ElementsMatch(t, pluginsResult.DataExchange, status.Plugins.DataExchange)
+	assert.ElementsMatch(t, pluginsResult.Identity, status.Plugins.Identity)
+	assert.ElementsMatch(t, pluginsResult.SharedStorage, status.Plugins.SharedStorage)
+	assert.ElementsMatch(t, pluginsResult.Tokens, status.Plugins.Tokens)
 
 	assert.True(t, or.GetNodeUUID(or.ctx).Equals(nodeID))
 	assert.True(t, or.GetNodeUUID(or.ctx).Equals(nodeID)) // cached
@@ -232,6 +275,14 @@ func TestGetStatusOrgOnlyRegistered(t *testing.T) {
 
 	assert.Equal(t, "node1", status.Node.Name)
 	assert.False(t, status.Node.Registered)
+
+	// Plugins
+	assert.ElementsMatch(t, pluginsResult.Blockchain, status.Plugins.Blockchain)
+	assert.ElementsMatch(t, pluginsResult.Database, status.Plugins.Database)
+	assert.ElementsMatch(t, pluginsResult.DataExchange, status.Plugins.DataExchange)
+	assert.ElementsMatch(t, pluginsResult.Identity, status.Plugins.Identity)
+	assert.ElementsMatch(t, pluginsResult.SharedStorage, status.Plugins.SharedStorage)
+	assert.ElementsMatch(t, pluginsResult.Tokens, status.Plugins.Tokens)
 
 	assert.Nil(t, or.GetNodeUUID(or.ctx))
 }

--- a/mocks/eventmocks/event_manager.go
+++ b/mocks/eventmocks/event_manager.go
@@ -132,6 +132,22 @@ func (_m *EventManager) DeletedSubscriptions() chan<- *fftypes.UUID {
 	return r0
 }
 
+// GetPlugins provides a mock function with given fields:
+func (_m *EventManager) GetPlugins() []*fftypes.NodeStatusPlugin {
+	ret := _m.Called()
+
+	var r0 []*fftypes.NodeStatusPlugin
+	if rf, ok := ret.Get(0).(func() []*fftypes.NodeStatusPlugin); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*fftypes.NodeStatusPlugin)
+		}
+	}
+
+	return r0
+}
+
 // NewEvents provides a mock function with given fields:
 func (_m *EventManager) NewEvents() chan<- int64 {
 	ret := _m.Called()

--- a/pkg/fftypes/node_status.go
+++ b/pkg/fftypes/node_status.go
@@ -21,6 +21,7 @@ type NodeStatus struct {
 	Node     NodeStatusNode     `ffstruct:"NodeStatus" json:"node"`
 	Org      NodeStatusOrg      `ffstruct:"NodeStatus" json:"org"`
 	Defaults NodeStatusDefaults `ffstruct:"NodeStatus" json:"defaults"`
+	Plugins  NodeStatusPlugins  `ffstruct:"NodeStatus" json:"plugins"`
 }
 
 // NodeStatusNode is the information about the local node, returned in the node status
@@ -42,4 +43,19 @@ type NodeStatusOrg struct {
 // NodeStatusDefaults is information about core configuration th
 type NodeStatusDefaults struct {
 	Namespace string `ffstruct:"NodeStatusDefaults" json:"namespace"`
+}
+
+// NodeStatusPlugins is a map of plugins configured on the node
+type NodeStatusPlugins struct {
+	Blockchain    []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"blockchain"`
+	Database      []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"database"`
+	DataExchange  []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"dataExchange"`
+	Identity      []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"identity"`
+	SharedStorage []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"sharedStorage"`
+	Tokens        []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"tokens"`
+}
+
+// NodeStatusPlugin is information about a plugin
+type NodeStatusPlugin struct {
+	Connection string `ffstruct:"NodeStatusPlugin" json:"connection"`
 }

--- a/pkg/fftypes/node_status.go
+++ b/pkg/fftypes/node_status.go
@@ -50,6 +50,7 @@ type NodeStatusPlugins struct {
 	Blockchain    []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"blockchain"`
 	Database      []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"database"`
 	DataExchange  []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"dataExchange"`
+	Events        []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"events"`
 	Identity      []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"identity"`
 	SharedStorage []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"sharedStorage"`
 	Tokens        []*NodeStatusPlugin `ffstruct:"NodeStatusPlugins" json:"tokens"`
@@ -57,5 +58,6 @@ type NodeStatusPlugins struct {
 
 // NodeStatusPlugin is information about a plugin
 type NodeStatusPlugin struct {
-	Connection string `ffstruct:"NodeStatusPlugin" json:"connection"`
+	Name       string `ffstruct:"NodeStatusPlugin" json:"name,omitempty"`
+	PluginType string `ffstruct:"NodeStatusPlugin" json:"pluginType"`
 }


### PR DESCRIPTION
`GET /api/v1/status` now returns a `plugin` key:
```json
{
  "node": {...},
  "org": {...},
  "defaults": {...},
  "plugins": {
    "blockchain": [
      {
        "pluginType": "ethereum"
      }
    ],
    "database": [
      {
        "pluginType": "sqlite3"
      }
    ],
    "dataExchange": [
      {
        "pluginType": "ffdx"
      }
    ],
    "events": [
      {
        "pluginType": "system"
      },
      {
        "pluginType": "websockets"
      },
      {
        "pluginType": "webhooks"
      }
    ],
    "identity": [
      {
        "pluginType": "onchain"
      }
    ],
    "sharedStorage": [
      {
        "pluginType": "ipfs"
      }
    ],
    "tokens": [
      {
        "name": "erc1155",
        "pluginType": "fftokens"
      }
    ]
  }
}
```