### PR TITLE
Add first step of FireFly Transaction Manager support - separate URL for submit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     "ffimethods",
     "ffresty",
     "ffstruct",
+    "FFTM",
     "fftypes",
     "finalizers",
     "Hyperledger",

--- a/internal/adminevents/manager_test.go
+++ b/internal/adminevents/manager_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/hyperledger/firefly/internal/coreconfig"
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/pkg/config"
 	"github.com/hyperledger/firefly/pkg/ffresty"
 	"github.com/hyperledger/firefly/pkg/fftypes"
@@ -42,9 +41,9 @@ func newTestAdminEventsManager(t *testing.T) (ae *adminEventManager, ws *webSock
 	svr := httptest.NewServer(http.HandlerFunc(ae.ServeHTTPWebSocketListener))
 
 	clientPrefix := config.NewPluginConfig("ut.wsclient")
-	wsconfig.InitPrefix(clientPrefix)
+	wsclient.InitPrefix(clientPrefix)
 	clientPrefix.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s", svr.Listener.Addr()))
-	wsConfig := wsconfig.GenerateConfigFromPrefix(clientPrefix)
+	wsConfig := wsclient.GenerateConfigFromPrefix(clientPrefix)
 
 	wsc, err := wsclient.New(ae.ctx, wsConfig, nil, nil)
 	assert.NoError(t, err)

--- a/internal/assets/operations.go
+++ b/internal/assets/operations.go
@@ -205,32 +205,36 @@ func (am *assetManager) OnOperationUpdate(ctx context.Context, op *fftypes.Opera
 
 func opCreatePool(op *fftypes.Operation, pool *fftypes.TokenPool) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: createPoolData{Pool: pool},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      createPoolData{Pool: pool},
 	}
 }
 
 func opActivatePool(op *fftypes.Operation, pool *fftypes.TokenPool) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: activatePoolData{Pool: pool},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      activatePoolData{Pool: pool},
 	}
 }
 
 func opTransfer(op *fftypes.Operation, pool *fftypes.TokenPool, transfer *fftypes.TokenTransfer) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: transferData{Pool: pool, Transfer: transfer},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      transferData{Pool: pool, Transfer: transfer},
 	}
 }
 
 func opApproval(op *fftypes.Operation, pool *fftypes.TokenPool, approval *fftypes.TokenApproval) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: approvalData{Pool: pool, Approval: approval},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      approvalData{Pool: pool, Approval: approval},
 	}
 }

--- a/internal/batchpin/operations.go
+++ b/internal/batchpin/operations.go
@@ -105,8 +105,9 @@ func (bp *batchPinSubmitter) OnOperationUpdate(ctx context.Context, op *fftypes.
 
 func opBatchPin(op *fftypes.Operation, batch *fftypes.BatchPersisted, contexts []*fftypes.Bytes32, payloadRef string) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: batchPinData{Batch: batch, Contexts: contexts, PayloadRef: payloadRef},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      batchPinData{Batch: batch, Contexts: contexts, PayloadRef: payloadRef},
 	}
 }

