### PR TITLE
Move "special" operation update handling out of Operations Manager

### DIFF
--- a/internal/batchpin/operations.go
+++ b/internal/batchpin/operations.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/operations"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/i18n"
@@ -96,6 +97,10 @@ func (bp *batchPinSubmitter) RunOperation(ctx context.Context, op *fftypes.Prepa
 	default:
 		return nil, false, i18n.NewError(ctx, coremsgs.MsgOperationDataIncorrect, op.Data)
 	}
+}
+
+func (bp *batchPinSubmitter) OnOperationUpdate(ctx context.Context, op *fftypes.Operation, update *operations.OperationUpdate) error {
+	return nil
 }
 
 func opBatchPin(op *fftypes.Operation, batch *fftypes.BatchPersisted, contexts []*fftypes.Bytes32, payloadRef string) *fftypes.PreparedOperation {

--- a/internal/batchpin/operations_test.go
+++ b/internal/batchpin/operations_test.go
@@ -147,3 +147,8 @@ func TestPrepareOperationBatchPinNotFound(t *testing.T) {
 	_, err := bp.PrepareOperation(context.Background(), op)
 	assert.Regexp(t, "FF10109", err)
 }
+
+func TestOperationUpdate(t *testing.T) {
+	bp := newTestBatchPinSubmitter(t, false)
+	assert.NoError(t, bp.OnOperationUpdate(context.Background(), nil, nil))
+}

--- a/internal/broadcast/operations.go
+++ b/internal/broadcast/operations.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/operations"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/i18n"
@@ -165,6 +166,10 @@ func (bm *broadcastManager) uploadBlob(ctx context.Context, data uploadBlobData)
 
 	log.L(ctx).Infof("Published blob with hash '%s' for data '%s' to shared storage: '%s'", data.Data.Blob.Hash, data.Data.ID, data.Data.Blob.Public)
 	return getUploadBlobOutputs(data.Data.Blob.Public), true, nil
+}
+
+func (bm *broadcastManager) OnOperationUpdate(ctx context.Context, op *fftypes.Operation, update *operations.OperationUpdate) error {
+	return nil
 }
 
 func opUploadBatch(op *fftypes.Operation, batch *fftypes.Batch, batchPersisted *fftypes.BatchPersisted) *fftypes.PreparedOperation {

--- a/internal/broadcast/operations_test.go
+++ b/internal/broadcast/operations_test.go
@@ -497,3 +497,9 @@ func TestRunOperationUploadBlobDownloadFail(t *testing.T) {
 	mps.AssertExpectations(t)
 	mdx.AssertExpectations(t)
 }
+
+func TestOperationUpdate(t *testing.T) {
+	bm, cancel := newTestBroadcast(t)
+	defer cancel()
+	assert.NoError(t, bm.OnOperationUpdate(context.Background(), nil, nil))
+}

--- a/internal/contracts/operations.go
+++ b/internal/contracts/operations.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/operations"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/i18n"
 )
@@ -69,6 +70,10 @@ func (cm *contractManager) RunOperation(ctx context.Context, op *fftypes.Prepare
 	default:
 		return nil, false, i18n.NewError(ctx, coremsgs.MsgOperationDataIncorrect, op.Data)
 	}
