### PR TITLE
Format JSON errors from connectors

### DIFF
--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -624,8 +624,37 @@ func TestSubmitBatchPinFail(t *testing.T) {
 
 	err := e.SubmitBatchPin(context.Background(), nil, nil, addr, batch)
 
-	assert.Regexp(t, "FF10111", err)
-	assert.Regexp(t, "pop", err)
+	assert.Regexp(t, "FF10111.*pop", err)
+
+}
+
+func TestSubmitBatchPinError(t *testing.T) {
+
+	e, cancel := newTestEthereum()
+	defer cancel()
+	httpmock.ActivateNonDefault(e.client.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	addr := ethHexFormatB32(fftypes.NewRandB32())
+	batch := &blockchain.BatchPin{
+		TransactionID:   fftypes.NewUUID(),
+		BatchID:         fftypes.NewUUID(),
+		BatchHash:       fftypes.NewRandB32(),
+		BatchPayloadRef: "Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD",
+		Contexts: []*fftypes.Bytes32{
+			fftypes.NewRandB32(),
+			fftypes.NewRandB32(),
+		},
+	}
+
+	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
+		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{
+			"error": "Unknown error",
+		}))
+
+	err := e.SubmitBatchPin(context.Background(), nil, nil, addr, batch)
+
+	assert.Regexp(t, "FF10111.*Unknown error", err)
 
 }
 

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -78,6 +78,10 @@ type fabTxInputHeaders struct {
 	Chaincode     string         `json:"chaincode,omitempty"`
 }
 
+type fabError struct {
+	Error string `json:"error,omitempty"`
+}
+
 type PayloadSchema struct {
 	Type        string        `json:"type"`
 	PrefixItems []*PrefixItem `json:"prefixItems"`
@@ -514,7 +518,14 @@ func (f *Fabric) NormalizeSigningKey(ctx context.Context, signingKeyInput string
 	return signingKeyInput, nil
 }
 
-func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, methodName, signingKey, requestID string, prefixItems []*PrefixItem, input map[string]string) (*resty.Response, error) {
+func wrapError(ctx context.Context, errRes *fabError, res *resty.Response, err error) error {
+	if errRes != nil && errRes.Error != "" {
+		return i18n.WrapError(ctx, err, coremsgs.MsgFabconnectRESTErr, errRes.Error)
+	}
+	return ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgFabconnectRESTErr)
+}
+
+func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, methodName, signingKey, requestID string, prefixItems []*PrefixItem, input map[string]string) error {
 	in := &fabTxNamedInput{
 		Headers: &fabTxInputHeaders{
 			ID: requestID,
@@ -530,10 +541,16 @@ func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, m
 		Args: input,
 	}
 
-	return f.client.R().
+	var resErr fabError
+	res, err := f.client.R().
 		SetContext(ctx).
 		SetBody(in).
+		SetError(&resErr).
 		Post("/transactions")
+	if err != nil || !res.IsSuccess() {
+		return wrapError(ctx, &resErr, res, err)
+	}
+	return nil
 }
 
 func getUserName(fullIDString string) string {
@@ -572,12 +589,7 @@ func (f *Fabric) SubmitBatchPin(ctx context.Context, operationID *fftypes.UUID, 
 	}
 
 	input, _ := jsonEncodeInput(pinInput)
-
-	res, err := f.invokeContractMethod(ctx, f.defaultChannel, f.chaincode, batchPinMethodName, signingKey, operationID.String(), batchPinPrefixItems, input)
-	if err != nil || !res.IsSuccess() {
-		return ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgFabconnectRESTErr)
-	}
-	return nil
+	return f.invokeContractMethod(ctx, f.defaultChannel, f.chaincode, batchPinMethodName, signingKey, operationID.String(), batchPinPrefixItems, input)
 }
 
 func (f *Fabric) InvokeContract(ctx context.Context, operationID *fftypes.UUID, signingKey string, location *fftypes.JSONAny, method *fftypes.FFIMethod, input map[string]interface{}) error {
@@ -606,12 +618,7 @@ func (f *Fabric) InvokeContract(ctx context.Context, operationID *fftypes.UUID, 
 		}
 	}
 
-	res, err := f.invokeContractMethod(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode, method.Name, signingKey, operationID.String(), prefixItems, args)
-
-	if err != nil || !res.IsSuccess() {
-		return ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgFabconnectRESTErr)
-	}
-	return nil
+	return f.invokeContractMethod(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode, method.Name, signingKey, operationID.String(), prefixItems, args)
 }
 
 func (f *Fabric) QueryContract(ctx context.Context, location *fftypes.JSONAny, method *fftypes.FFIMethod, input map[string]interface{}) (interface{}, error) {

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -476,8 +476,37 @@ func TestSubmitBatchPinFail(t *testing.T) {
 
 	err := e.SubmitBatchPin(context.Background(), nil, nil, signer, batch)
 
-	assert.Regexp(t, "FF10284", err)
-	assert.Regexp(t, "pop", err)
+	assert.Regexp(t, "FF10284.*pop", err)
+
+}
+
+func TestSubmitBatchPinError(t *testing.T) {
+
+	e, cancel := newTestFabric()
+	defer cancel()
+	httpmock.ActivateNonDefault(e.client.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	signer := "signer001"
+	batch := &blockchain.BatchPin{
+		TransactionID:   fftypes.NewUUID(),
+		BatchID:         fftypes.NewUUID(),
+		BatchHash:       fftypes.NewRandB32(),
+		BatchPayloadRef: "Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD",
+		Contexts: []*fftypes.Bytes32{
+			fftypes.NewRandB32(),
+			fftypes.NewRandB32(),
+		},
+	}
+
+	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
+		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{
+			"error": "Invalid",
+		}))
+
+	err := e.SubmitBatchPin(context.Background(), nil, nil, signer, batch)
+
+	assert.Regexp(t, "FF10284.*Invalid", err)
 
 }
 

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -165,7 +165,10 @@ func TestCreateTokenPoolError(t *testing.T) {
 	}
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/v1/createpool", httpURL),
-		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{}))
+		httpmock.NewJsonResponderOrPanic(400, fftypes.JSONObject{
+			"error":   "Bad Request",
+			"message": "Missing required field",
+		}))
 
 	complete, err := h.CreateTokenPool(context.Background(), fftypes.NewUUID(), pool)
 	assert.False(t, complete)


### PR DESCRIPTION
```
Parse a JSON error of the form:
  {"error": "Bad Request", "message": "Field 'x' is required"}
into a message of the form:
  "Bad Request: Field 'x' is required"
```

See https://github.com/hyperledger/firefly/issues/753