--- a/internal/blockchain/ethereum/config.go
+++ b/internal/blockchain/ethereum/config.go
@@ -67,6 +67,9 @@ const (
 	AddressResolverCacheSize = "cache.size"
 	// AddressResolverCacheTTL the TTL on cache entries
 	AddressResolverCacheTTL = "cache.ttl"
+
+	// FFTMConfigKey is a sub-key in the config that optionally contains FireFly transaction connection information
+	FFTMConfigKey = "fftm"
 )
 
 func (e *Ethereum) InitPrefix(prefix config.Prefix) {
@@ -78,6 +81,9 @@ func (e *Ethereum) InitPrefix(prefix config.Prefix) {
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchTimeout, defaultBatchTimeout)
 	ethconnectConf.AddKnownKey(EthconnectPrefixShort, defaultPrefixShort)
 	ethconnectConf.AddKnownKey(EthconnectPrefixLong, defaultPrefixLong)
+
+	fftmConf := prefix.SubPrefix(FFTMConfigKey)
+	ffresty.InitPrefix(fftmConf)
 
 	addressResolverConf := prefix.SubPrefix(AddressResolverConfigKey)
 	ffresty.InitPrefix(addressResolverConf)

--- a/internal/blockchain/ethereum/config.go
+++ b/internal/blockchain/ethereum/config.go
@@ -17,9 +17,9 @@
 package ethereum
 
 import (
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/pkg/config"
 	"github.com/hyperledger/firefly/pkg/ffresty"
+	"github.com/hyperledger/firefly/pkg/wsclient"
 )
 
 const (
@@ -71,7 +71,7 @@ const (
 
 func (e *Ethereum) InitPrefix(prefix config.Prefix) {
 	ethconnectConf := prefix.SubPrefix(EthconnectConfigKey)
-	wsconfig.InitPrefix(ethconnectConf)
+	wsclient.InitPrefix(ethconnectConf)
 	ethconnectConf.AddKnownKey(EthconnectConfigInstancePath)
 	ethconnectConf.AddKnownKey(EthconnectConfigTopic)
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchSize, defaultBatchSize)

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/internal/metrics"
 	"github.com/hyperledger/firefly/pkg/blockchain"
@@ -203,7 +202,7 @@ func (e *Ethereum) Init(ctx context.Context, prefix config.Prefix, callbacks blo
 	e.prefixShort = ethconnectConf.GetString(EthconnectPrefixShort)
 	e.prefixLong = ethconnectConf.GetString(EthconnectPrefixLong)
 
-	wsConfig := wsconfig.GenerateConfigFromPrefix(ethconnectConf)
+	wsConfig := wsclient.GenerateConfigFromPrefix(ethconnectConf)
 
 	if wsConfig.WSKeyPath == "" {
 		wsConfig.WSKeyPath = "/ws"

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -43,6 +43,7 @@ import (
 var utConfPrefix = config.NewPluginConfig("eth_unit_tests")
 var utEthconnectConf = utConfPrefix.SubPrefix(EthconnectConfigKey)
 var utAddressResolverConf = utConfPrefix.SubPrefix(AddressResolverConfigKey)
+var utFFTMConf = utConfPrefix.SubPrefix(FFTMConfigKey)
 
 func testFFIMethod() *fftypes.FFIMethod {
 	return &fftypes.FFIMethod{
@@ -139,7 +140,7 @@ func TestInitMissingTopic(t *testing.T) {
 	assert.Regexp(t, "FF10138.*topic", err)
 }
 
-func TestInitAllNewStreamsAndWSEvent(t *testing.T) {
+func TestInitAllNewStreamsAndWSEventWithFFTM(t *testing.T) {
 
 	log.SetLevel("trace")
 	e, cancel := newTestEthereum()
@@ -175,9 +176,11 @@ func TestInitAllNewStreamsAndWSEvent(t *testing.T) {
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
 	utEthconnectConf.Set(EthconnectConfigInstancePath, "/instances/0x12345")
 	utEthconnectConf.Set(EthconnectConfigTopic, "topic1")
+	utFFTMConf.Set(ffresty.HTTPConfigURL, "http://fftm.example.com:12345")
 
 	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 	assert.NoError(t, err)
+	assert.NotNil(t, e.fftmClient)
 
 	assert.Equal(t, "ethereum", e.Name())
 	assert.Equal(t, fftypes.VerifierTypeEthAddress, e.VerifierType())

--- a/internal/blockchain/fabric/config.go
+++ b/internal/blockchain/fabric/config.go
@@ -17,8 +17,8 @@
 package fabric
 
 import (
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/pkg/config"
+	"github.com/hyperledger/firefly/pkg/wsclient"
 )
 
 const (
@@ -53,7 +53,7 @@ const (
 
 func (f *Fabric) InitPrefix(prefix config.Prefix) {
 	fabconnectConf := prefix.SubPrefix(FabconnectConfigKey)
-	wsconfig.InitPrefix(fabconnectConf)
+	wsclient.InitPrefix(fabconnectConf)
 	fabconnectConf.AddKnownKey(FabconnectConfigDefaultChannel)
 	fabconnectConf.AddKnownKey(FabconnectConfigChaincode)
 	fabconnectConf.AddKnownKey(FabconnectConfigSigner)

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/internal/metrics"
 	"github.com/hyperledger/firefly/pkg/blockchain"
@@ -187,7 +186,7 @@ func (f *Fabric) Init(ctx context.Context, prefix config.Prefix, callbacks block
 		GlobalSequencer: true,
 	}
 
-	wsConfig := wsconfig.GenerateConfigFromPrefix(fabconnectConf)
+	wsConfig := wsclient.GenerateConfigFromPrefix(fabconnectConf)
 
 	if wsConfig.WSKeyPath == "" {
 		wsConfig.WSKeyPath = "/ws"

--- a/internal/broadcast/operations.go
+++ b/internal/broadcast/operations.go
@@ -174,16 +174,18 @@ func (bm *broadcastManager) OnOperationUpdate(ctx context.Context, op *fftypes.O
 
 func opUploadBatch(op *fftypes.Operation, batch *fftypes.Batch, batchPersisted *fftypes.BatchPersisted) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: uploadBatchData{Batch: batch, BatchPersisted: batchPersisted},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      uploadBatchData{Batch: batch, BatchPersisted: batchPersisted},
 	}
 }
 
 func opUploadBlob(op *fftypes.Operation, data *fftypes.Data, blob *fftypes.Blob) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: uploadBlobData{Data: data, Blob: blob},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      uploadBlobData{Data: data, Blob: blob},
 	}
 }

--- a/internal/contracts/operations.go
+++ b/internal/contracts/operations.go
@@ -93,8 +93,9 @@ func (cm *contractManager) OnOperationUpdate(ctx context.Context, op *fftypes.Op
 
 func opBlockchainInvoke(op *fftypes.Operation, req *fftypes.ContractCallRequest) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: blockchainInvokeData{Request: req},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      blockchainInvokeData{Request: req},
 	}
 }

--- a/internal/database/sqlcommon/operation_sql_test.go
+++ b/internal/database/sqlcommon/operation_sql_test.go
@@ -50,6 +50,7 @@ func TestOperationE2EWithDB(t *testing.T) {
 		Updated:     fftypes.Now(),
 	}
 	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionOperations, fftypes.ChangeEventTypeCreated, "ns1", operationID).Return()
+	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionOperations, fftypes.ChangeEventTypeUpdated, "ns1", operationID).Return()
 	hookCalled := false
 	err := s.InsertOperation(ctx, operation, func() {
 		hookCalled = true
@@ -94,7 +95,7 @@ func TestOperationE2EWithDB(t *testing.T) {
 	assert.Equal(t, 0, len(operations))
 
 	// Update
-	err = s.ResolveOperation(ctx, operation.ID, fftypes.OpStatusSucceeded, "", fftypes.JSONObject{"extra": "info"})
+	err = s.ResolveOperation(ctx, operation.Namespace, operation.ID, fftypes.OpStatusSucceeded, "", fftypes.JSONObject{"extra": "info"})
 	assert.NoError(t, err)
 
 	// Test find updated value

--- a/internal/dataexchange/ffdx/config.go
+++ b/internal/dataexchange/ffdx/config.go
@@ -17,8 +17,8 @@
 package ffdx
 
 import (
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/pkg/config"
+	"github.com/hyperledger/firefly/pkg/wsclient"
 )
 
 const (
@@ -29,7 +29,7 @@ const (
 )
 
 func (h *FFDX) InitPrefix(prefix config.Prefix) {
-	wsconfig.InitPrefix(prefix)
+	wsclient.InitPrefix(prefix)
 	prefix.AddKnownKey(DataExchangeManifestEnabled, false)
 	prefix.AddKnownKey(DataExchangeInitEnabled, false)
 }

--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/pkg/config"
 	"github.com/hyperledger/firefly/pkg/dataexchange"
@@ -127,7 +126,7 @@ func (h *FFDX) Init(ctx context.Context, prefix config.Prefix, nodes []fftypes.J
 		Manifest: prefix.GetBool(DataExchangeManifestEnabled),
 	}
 
-	wsConfig := wsconfig.GenerateConfigFromPrefix(prefix)
+	wsConfig := wsclient.GenerateConfigFromPrefix(prefix)
 
 	h.wsconn, err = wsclient.New(ctx, wsConfig, h.beforeConnect, nil)
 	if err != nil {

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -65,7 +65,7 @@ func (em *eventManager) confirmPool(ctx context.Context, pool *fftypes.TokenPool
 		return err
 	} else if op == nil {
 		log.L(ctx).Warnf("No activate operation found for token pool transaction=%s", pool.TX.ID)
-	} else if err := em.database.ResolveOperation(ctx, op.ID, fftypes.OpStatusSucceeded, "", nil); err != nil {
+	} else if err := em.database.ResolveOperation(ctx, op.Namespace, op.ID, fftypes.OpStatusSucceeded, "", nil); err != nil {
 		return err
 	}
 	if _, err := em.txHelper.PersistTransaction(ctx, pool.Namespace, pool.TX.ID, pool.TX.Type, ev.BlockchainTXID); err != nil {

--- a/internal/events/token_pool_created_test.go
+++ b/internal/events/token_pool_created_test.go
@@ -141,9 +141,10 @@ func TestTokenPoolCreatedConfirm(t *testing.T) {
 		return e.Type == fftypes.EventTypeBlockchainEventReceived
 	})).Return(nil).Once()
 	mdi.On("GetOperations", em.ctx, mock.Anything).Return([]*fftypes.Operation{{
-		ID: opID,
+		ID:        opID,
+		Namespace: "ns1",
 	}}, nil, nil)
-	mdi.On("ResolveOperation", em.ctx, opID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(nil)
+	mdi.On("ResolveOperation", em.ctx, "ns1", opID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(nil)
 	mth.On("PersistTransaction", mock.Anything, "ns1", txID, fftypes.TransactionTypeTokenPool, "0xffffeeee").Return(true, nil).Once()
 	mdi.On("UpsertTokenPool", em.ctx, storedPool).Return(nil).Once()
 	mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
@@ -412,9 +413,10 @@ func TestConfirmPoolResolveOpFail(t *testing.T) {
 		return e.Type == fftypes.EventTypeBlockchainEventReceived
 	})).Return(nil)
 	mdi.On("GetOperations", em.ctx, mock.Anything).Return([]*fftypes.Operation{{
-		ID: opID,
+		ID:        opID,
+		Namespace: "ns1",
 	}}, nil, nil)
-	mdi.On("ResolveOperation", em.ctx, opID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(fmt.Errorf("pop"))
+	mdi.On("ResolveOperation", em.ctx, "ns1", opID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := em.confirmPool(em.ctx, storedPool, event)
 	assert.EqualError(t, err, "pop")

--- a/internal/events/websockets/websockets_test.go
+++ b/internal/events/websockets/websockets_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly/internal/coreconfig"
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/mocks/eventsmocks"
 	"github.com/hyperledger/firefly/pkg/config"
 	"github.com/hyperledger/firefly/pkg/events"
@@ -55,13 +54,13 @@ func newTestWebsockets(t *testing.T, cbs *eventsmocks.Callbacks, queryParams ...
 	svr := httptest.NewServer(ws)
 
 	clientPrefix := config.NewPluginConfig("ut.wsclient")
-	wsconfig.InitPrefix(clientPrefix)
+	wsclient.InitPrefix(clientPrefix)
 	qs := ""
 	if len(queryParams) > 0 {
 		qs = fmt.Sprintf("?%s", strings.Join(queryParams, "&"))
 	}
 	clientPrefix.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s%s", svr.Listener.Addr(), qs))
-	wsConfig := wsconfig.GenerateConfigFromPrefix(clientPrefix)
+	wsConfig := wsclient.GenerateConfigFromPrefix(clientPrefix)
 
 	wsc, err := wsclient.New(ctx, wsConfig, nil, nil)
 	assert.NoError(t, err)

--- a/internal/operations/manager.go
+++ b/internal/operations/manager.go
@@ -107,10 +107,10 @@ func (om *operationsManager) RunOperation(ctx context.Context, op *fftypes.Prepa
 	log.L(ctx).Tracef("Operation detail: %+v", op)
 	outputs, complete, err := handler.RunOperation(ctx, op)
 	if err != nil {
-		om.writeOperationFailure(ctx, op.ID, outputs, err, failState)
+		om.writeOperationFailure(ctx, op.Namespace, op.ID, outputs, err, failState)
 		return nil, err
 	} else if complete {
-		om.writeOperationSuccess(ctx, op.ID, outputs)
+		om.writeOperationSuccess(ctx, op.Namespace, op.ID, outputs)
 	}
 	return outputs, nil
 }
@@ -198,14 +198,14 @@ func (om *operationsManager) TransferResult(dx dataexchange.Plugin, event dataex
 	om.SubmitOperationUpdate(dx, opUpdate)
 }
 
-func (om *operationsManager) writeOperationSuccess(ctx context.Context, opID *fftypes.UUID, outputs fftypes.JSONObject) {
-	if err := om.database.ResolveOperation(ctx, opID, fftypes.OpStatusSucceeded, "", outputs); err != nil {
+func (om *operationsManager) writeOperationSuccess(ctx context.Context, ns string, opID *fftypes.UUID, outputs fftypes.JSONObject) {
+	if err := om.database.ResolveOperation(ctx, ns, opID, fftypes.OpStatusSucceeded, "", outputs); err != nil {
 		log.L(ctx).Errorf("Failed to update operation %s: %s", opID, err)
 	}
 }
 
-func (om *operationsManager) writeOperationFailure(ctx context.Context, opID *fftypes.UUID, outputs fftypes.JSONObject, err error, newStatus fftypes.OpStatus) {
-	if err := om.database.ResolveOperation(ctx, opID, newStatus, err.Error(), outputs); err != nil {
+func (om *operationsManager) writeOperationFailure(ctx context.Context, ns string, opID *fftypes.UUID, outputs fftypes.JSONObject, err error, newStatus fftypes.OpStatus) {
+	if err := om.database.ResolveOperation(ctx, ns, opID, newStatus, err.Error(), outputs); err != nil {
 		log.L(ctx).Errorf("Failed to update operation %s: %s", opID, err)
 	}
 }
@@ -215,7 +215,7 @@ func (om *operationsManager) ResolveOperationByID(ctx context.Context, id string
 	if err != nil {
 		return nil, err
 	}
-	err = om.database.ResolveOperation(ctx, u, op.Status, op.Error, op.Output)
+	err = om.database.ResolveOperation(ctx, op.Namespace, u, op.Status, op.Error, op.Output)
 	return op, err
 }
 

--- a/internal/operations/manager_test.go
+++ b/internal/operations/manager_test.go
@@ -143,12 +143,13 @@ func TestRunOperationSyncSuccess(t *testing.T) {
 
 	ctx := context.Background()
 	op := &fftypes.PreparedOperation{
-		ID:   fftypes.NewUUID(),
-		Type: fftypes.OpTypeBlockchainPinBatch,
+		ID:        fftypes.NewUUID(),
+		Namespace: "ns1",
+		Type:      fftypes.OpTypeBlockchainPinBatch,
 	}
 
 	mdi := om.database.(*databasemocks.Plugin)
-	mdi.On("ResolveOperation", ctx, op.ID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(nil)
+	mdi.On("ResolveOperation", ctx, "ns1", op.ID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(nil)
 
 	om.RegisterHandler(ctx, &mockHandler{Complete: true}, []fftypes.OpType{fftypes.OpTypeBlockchainPinBatch})
 	_, err := om.RunOperation(ctx, op)
@@ -164,12 +165,13 @@ func TestRunOperationFail(t *testing.T) {
 
 	ctx := context.Background()
 	op := &fftypes.PreparedOperation{
-		ID:   fftypes.NewUUID(),
-		Type: fftypes.OpTypeBlockchainPinBatch,
+		ID:        fftypes.NewUUID(),
+		Namespace: "ns1",
+		Type:      fftypes.OpTypeBlockchainPinBatch,
 	}
 
 	mdi := om.database.(*databasemocks.Plugin)
-	mdi.On("ResolveOperation", ctx, op.ID, fftypes.OpStatusFailed, "pop", mock.Anything).Return(nil)
+	mdi.On("ResolveOperation", ctx, "ns1", op.ID, fftypes.OpStatusFailed, "pop", mock.Anything).Return(nil)
 
 	om.RegisterHandler(ctx, &mockHandler{RunErr: fmt.Errorf("pop")}, []fftypes.OpType{fftypes.OpTypeBlockchainPinBatch})
 	_, err := om.RunOperation(ctx, op)
@@ -185,12 +187,13 @@ func TestRunOperationFailRemainPending(t *testing.T) {
 
 	ctx := context.Background()
 	op := &fftypes.PreparedOperation{
-		ID:   fftypes.NewUUID(),
-		Type: fftypes.OpTypeBlockchainPinBatch,
+		ID:        fftypes.NewUUID(),
+		Namespace: "ns1",
+		Type:      fftypes.OpTypeBlockchainPinBatch,
 	}
 
 	mdi := om.database.(*databasemocks.Plugin)
-	mdi.On("ResolveOperation", ctx, op.ID, fftypes.OpStatusPending, "pop", mock.Anything).Return(nil)
+	mdi.On("ResolveOperation", ctx, "ns1", op.ID, fftypes.OpStatusPending, "pop", mock.Anything).Return(nil)
 
 	om.RegisterHandler(ctx, &mockHandler{RunErr: fmt.Errorf("pop")}, []fftypes.OpType{fftypes.OpTypeBlockchainPinBatch})
 	_, err := om.RunOperation(ctx, op, RemainPendingOnFailure)
@@ -207,10 +210,11 @@ func TestRetryOperationSuccess(t *testing.T) {
 	ctx := context.Background()
 	opID := fftypes.NewUUID()
 	op := &fftypes.Operation{
-		ID:     opID,
-		Plugin: "blockchain",
-		Type:   fftypes.OpTypeBlockchainPinBatch,
-		Status: fftypes.OpStatusFailed,
+		ID:        opID,
+		Namespace: "ns1",
+		Plugin:    "blockchain",
+		Type:      fftypes.OpTypeBlockchainPinBatch,
+		Status:    fftypes.OpStatusFailed,
 	}
 	po := &fftypes.PreparedOperation{
 		ID:   op.ID,
@@ -379,9 +383,9 @@ func TestWriteOperationSuccess(t *testing.T) {
 	opID := fftypes.NewUUID()
 
 	mdi := om.database.(*databasemocks.Plugin)
-	mdi.On("ResolveOperation", ctx, opID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(fmt.Errorf("pop"))
+	mdi.On("ResolveOperation", ctx, "ns1", opID, fftypes.OpStatusSucceeded, "", mock.Anything).Return(fmt.Errorf("pop"))
 
-	om.writeOperationSuccess(ctx, opID, nil)
+	om.writeOperationSuccess(ctx, "ns1", opID, nil)
 
 	mdi.AssertExpectations(t)
 }
@@ -394,9 +398,9 @@ func TestWriteOperationFailure(t *testing.T) {
 	opID := fftypes.NewUUID()
 
 	mdi := om.database.(*databasemocks.Plugin)
-	mdi.On("ResolveOperation", ctx, opID, fftypes.OpStatusFailed, "pop", mock.Anything).Return(fmt.Errorf("pop"))
+	mdi.On("ResolveOperation", ctx, "ns1", opID, fftypes.OpStatusFailed, "pop", mock.Anything).Return(fmt.Errorf("pop"))
 
-	om.writeOperationFailure(ctx, opID, nil, fmt.Errorf("pop"), fftypes.OpStatusFailed)
+	om.writeOperationFailure(ctx, "ns1", opID, nil, fmt.Errorf("pop"), fftypes.OpStatusFailed)
 
 	mdi.AssertExpectations(t)
 }
@@ -431,14 +435,15 @@ func TestTransferResultManifestMismatch(t *testing.T) {
 	mdi := om.database.(*databasemocks.Plugin)
 	mdi.On("GetOperations", mock.Anything, mock.Anything).Return([]*fftypes.Operation{
 		{
-			ID:   opID1,
-			Type: fftypes.OpTypeDataExchangeSendBatch,
+			ID:        opID1,
+			Namespace: "ns1",
+			Type:      fftypes.OpTypeDataExchangeSendBatch,
 			Input: fftypes.JSONObject{
 				"batch": fftypes.NewUUID().String(),
 			},
 		},
 	}, nil, nil)
-	mdi.On("ResolveOperation", mock.Anything, opID1, fftypes.OpStatusFailed, mock.MatchedBy(func(errorMsg string) bool {
+	mdi.On("ResolveOperation", mock.Anything, "ns1", opID1, fftypes.OpStatusFailed, mock.MatchedBy(func(errorMsg string) bool {
 		return strings.Contains(errorMsg, "FF10329")
 	}), fftypes.JSONObject{
 		"extra": "info",
@@ -479,14 +484,15 @@ func TestTransferResultHashMismatch(t *testing.T) {
 	mdi := om.database.(*databasemocks.Plugin)
 	mdi.On("GetOperations", mock.Anything, mock.Anything).Return([]*fftypes.Operation{
 		{
-			ID:   opID1,
-			Type: fftypes.OpTypeDataExchangeSendBlob,
+			ID:        opID1,
+			Namespace: "ns1",
+			Type:      fftypes.OpTypeDataExchangeSendBlob,
 			Input: fftypes.JSONObject{
 				"hash": "Bob",
 			},
 		},
 	}, nil, nil)
-	mdi.On("ResolveOperation", mock.Anything, opID1, fftypes.OpStatusFailed, mock.MatchedBy(func(errorMsg string) bool {
+	mdi.On("ResolveOperation", mock.Anything, "ns1", opID1, fftypes.OpStatusFailed, mock.MatchedBy(func(errorMsg string) bool {
 		return strings.Contains(errorMsg, "FF10348")
 	}), fftypes.JSONObject{
 		"extra": "info",
@@ -558,17 +564,18 @@ func TestResolveOperationByIDOk(t *testing.T) {
 
 	ctx := context.Background()
 	op := &fftypes.Operation{
-		ID:     fftypes.NewUUID(),
-		Type:   fftypes.OpTypeBlockchainPinBatch,
-		Status: fftypes.OpStatusSucceeded,
-		Error:  "my error",
+		ID:        fftypes.NewUUID(),
+		Namespace: "ns1",
+		Type:      fftypes.OpTypeBlockchainPinBatch,
+		Status:    fftypes.OpStatusSucceeded,
+		Error:     "my error",
 		Output: fftypes.JSONObject{
 			"my": "data",
 		},
 	}
 
 	mdi := om.database.(*databasemocks.Plugin)
-	mdi.On("ResolveOperation", ctx, op.ID, fftypes.OpStatusSucceeded, "my error", fftypes.JSONObject{
+	mdi.On("ResolveOperation", ctx, "ns1", op.ID, fftypes.OpStatusSucceeded, "my error", fftypes.JSONObject{
 		"my": "data",
 	}).Return(nil)
 

--- a/internal/operations/operation_updater.go
+++ b/internal/operations/operation_updater.go
@@ -277,7 +277,7 @@ func (ou *operationUpdater) doUpdate(ctx context.Context, update *OperationUpdat
 		}
 	}
 
-	if err := ou.database.ResolveOperation(ctx, op.ID, update.Status, update.ErrorMessage, update.Output); err != nil {
+	if err := ou.database.ResolveOperation(ctx, op.Namespace, op.ID, update.Status, update.ErrorMessage, update.Output); err != nil {
 		return err
 	}
 

--- a/internal/operations/operation_updater_test.go
+++ b/internal/operations/operation_updater_test.go
@@ -114,15 +114,15 @@ func TestSubmitUpdateWorkerE2ESuccess(t *testing.T) {
 
 	mdi := om.database.(*databasemocks.Plugin)
 	mdi.On("GetOperations", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Operation{
-		{ID: opID1, Type: fftypes.OpTypeBlockchainInvoke, Transaction: tx1.ID},
-		{ID: opID2, Type: fftypes.OpTypeTokenTransfer, Input: fftypes.JSONObject{"test": "test"}},
-		{ID: opID3, Type: fftypes.OpTypeTokenApproval, Input: fftypes.JSONObject{"test": "test"}},
+		{ID: opID1, Namespace: "ns1", Type: fftypes.OpTypeBlockchainInvoke, Transaction: tx1.ID},
+		{ID: opID2, Namespace: "ns1", Type: fftypes.OpTypeTokenTransfer, Input: fftypes.JSONObject{"test": "test"}},
+		{ID: opID3, Namespace: "ns1", Type: fftypes.OpTypeTokenApproval, Input: fftypes.JSONObject{"test": "test"}},
 	}, nil, nil)
 	mdi.On("GetTransactions", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Transaction{tx1}, nil, nil)
-	mdi.On("ResolveOperation", mock.Anything, opID1, fftypes.OpStatusSucceeded, "", fftypes.JSONObject(nil)).Return(nil)
+	mdi.On("ResolveOperation", mock.Anything, "ns1", opID1, fftypes.OpStatusSucceeded, "", fftypes.JSONObject(nil)).Return(nil)
 	mdi.On("UpdateTransaction", mock.Anything, tx1.ID, mock.Anything).Return(nil)
-	mdi.On("ResolveOperation", mock.Anything, opID2, fftypes.OpStatusFailed, "err1", fftypes.JSONObject{"test": true}).Return(nil)
-	mdi.On("ResolveOperation", mock.Anything, opID3, fftypes.OpStatusFailed, "err2", fftypes.JSONObject(nil)).Return(nil).
+	mdi.On("ResolveOperation", mock.Anything, "ns1", opID2, fftypes.OpStatusFailed, "err1", fftypes.JSONObject{"test": true}).Return(nil)
+	mdi.On("ResolveOperation", mock.Anything, "ns1", opID3, fftypes.OpStatusFailed, "err2", fftypes.JSONObject(nil)).Return(nil).
 		Run(func(args mock.Arguments) {
 			close(done)
 		})
@@ -178,9 +178,9 @@ func TestDoBatchUpdateFailUpdate(t *testing.T) {
 	opID1 := fftypes.NewUUID()
 	mdi := ou.database.(*databasemocks.Plugin)
 	mdi.On("GetOperations", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.Operation{
-		{ID: opID1, Type: fftypes.OpTypeBlockchainInvoke},
+		{ID: opID1, Namespace: "ns1", Type: fftypes.OpTypeBlockchainInvoke},
 	}, nil, nil)
-	mdi.On("ResolveOperation", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	mdi.On("ResolveOperation", mock.Anything, "ns1", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	ou.initQueues()
 

--- a/internal/privatemessaging/operations.go
+++ b/internal/privatemessaging/operations.go
@@ -149,16 +149,18 @@ func (pm *privateMessaging) OnOperationUpdate(ctx context.Context, op *fftypes.O
 
 func opSendBlob(op *fftypes.Operation, node *fftypes.Identity, blob *fftypes.Blob) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: transferBlobData{Node: node, Blob: blob},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      transferBlobData{Node: node, Blob: blob},
 	}
 }
 
 func opSendBatch(op *fftypes.Operation, node *fftypes.Identity, transport *fftypes.TransportWrapper) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
-		Data: batchSendData{Node: node, Transport: transport},
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
+		Data:      batchSendData{Node: node, Transport: transport},
 	}
 }

--- a/internal/shareddownload/operations.go
+++ b/internal/shareddownload/operations.go
@@ -172,8 +172,9 @@ func (dm *downloadManager) OnOperationUpdate(ctx context.Context, op *fftypes.Op
 
 func opDownloadBatch(op *fftypes.Operation, ns string, payloadRef string) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
 		Data: downloadBatchData{
 			Namespace:  ns,
 			PayloadRef: payloadRef,
@@ -183,8 +184,9 @@ func opDownloadBatch(op *fftypes.Operation, ns string, payloadRef string) *fftyp
 
 func opDownloadBlob(op *fftypes.Operation, ns string, dataID *fftypes.UUID, payloadRef string) *fftypes.PreparedOperation {
 	return &fftypes.PreparedOperation{
-		ID:   op.ID,
-		Type: op.Type,
+		ID:        op.ID,
+		Namespace: op.Namespace,
+		Type:      op.Type,
 		Data: downloadBlobData{
 			Namespace:  ns,
 			DataID:     dataID,

--- a/internal/tokens/fftokens/config.go
+++ b/internal/tokens/fftokens/config.go
@@ -17,10 +17,10 @@
 package fftokens
 
 import (
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/pkg/config"
+	"github.com/hyperledger/firefly/pkg/wsclient"
 )
 
 func (ft *FFTokens) InitPrefix(prefix config.PrefixArray) {
-	wsconfig.InitPrefix(prefix)
+	wsclient.InitPrefix(prefix)
 }

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/hyperledger/firefly/internal/coreconfig/wsconfig"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/config"
@@ -139,7 +138,7 @@ func (ft *FFTokens) Init(ctx context.Context, name string, prefix config.Prefix,
 	ft.client = ffresty.New(ft.ctx, prefix)
 	ft.capabilities = &tokens.Capabilities{}
 
-	wsConfig := wsconfig.GenerateConfigFromPrefix(prefix)
+	wsConfig := wsclient.GenerateConfigFromPrefix(prefix)
 
 	if wsConfig.WSKeyPath == "" {
 		wsConfig.WSKeyPath = "/api/ws"

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,7 @@
 {
   "ethconnect": {
-    "image": "ghcr.io/hyperledger/firefly-ethconnect",
-    "tag": "v3.1.6",
-    "sha": "7336bb15640a01eea1c440195461862b6982a24e1a33b4ea0d89a30acb8bcf7b"
+    "image": "hyperledger/firefly-ethconnect",
+    "local": true
   },
   "fabconnect": {
     "image": "ghcr.io/hyperledger/firefly-fabconnect",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
   "ethconnect": {
-    "image": "hyperledger/firefly-ethconnect",
-    "local": true
+    "image": "ghcr.io/hyperledger/firefly-ethconnect",
+    "tag": "v3.1.6",
+    "sha": "7336bb15640a01eea1c440195461862b6982a24e1a33b4ea0d89a30acb8bcf7b"
   },
   "fabconnect": {
     "image": "ghcr.io/hyperledger/firefly-fabconnect",

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2504,13 +2504,13 @@ func (_m *Plugin) ReplaceMessage(ctx context.Context, message *fftypes.Message) 
 	return r0
 }
 
-// ResolveOperation provides a mock function with given fields: ctx, id, status, errorMsg, output
-func (_m *Plugin) ResolveOperation(ctx context.Context, id *fftypes.UUID, status fftypes.OpStatus, errorMsg string, output fftypes.JSONObject) error {
-	ret := _m.Called(ctx, id, status, errorMsg, output)
+// ResolveOperation provides a mock function with given fields: ctx, ns, id, status, errorMsg, output
+func (_m *Plugin) ResolveOperation(ctx context.Context, ns string, id *fftypes.UUID, status fftypes.OpStatus, errorMsg string, output fftypes.JSONObject) error {
+	ret := _m.Called(ctx, ns, id, status, errorMsg, output)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, fftypes.OpStatus, string, fftypes.JSONObject) error); ok {
-		r0 = rf(ctx, id, status, errorMsg, output)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID, fftypes.OpStatus, string, fftypes.JSONObject) error); ok {
+		r0 = rf(ctx, ns, id, status, errorMsg, output)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2686,13 +2686,20 @@ func (_m *Plugin) UpdateOffset(ctx context.Context, rowID int64, update database
 	return r0
 }
 
-// UpdateOperation provides a mock function with given fields: ctx, id, update
-func (_m *Plugin) UpdateOperation(ctx context.Context, id *fftypes.UUID, update database.Update) error {
-	ret := _m.Called(ctx, id, update)
+// UpdateOperation provides a mock function with given fields: ctx, id, update, hooks
+func (_m *Plugin) UpdateOperation(ctx context.Context, id *fftypes.UUID, update database.Update, hooks ...database.PostCompletionHook) error {
+	_va := make([]interface{}, len(hooks))
+	for _i := range hooks {
+		_va[_i] = hooks[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, id, update)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, database.Update) error); ok {
-		r0 = rf(ctx, id, update)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, database.Update, ...database.PostCompletionHook) error); ok {
+		r0 = rf(ctx, id, update, hooks...)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -219,10 +219,10 @@ type iOperationCollection interface {
 	InsertOperation(ctx context.Context, operation *fftypes.Operation, hooks ...PostCompletionHook) (err error)
 
 	// ResolveOperation - Resolve operation upon completion
-	ResolveOperation(ctx context.Context, id *fftypes.UUID, status fftypes.OpStatus, errorMsg string, output fftypes.JSONObject) (err error)
+	ResolveOperation(ctx context.Context, ns string, id *fftypes.UUID, status fftypes.OpStatus, errorMsg string, output fftypes.JSONObject) (err error)
 
 	// UpdateOperation - Update an operation
-	UpdateOperation(ctx context.Context, id *fftypes.UUID, update Update) (err error)
+	UpdateOperation(ctx context.Context, id *fftypes.UUID, update Update, hooks ...PostCompletionHook) (err error)
 
 	// GetOperationByID - Get an operation by ID
 	GetOperationByID(ctx context.Context, id *fftypes.UUID) (operation *fftypes.Operation, err error)

--- a/pkg/fftypes/operation.go
+++ b/pkg/fftypes/operation.go
@@ -100,7 +100,8 @@ type Operation struct {
 // PreparedOperation from an Operation. Data is defined by the Manager, but should be JSON-serializable
 // to support inspection and debugging.
 type PreparedOperation struct {
-	ID   *UUID       `json:"id"`
-	Type OpType      `json:"type" ffenum:"optype"`
-	Data interface{} `json:"data"`
+	ID        *UUID       `json:"id"`
+	Namespace string      `json:"namespace"`
+	Type      OpType      `json:"type" ffenum:"optype"`
+	Data      interface{} `json:"data"`
 }

--- a/pkg/wsclient/wsconfig.go
+++ b/pkg/wsclient/wsconfig.go
@@ -14,12 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wsconfig
+package wsclient
 
 import (
 	"github.com/hyperledger/firefly/pkg/config"
 	"github.com/hyperledger/firefly/pkg/ffresty"
-	"github.com/hyperledger/firefly/pkg/wsclient"
 )
 
 const (
@@ -54,8 +53,8 @@ func InitPrefix(prefix config.KeySet) {
 	prefix.AddKnownKey(WSConfigHeartbeatInterval, defaultHeartbeatInterval)
 }
 
-func GenerateConfigFromPrefix(prefix config.Prefix) *wsclient.WSConfig {
-	return &wsclient.WSConfig{
+func GenerateConfigFromPrefix(prefix config.Prefix) *WSConfig {
+	return &WSConfig{
 		HTTPURL:                prefix.GetString(ffresty.HTTPConfigURL),
 		WSKeyPath:              prefix.GetString(WSConfigKeyPath),
 		ReadBufferSize:         int(prefix.GetByteSize(WSConfigKeyReadBufferSize)),

--- a/pkg/wsclient/wsconfig_test.go
+++ b/pkg/wsclient/wsconfig_test.go
@@ -1,4 +1,4 @@
-package wsconfig
+package wsclient
 
 import (
 	"testing"


### PR DESCRIPTION
This is the first step, to allow a URL to be specified, and use it only for `SendTransaction`.