+}
+
+func (cm *contractManager) OnOperationUpdate(ctx context.Context, op *fftypes.Operation, update *operations.OperationUpdate) error {
+	return nil
 }
 
 func opBlockchainInvoke(op *fftypes.Operation, req *fftypes.ContractCallRequest) *fftypes.PreparedOperation {

--- a/internal/contracts/operations_test.go
+++ b/internal/contracts/operations_test.go
@@ -93,3 +93,8 @@ func TestRunOperationNotSupported(t *testing.T) {
 	assert.False(t, complete)
 	assert.Regexp(t, "FF10378", err)
 }
+
+func TestOperationUpdate(t *testing.T) {
+	cm := newTestContractManager()
+	assert.NoError(t, cm.OnOperationUpdate(context.Background(), nil, nil))
+}

--- a/internal/operations/manager.go
+++ b/internal/operations/manager.go
@@ -33,6 +33,7 @@ type OperationHandler interface {
 	fftypes.Named
 	PrepareOperation(ctx context.Context, op *fftypes.Operation) (*fftypes.PreparedOperation, error)
 	RunOperation(ctx context.Context, op *fftypes.PreparedOperation) (outputs fftypes.JSONObject, complete bool, err error)
+	OnOperationUpdate(ctx context.Context, op *fftypes.Operation, update *OperationUpdate) error
 }
 
 type Manager interface {
@@ -69,8 +70,9 @@ func NewOperationsManager(ctx context.Context, di database.Plugin, txHelper txco
 		ctx:      ctx,
 		database: di,
 		handlers: make(map[fftypes.OpType]OperationHandler),
-		updater:  newOperationUpdater(ctx, di, txHelper),
 	}
+	updater := newOperationUpdater(ctx, om, di, txHelper)
+	om.updater = updater
 	return om, nil
 }
 

--- a/internal/privatemessaging/operations.go
+++ b/internal/privatemessaging/operations.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/operations"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/i18n"
 )
@@ -140,6 +141,10 @@ func (pm *privateMessaging) RunOperation(ctx context.Context, op *fftypes.Prepar
 	default:
 		return nil, false, i18n.NewError(ctx, coremsgs.MsgOperationDataIncorrect, op.Data)
 	}
+}
+
+func (pm *privateMessaging) OnOperationUpdate(ctx context.Context, op *fftypes.Operation, update *operations.OperationUpdate) error {
+	return nil
 }
 
 func opSendBlob(op *fftypes.Operation, node *fftypes.Identity, blob *fftypes.Blob) *fftypes.PreparedOperation {

--- a/internal/privatemessaging/operations_test.go
+++ b/internal/privatemessaging/operations_test.go
@@ -533,3 +533,9 @@ func TestRunOperationBatchSendInvalidData(t *testing.T) {
 	assert.False(t, complete)
 	assert.Regexp(t, "FF10137", err)
 }
+
+func TestOperationUpdate(t *testing.T) {
+	pm, cancel := newTestPrivateMessaging(t)
+	defer cancel()
+	assert.NoError(t, pm.OnOperationUpdate(context.Background(), nil, nil))
+}

--- a/internal/shareddownload/operations.go
+++ b/internal/shareddownload/operations.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/operations"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/i18n"
 	"github.com/hyperledger/firefly/pkg/log"
@@ -163,6 +164,10 @@ func (dm *downloadManager) downloadBlob(ctx context.Context, data downloadBlobDa
 	dm.callbacks.SharedStorageBlobDownloaded(*hash, blobSize, dxPayloadRef)
 
 	return getDownloadBlobOutputs(hash, blobSize, dxPayloadRef), true, nil
+}
+
+func (dm *downloadManager) OnOperationUpdate(ctx context.Context, op *fftypes.Operation, update *operations.OperationUpdate) error {
+	return nil
 }
 
 func opDownloadBatch(op *fftypes.Operation, ns string, payloadRef string) *fftypes.PreparedOperation {

--- a/internal/shareddownload/operations_test.go
+++ b/internal/shareddownload/operations_test.go
@@ -18,6 +18,7 @@ package shareddownload
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -133,4 +134,10 @@ func TestDownloadBlobDownloadDataReadFail(t *testing.T) {
 
 	mss.AssertExpectations(t)
 	mdx.AssertExpectations(t)
+}
+
+func TestOperationUpdate(t *testing.T) {
+	dm, cancel := newTestDownloadManager(t)
+	defer cancel()
+	assert.NoError(t, dm.OnOperationUpdate(context.Background(), nil, nil))
 }


### PR DESCRIPTION
Feels like these should be farmed out instead of Operations Manager having knowledge of the various specific operation types.