### PR TITLE
Perform all identity claims, under the root identity topic ordering context

### DIFF
--- a/internal/broadcast/definition.go
+++ b/internal/broadcast/definition.go
@@ -50,6 +50,11 @@ func (bm *broadcastManager) BroadcastIdentityClaim(ctx context.Context, ns strin
 		return nil, err
 	}
 
+	// We must have the root here passed in, so all definitions from that root are ordered consistently
+	if def.Root == nil {
+		return nil, i18n.NewError(ctx, coremsgs.MsgParentIdentityNotResolved)
+	}
+
 	return bm.broadcastDefinitionCommon(ctx, ns, def, signingIdentity, tag, waitConfirm)
 }
 

--- a/internal/broadcast/definition_test.go
+++ b/internal/broadcast/definition_test.go
@@ -57,12 +57,31 @@ func TestBroadcastIdentityClaim(t *testing.T) {
 
 	_, err := bm.BroadcastIdentityClaim(bm.ctx, fftypes.SystemNamespace, &fftypes.IdentityClaim{
 		Identity: &fftypes.Identity{},
+		Root:     &fftypes.IdentityBase{},
 	}, &fftypes.SignerRef{
 		Key: "0x1234",
 	}, fftypes.SystemTagDefineNamespace, true)
 	assert.EqualError(t, err, "pop")
 
 	msa.AssertExpectations(t)
+	mim.AssertExpectations(t)
+}
+
+func TestBroadcastIdentityClaimMissingRoot(t *testing.T) {
+	bm, cancel := newTestBroadcast(t)
+	defer cancel()
+
+	mim := bm.identity.(*identitymanagermocks.Manager)
+
+	mim.On("NormalizeSigningKey", mock.Anything, "0x1234", identity.KeyNormalizationBlockchainPlugin).Return("", nil)
+
+	_, err := bm.BroadcastIdentityClaim(bm.ctx, fftypes.SystemNamespace, &fftypes.IdentityClaim{
+		Identity: &fftypes.Identity{},
+	}, &fftypes.SignerRef{
+		Key: "0x1234",
+	}, fftypes.SystemTagDefineNamespace, true)
+	assert.Regexp(t, "FF10385", err)
+
 	mim.AssertExpectations(t)
 }
 

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -231,4 +231,5 @@ var (
 	MsgFFStructTagMissing           = ffe("FF10382", "ffstruct tag is missing for '%s' on route '%s'")
 	MsgContractListenerExists       = ffe("FF10383", "A contract listener already exists for this combination of topic + location + event", 409)
 	MsgRouteDescriptionMissing      = ffe("FF10384", "API route description missing for route '%s'")
+	MsgParentIdentityNotResolved    = ffe("FF10385", "Attempt to broadcast without a resolved parent identity")
 )

