### PR TITLE
Fix account creation for nightly integration runs

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -11,19 +11,19 @@ STACKS_DIR=~/.firefly/stacks
 
 create_accounts() {
   if [ "$TEST_SUITE" == "TestEthereumE2ESuite" ]; then
-      # Create 5 new accounts for use in testing
+      # Create 4 new accounts for use in testing
       for i in {1..4}
       do
           $CLI accounts create $STACK_NAME
       done
   elif [ "$TEST_SUITE" == "TestFabricE2ESuite" ]; then
-      # Create 5 new accounts for use in testing
+      # Create 4 new accounts for the first org for use in testing
       for i in {1..3}
       do
-          $CLI accounts create $STACK_NAME org_0  user_$i
+          $CLI accounts create $STACK_NAME org_0 user_$(openssl rand -hex 10)
       done
-      # Create one account that is specifically only usable from the second org
-      $CLI accounts create $STACK_NAME org_1  user_5
+      # Create one account for the second org
+      $CLI accounts create $STACK_NAME org_1 user_$(openssl rand -hex 10)
   fi
 }
 
@@ -110,7 +110,6 @@ fi
 
 if [ "$TEST_SUITE" == "TestEthereumE2ESuite" ]; then
     export CONTRACT_ADDRESS=$($CLI deploy ethereum $STACK_NAME ../data/simplestorage/simple_storage.json | jq -r '.address')
-    # Create 5 new accounts for use in testing
 fi
 
 if [ "$TOKENS_PROVIDER" == "erc20_erc721" ]; then

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -9,6 +9,24 @@ CLI="ff -v --ansi never"
 CLI_VERSION=$(cat $CWD/../../manifest.json | jq -r .cli.tag)
 STACKS_DIR=~/.firefly/stacks
 
+create_accounts() {
+  if [ "$TEST_SUITE" == "TestEthereumE2ESuite" ]; then
+      # Create 5 new accounts for use in testing
+      for i in {1..4}
+      do
+          $CLI accounts create $STACK_NAME
+      done
+  elif [ "$TEST_SUITE" == "TestFabricE2ESuite" ]; then
+      # Create 5 new accounts for use in testing
+      for i in {1..3}
+      do
+          $CLI accounts create $STACK_NAME org_0  user_$i
+      done
+      # Create one account that is specifically only usable from the second org
+      $CLI accounts create $STACK_NAME org_1  user_5
+  fi
+}
+
 checkOk() {
   local rc=$1
 
@@ -88,29 +106,19 @@ if [ "$CREATE_STACK" == "true" ]; then
 
   $CLI start -b $STACK_NAME
   checkOk $?
+fi
 
-  if [ "$TEST_SUITE" == "TestEthereumE2ESuite" ]; then
-      export CONTRACT_ADDRESS=$($CLI deploy ethereum $STACK_NAME ../data/simplestorage/simple_storage.json | jq -r '.address')
-      # Create 5 new accounts for use in testing
-      for i in {1..4}
-      do
-          $CLI accounts create $STACK_NAME
-      done
-  elif [ "$TEST_SUITE" == "TestFabricE2ESuite" ]; then
-      # Create 5 new accounts for use in testing
-      for i in {1..3}
-      do
-          $CLI accounts create $STACK_NAME org_0  user_$i
-      done
-      # Create one account that is specifically only usable from the second org
-      $CLI accounts create $STACK_NAME org_1  user_5
-  fi
+if [ "$TEST_SUITE" == "TestEthereumE2ESuite" ]; then
+    export CONTRACT_ADDRESS=$($CLI deploy ethereum $STACK_NAME ../data/simplestorage/simple_storage.json | jq -r '.address')
+    # Create 5 new accounts for use in testing
 fi
 
 if [ "$TOKENS_PROVIDER" == "erc20_erc721" ]; then
     export ERC20_CONTRACT_ADDRESS=$($CLI deploy ethereum $STACK_NAME ../data/erc20/ERC20WithData.json | jq -r '.address')
     export ERC721_CONTRACT_ADDRESS=$($CLI deploy ethereum $STACK_NAME ../data/erc721/ERC721WithData.json | jq -r '.address')
 fi
+
+create_accounts
 
 $CLI info $STACK_NAME
 checkOk $?
@@ -127,6 +135,8 @@ if [ "$RESTART" == "true" ]; then
 
   $CLI start $STACK_NAME
   checkOk $?
+
+  create_accounts
 
   go clean -testcache && go test -v . -run $TEST_SUITE
   checkOk $?


### PR DESCRIPTION
We recently merged a change in how blockchain accounts are created for the E2E tests. This worked fine for a normal run. The nightly integration test also stops all the services, starts them up again, and re-runs all the tests. This meant that there weren't enough "extra" test blockchain accounts allocated for the second test run after the restart. This PR fixes that.