--- a/internal/definitions/definition_handler_identity_claim.go
+++ b/internal/definitions/definition_handler_identity_claim.go
@@ -130,7 +130,7 @@ func (dh *definitionHandlers) handleIdentityClaim(ctx context.Context, state Def
 	l := log.L(ctx)
 
 	identity := identityClaim.Identity
-	parent, retryable, err := dh.identity.VerifyIdentityChain(ctx, identity)
+	parent, _, retryable, err := dh.identity.VerifyIdentityChain(ctx, identity)
 	if err != nil && retryable {
 		return HandlerResult{Action: ActionRetry}, err
 	} else if err != nil {

--- a/internal/definitions/definition_handler_identity_claim_test.go
+++ b/internal/definitions/definition_handler_identity_claim_test.go
@@ -144,7 +144,7 @@ func TestHandleDefinitionIdentityClaimCustomWithExistingParentVerificationOk(t *
 	custom1, org1, claimMsg, claimData, verifyMsg, verifyData := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -194,7 +194,7 @@ func TestHandleDefinitionIdentityClaimIdempotentReplay(t *testing.T) {
 	custom1, org1, claimMsg, claimData, verifyMsg, verifyData := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -239,7 +239,7 @@ func TestHandleDefinitionIdentityClaimFailInsertIdentity(t *testing.T) {
 	custom1, org1, claimMsg, claimData, verifyMsg, verifyData := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -271,7 +271,7 @@ func TestHandleDefinitionIdentityClaimVerificationDataFail(t *testing.T) {
 	custom1, org1, claimMsg, claimData, verifyMsg, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -301,7 +301,7 @@ func TestHandleDefinitionIdentityClaimVerificationMissingData(t *testing.T) {
 	custom1, org1, claimMsg, claimData, verifyMsg, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -331,7 +331,7 @@ func TestHandleDefinitionIdentityClaimFailInsertVerifier(t *testing.T) {
 	custom1, org1, claimMsg, claimData, verifyMsg, verifyData := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -362,7 +362,7 @@ func TestHandleDefinitionIdentityClaimCustomMissingParentVerificationOk(t *testi
 	custom1, org1, claimMsg, claimData, _, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -386,7 +386,7 @@ func TestHandleDefinitionIdentityClaimCustomParentVerificationFail(t *testing.T)
 	custom1, org1, claimMsg, claimData, _, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -410,7 +410,7 @@ func TestHandleDefinitionIdentityClaimVerifierClash(t *testing.T) {
 	custom1, org1, claimMsg, claimData, _, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -435,7 +435,7 @@ func TestHandleDefinitionIdentityClaimVerifierError(t *testing.T) {
 	custom1, org1, claimMsg, claimData, _, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -458,7 +458,7 @@ func TestHandleDefinitionIdentityClaimIdentityClash(t *testing.T) {
 	custom1, org1, claimMsg, claimData, _, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(&fftypes.Identity{
@@ -483,7 +483,7 @@ func TestHandleDefinitionIdentityClaimIdentityError(t *testing.T) {
 	custom1, org1, claimMsg, claimData, _, _ := testCustomClaimAndVerification(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, custom1.Type, custom1.Namespace, custom1.Name).Return(nil, nil)
@@ -506,7 +506,7 @@ func TestHandleDefinitionIdentityMissingAuthor(t *testing.T) {
 	claimMsg.Header.Author = ""
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	action, err := dh.HandleDefinitionBroadcast(ctx, bs, claimMsg, fftypes.DataArray{claimData}, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: ActionReject}, action)
@@ -524,7 +524,7 @@ func TestHandleDefinitionIdentityClaimBadSignature(t *testing.T) {
 	claimMsg.Header.Author = org1.DID // should be the child for the claim
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(org1, nil, false, nil)
 
 	action, err := dh.HandleDefinitionBroadcast(ctx, bs, claimMsg, fftypes.DataArray{claimData}, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: ActionReject}, action)
@@ -542,7 +542,7 @@ func TestHandleDefinitionIdentityVerifyChainFail(t *testing.T) {
 	claimMsg.Header.Author = org1.DID // should be the child for the claim
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(nil, true, fmt.Errorf("pop"))
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(nil, nil, true, fmt.Errorf("pop"))
 
 	action, err := dh.HandleDefinitionBroadcast(ctx, bs, claimMsg, fftypes.DataArray{claimData}, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: ActionRetry}, action)
@@ -560,7 +560,7 @@ func TestHandleDefinitionIdentityVerifyChainInvalid(t *testing.T) {
 	claimMsg.Header.Author = org1.DID // should be the child for the claim
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, custom1).Return(nil, false, fmt.Errorf("wrong"))
+	mim.On("VerifyIdentityChain", ctx, custom1).Return(nil, nil, false, fmt.Errorf("wrong"))
 
 	action, err := dh.HandleDefinitionBroadcast(ctx, bs, claimMsg, fftypes.DataArray{claimData}, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: ActionReject}, action)

--- a/internal/definitions/definition_handler_identity_verification_test.go
+++ b/internal/definitions/definition_handler_identity_verification_test.go
@@ -39,7 +39,7 @@ func TestHandleDefinitionIdentityVerificationWithExistingClaimOk(t *testing.T) {
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
 	mim.On("CachedIdentityLookupByID", ctx, org1.ID).Return(org1, nil)
-	mim.On("VerifyIdentityChain", ctx, mock.Anything).Return(custom1, false, nil)
+	mim.On("VerifyIdentityChain", ctx, mock.Anything).Return(custom1, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetMessageByID", ctx, claimMsg.Header.ID).Return(nil, nil) // Simulate pending confirm in same pin batch

--- a/internal/definitions/definition_handler_network_node_test.go
+++ b/internal/definitions/definition_handler_network_node_test.go
@@ -106,7 +106,7 @@ func TestHandleDeprecatedNodeDefinitionOK(t *testing.T) {
 		Type:  fftypes.VerifierTypeEthAddress,
 		Value: node.Owner,
 	}).Return(parent.Migrated().Identity, nil)
-	mim.On("VerifyIdentityChain", ctx, mock.Anything).Return(parent.Migrated().Identity, false, nil)
+	mim.On("VerifyIdentityChain", ctx, mock.Anything).Return(parent.Migrated().Identity, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, fftypes.IdentityTypeNode, fftypes.SystemNamespace, node.Name).Return(nil, nil)

--- a/internal/definitions/definition_handler_network_org_test.go
+++ b/internal/definitions/definition_handler_network_org_test.go
@@ -89,7 +89,7 @@ func TestHandleDeprecatedOrgDefinitionOK(t *testing.T) {
 	org, msg, data := testDeprecatedRootOrg(t)
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", ctx, mock.Anything).Return(nil, false, nil)
+	mim.On("VerifyIdentityChain", ctx, mock.Anything).Return(nil, nil, false, nil)
 
 	mdi := dh.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByName", ctx, fftypes.IdentityTypeOrg, fftypes.SystemNamespace, org.Name).Return(nil, nil)

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -929,8 +929,9 @@ func TestVerifyIdentityChainCustomOrgOrgOk(t *testing.T) {
 	mdi.On("GetIdentityByID", ctx, idIntermediateCustom.ID).Return(idIntermediateCustom, nil).Once()
 	mdi.On("GetIdentityByID", ctx, idRoot.ID).Return(idRoot, nil).Once()
 
-	immeidateParent, _, err := im.VerifyIdentityChain(ctx, idLeaf)
+	immeidateParent, identityRoot, _, err := im.VerifyIdentityChain(ctx, idLeaf)
 	assert.Equal(t, idIntermediateCustom, immeidateParent)
+	assert.Equal(t, idRoot, identityRoot)
 	assert.NoError(t, err)
 
 	mdi.AssertExpectations(t)
@@ -944,7 +945,7 @@ func TestVerifyIdentityInvalid(t *testing.T) {
 		IdentityBase: fftypes.IdentityBase{},
 	}
 
-	_, retryable, err := im.VerifyIdentityChain(ctx, id1)
+	_, _, retryable, err := im.VerifyIdentityChain(ctx, id1)
 	assert.Regexp(t, "FF00114", err)
 	assert.False(t, retryable)
 
@@ -986,7 +987,7 @@ func TestVerifyIdentityChainLoop(t *testing.T) {
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByID", ctx, idID2).Return(id2, nil).Once()
 
-	_, retryable, err := im.VerifyIdentityChain(ctx, id1)
+	_, _, retryable, err := im.VerifyIdentityChain(ctx, id1)
 	assert.Regexp(t, "FF10364", err)
 	assert.False(t, retryable)
 
@@ -1022,7 +1023,7 @@ func TestVerifyIdentityChainBadParent(t *testing.T) {
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByID", ctx, idID2).Return(id2, nil).Once()
 
-	_, retryable, err := im.VerifyIdentityChain(ctx, id1)
+	_, _, retryable, err := im.VerifyIdentityChain(ctx, id1)
 	assert.Regexp(t, "FF10366", err)
 	assert.False(t, retryable)
 
@@ -1048,7 +1049,7 @@ func TestVerifyIdentityChainErr(t *testing.T) {
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByID", ctx, idID2).Return(nil, fmt.Errorf("pop"))
 
-	_, retryable, err := im.VerifyIdentityChain(ctx, id1)
+	_, _, retryable, err := im.VerifyIdentityChain(ctx, id1)
 	assert.Regexp(t, "pop", err)
 	assert.True(t, retryable)
 
@@ -1074,7 +1075,7 @@ func TestVerifyIdentityChainNotFound(t *testing.T) {
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByID", ctx, idID2).Return(nil, nil)
 
-	_, retryable, err := im.VerifyIdentityChain(ctx, id1)
+	_, _, retryable, err := im.VerifyIdentityChain(ctx, id1)
 	assert.Regexp(t, "FF10214", err)
 	assert.False(t, retryable)
 
@@ -1109,7 +1110,7 @@ func TestVerifyIdentityChainInvalidParent(t *testing.T) {
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByID", ctx, id1.ID).Return(id1, nil).Once()
 
-	_, retryable, err := im.VerifyIdentityChain(ctx, id2)
+	_, _, retryable, err := im.VerifyIdentityChain(ctx, id2)
 	assert.Regexp(t, "FF10365", err)
 	assert.False(t, retryable)
 

--- a/internal/networkmap/register_identity_test.go
+++ b/internal/networkmap/register_identity_test.go
@@ -38,7 +38,7 @@ func TestRegisterIdentityOrgWithParentOk(t *testing.T) {
 	parentIdentity := testOrg("parent1")
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, &fftypes.Identity{}, false, nil)
 	mim.On("ResolveIdentitySigner", nm.ctx, parentIdentity).Return(&fftypes.SignerRef{
 		Key: "0x23456",
 	}, nil)
@@ -84,7 +84,7 @@ func TestRegisterIdentityOrgWithParentWaitConfirmOk(t *testing.T) {
 	parentIdentity := testOrg("parent1")
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, &fftypes.Identity{}, false, nil)
 	mim.On("ResolveIdentitySigner", nm.ctx, parentIdentity).Return(&fftypes.SignerRef{
 		Key: "0x23456",
 	}, nil)
@@ -141,7 +141,7 @@ func TestRegisterIdentityCustomWithParentFail(t *testing.T) {
 	parentIdentity := testOrg("parent1")
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, &fftypes.Identity{}, false, nil)
 	mim.On("CachedIdentityLookupMustExist", nm.ctx, "did:firefly:org/parent1").Return(&fftypes.Identity{
 		IdentityBase: fftypes.IdentityBase{
 			ID:  fftypes.NewUUID(),
@@ -190,7 +190,7 @@ func TestRegisterIdentityGetParentMsgFail(t *testing.T) {
 	parentIdentity := testOrg("parent1")
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentIdentity, &fftypes.Identity{}, false, nil)
 	mim.On("ResolveIdentitySigner", nm.ctx, parentIdentity).Return(nil, fmt.Errorf("pop"))
 
 	_, err := nm.RegisterIdentity(nm.ctx, "ns1", &fftypes.IdentityCreateDTO{
@@ -209,7 +209,7 @@ func TestRegisterIdentityRootBroadcastFail(t *testing.T) {
 	defer cancel()
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, &fftypes.Identity{}, false, nil)
 
 	mbm := nm.broadcast.(*broadcastmocks.Manager)
 	mbm.On("BroadcastIdentityClaim", nm.ctx,
@@ -237,7 +237,7 @@ func TestRegisterIdentityMissingKey(t *testing.T) {
 	defer cancel()
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, &fftypes.Identity{}, false, nil)
 
 	_, err := nm.RegisterIdentity(nm.ctx, "ns1", &fftypes.IdentityCreateDTO{
 		Name:   "custom1",
@@ -254,7 +254,7 @@ func TestRegisterIdentityVerifyFail(t *testing.T) {
 	defer cancel()
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, false, fmt.Errorf("pop"))
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, nil, false, fmt.Errorf("pop"))
 
 	_, err := nm.RegisterIdentity(nm.ctx, "ns1", &fftypes.IdentityCreateDTO{
 		Name:   "custom1",

--- a/internal/networkmap/register_node_test.go
+++ b/internal/networkmap/register_node_test.go
@@ -43,7 +43,7 @@ func TestRegisterNodeOk(t *testing.T) {
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
 	mim.On("GetNodeOwnerOrg", nm.ctx).Return(parentOrg, nil)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentOrg, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentOrg, parentOrg, false, nil)
 	signerRef := &fftypes.SignerRef{Key: "0x23456"}
 	mim.On("ResolveIdentitySigner", nm.ctx, parentOrg).Return(signerRef, nil)
 
@@ -80,7 +80,7 @@ func TestRegisterNodePeerInfoFail(t *testing.T) {
 
 	mim := nm.identity.(*identitymanagermocks.Manager)
 	mim.On("GetNodeOwnerOrg", nm.ctx).Return(parentOrg, nil)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentOrg, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(parentOrg, parentOrg, false, nil)
 	signerRef := &fftypes.SignerRef{Key: "0x23456"}
 	mim.On("ResolveIdentitySigner", nm.ctx, parentOrg).Return(signerRef, nil)
 

--- a/internal/networkmap/register_org_test.go
+++ b/internal/networkmap/register_org_test.go
@@ -64,7 +64,7 @@ func TestRegisterNodeOrgOk(t *testing.T) {
 	mim.On("GetNodeOwnerBlockchainKey", nm.ctx).Return(&fftypes.VerifierRef{
 		Value: "0x12345",
 	}, nil)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, &fftypes.Identity{}, false, nil)
 
 	mockMsg := &fftypes.Message{Header: fftypes.MessageHeader{ID: fftypes.NewUUID()}}
 	mbm := nm.broadcast.(*broadcastmocks.Manager)
@@ -94,7 +94,7 @@ func TestRegisterNodeOrgNoName(t *testing.T) {
 	mim.On("GetNodeOwnerBlockchainKey", nm.ctx).Return(&fftypes.VerifierRef{
 		Value: "0x12345",
 	}, nil)
-	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, false, nil)
+	mim.On("VerifyIdentityChain", nm.ctx, mock.AnythingOfType("*fftypes.Identity")).Return(nil, &fftypes.Identity{}, false, nil)
 
 	_, err := nm.RegisterNodeOrganization(nm.ctx, false)
 	assert.Regexp(t, "FF10216", err)

--- a/mocks/identitymanagermocks/manager.go
+++ b/mocks/identitymanagermocks/manager.go
@@ -263,7 +263,7 @@ func (_m *Manager) ResolveNodeOwnerSigningIdentity(ctx context.Context, msgSigne
 }
 
 // VerifyIdentityChain provides a mock function with given fields: ctx, _a1
-func (_m *Manager) VerifyIdentityChain(ctx context.Context, _a1 *fftypes.Identity) (*fftypes.Identity, bool, error) {
+func (_m *Manager) VerifyIdentityChain(ctx context.Context, _a1 *fftypes.Identity) (*fftypes.Identity, *fftypes.Identity, bool, error) {
 	ret := _m.Called(ctx, _a1)
 
 	var r0 *fftypes.Identity
@@ -275,19 +275,28 @@ func (_m *Manager) VerifyIdentityChain(ctx context.Context, _a1 *fftypes.Identit
 		}
 	}
 
-	var r1 bool
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Identity) bool); ok {
+	var r1 *fftypes.Identity
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Identity) *fftypes.Identity); ok {
 		r1 = rf(ctx, _a1)
 	} else {
-		r1 = ret.Get(1).(bool)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*fftypes.Identity)
+		}
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, *fftypes.Identity) error); ok {
+	var r2 bool
+	if rf, ok := ret.Get(2).(func(context.Context, *fftypes.Identity) bool); ok {
 		r2 = rf(ctx, _a1)
 	} else {
-		r2 = ret.Error(2)
+		r2 = ret.Get(2).(bool)
 	}
 
-	return r0, r1, r2
+	var r3 error
+	if rf, ok := ret.Get(3).(func(context.Context, *fftypes.Identity) error); ok {
+		r3 = rf(ctx, _a1)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }

--- a/pkg/fftypes/identity.go
+++ b/pkg/fftypes/identity.go
@@ -111,7 +111,8 @@ type SignerRef struct {
 // from the parent identity to be published (on the same topic) before the identity is considered valid
 // and is stored as a confirmed identity.
 type IdentityClaim struct {
-	Identity *Identity `ffstruct:"IdentityClaim" json:"identity"`
+	Identity *Identity     `ffstruct:"IdentityClaim" json:"identity"`
+	Root     *IdentityBase `ffstruct:"IdentityClaim" json:"root"`
 }
 
 // IdentityVerification is the data payload used in message to broadcast a verification of a child identity.
@@ -131,7 +132,10 @@ type IdentityUpdate struct {
 }
 
 func (ic *IdentityClaim) Topic() string {
-	return ic.Identity.Topic()
+	if ic.Root == nil {
+		return ic.Identity.Topic()
+	}
+	return ic.Root.Topic()
 }
 
 func (ic *IdentityClaim) SetBroadcastMessage(msgID *UUID) {

--- a/pkg/fftypes/identity_test.go
+++ b/pkg/fftypes/identity_test.go
@@ -212,8 +212,10 @@ func TestDefinitionObjects(t *testing.T) {
 	assert.Equal(t, "7ea456fa05fc63778e7c4cb22d0498d73f184b2778c11fd2ba31b5980f8490b9", o.IdentityBase.Topic())
 	assert.Equal(t, o.Topic(), o.IdentityBase.Topic())
 
+	// Root identity
 	ic := IdentityClaim{
 		Identity: o,
+		Root:     &o.IdentityBase,
 	}
 	assert.Equal(t, o.Topic(), ic.Topic())
 	claimMsg := NewUUID()

--- a/pkg/fftypes/node.go
+++ b/pkg/fftypes/node.go
@@ -38,7 +38,7 @@ type DeprecatedDXInfo struct {
 }
 
 // Migrate creates and maintains a migrated IdentityClaim object, which
-// is used when processing an old-style nodeanization broadcast received when
+// is used when processing an old-style node broadcast received when
 // joining an existing network
 func (node *DeprecatedNode) Migrated() *IdentityClaim {
 	if node.identityClaim != nil {


### PR DESCRIPTION
Investigating https://github.com/hyperledger/firefly/issues/692 I realized that the only safe thing to do in terms of an ordering context, given that identities are arbitrarily nested in their hierarchy, is to broadcast them all under a single ordering context up to the root identity.  Then if a node is replaying a chain and potentially processing batches of blockchain transactions, it will be assured to get the same outcome in sequencing of identities for the whole hierarchy.