### PR TITLE
Gauge Metrics for Network Identities

### DIFF
--- a/internal/apiserver/route_get_identity_did.go
+++ b/internal/apiserver/route_get_identity_did.go
@@ -39,6 +39,6 @@ var getIdentityDID = &oapispec.Route{
 	JSONOutputValue: func() interface{} { return &networkmap.DIDDocument{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
-		return getOr(r.Ctx).NetworkMap().GetDIDDocForIndentityByID(r.Ctx, r.PP["ns"], r.PP["iid"])
+		return getOr(r.Ctx).NetworkMap().GetDIDDocForIdentityByID(r.Ctx, r.PP["ns"], r.PP["iid"])
 	},
 }

--- a/internal/apiserver/route_get_identity_did_test.go
+++ b/internal/apiserver/route_get_identity_did_test.go
@@ -34,7 +34,7 @@ func TestGetIdentityDID(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	mnm.On("GetDIDDocForIndentityByID", mock.Anything, "ns1", "id1").Return(&networkmap.DIDDocument{}, nil, nil)
+	mnm.On("GetDIDDocForIdentityByID", mock.Anything, "ns1", "id1").Return(&networkmap.DIDDocument{}, nil, nil)
 	r.ServeHTTP(res, req)
 
 	assert.Equal(t, 200, res.Result().StatusCode)

--- a/internal/apiserver/route_get_net_diddoc.go
+++ b/internal/apiserver/route_get_net_diddoc.go
@@ -37,6 +37,6 @@ var getDIDDocByDID = &oapispec.Route{
 	JSONOutputValue: func() interface{} { return &networkmap.DIDDocument{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
-		return getOr(r.Ctx).NetworkMap().GetDIDDocForIndentityByDID(r.Ctx, r.PP["did"])
+		return getOr(r.Ctx).NetworkMap().GetDIDDocForIdentityByDID(r.Ctx, r.PP["did"])
 	},
 }

--- a/internal/apiserver/route_get_net_diddoc_test.go
+++ b/internal/apiserver/route_get_net_diddoc_test.go
@@ -34,7 +34,7 @@ func TestGetDIDDocByDID(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	nmn.On("GetDIDDocForIndentityByDID", mock.Anything, "did:firefly:org/org_1").
+	nmn.On("GetDIDDocForIdentityByDID", mock.Anything, "did:firefly:org/org_1").
 		Return(&networkmap.DIDDocument{}, nil)
 	r.ServeHTTP(res, req)
 

--- a/internal/database/sqlcommon/identity_sql.go
+++ b/internal/database/sqlcommon/identity_sql.go
@@ -203,7 +203,6 @@ func (s *SQLCommon) GetIdentityByID(ctx context.Context, id *fftypes.UUID) (iden
 }
 
 func (s *SQLCommon) GetIdentities(ctx context.Context, filter database.Filter) (identities []*fftypes.Identity, fr *database.FilterResult, err error) {
-
 	query, fop, fi, err := s.filterSelect(ctx, "", sq.Select(identityColumns...).From("identities"), filter, identityFilterFieldMap, []interface{}{"sequence"})
 	if err != nil {
 		return nil, nil, err

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -37,6 +37,7 @@ type Manager interface {
 	BlockchainTransaction(location, methodName string)
 	BlockchainQuery(location, methodName string)
 	BlockchainEvent(location, signature string)
+	SetNetworkIdentities(count int64, iType string)
 	AddTime(id string)
 	GetTime(id string) time.Time
 	DeleteTime(id string)
@@ -162,6 +163,10 @@ func (mm *metricsManager) DeleteTime(id string) {
 	mutex.Lock()
 	delete(mm.timeMap, id)
 	mutex.Unlock()
+}
+
+func (mm *metricsManager) SetNetworkIdentities(count int64, iType string) {
+	NetworkIdentitiesGauge.WithLabelValues(iType).Set(float64(count))
 }
 
 func (mm *metricsManager) IsMetricsEnabled() bool {

--- a/internal/metrics/network.go
+++ b/internal/metrics/network.go
@@ -26,7 +26,7 @@ var NetworkIdentitiesGaugeName = "ff_network_identities"
 func InitNetworkMetrics() {
 	NetworkIdentitiesGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: NetworkIdentitiesGaugeName,
-		Help: "Number of identities registered",
+		Help: "Number of identities confirmed",
 	}, []string{"type"})
 }
 

--- a/internal/metrics/network.go
+++ b/internal/metrics/network.go
@@ -1,0 +1,35 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var NetworkIdentitiesGauge *prometheus.GaugeVec
+
+// NetworkIdentitiesGaugeName is the prometheus metric for observing the total identities registered
+var NetworkIdentitiesGaugeName = "ff_network_identities"
+
+func InitNetworkMetrics() {
+	NetworkIdentitiesGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: NetworkIdentitiesGaugeName,
+		Help: "Number of nodes registered",
+	}, []string{"type"})
+}
+
+func RegisterNetworkMetrics() {
+	registry.MustRegister(NetworkIdentitiesGauge)
+}

--- a/internal/metrics/network.go
+++ b/internal/metrics/network.go
@@ -26,7 +26,7 @@ var NetworkIdentitiesGaugeName = "ff_network_identities"
 func InitNetworkMetrics() {
 	NetworkIdentitiesGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: NetworkIdentitiesGaugeName,
-		Help: "Number of nodes registered",
+		Help: "Number of identities registered",
 	}, []string{"type"})
 }
 

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -81,6 +81,7 @@ func initMetricsCollectors() {
 	InitTokenBurnMetrics()
 	InitBatchPinMetrics()
 	InitBlockchainMetrics()
+	InitNetworkMetrics()
 }
 
 func registerMetricsCollectors() {
@@ -94,4 +95,5 @@ func registerMetricsCollectors() {
 	RegisterTokenTransferMetrics()
 	RegisterTokenBurnMetrics()
 	RegisterBlockchainMetrics()
+	RegisterNetworkMetrics()
 }

--- a/internal/networkmap/data_query.go
+++ b/internal/networkmap/data_query.go
@@ -201,7 +201,7 @@ func (nm *networkMap) GetIdentityVerifiers(ctx context.Context, ns, id string, f
 	return nm.database.GetVerifiers(ctx, filter)
 }
 
-func (nm *networkMap) GetDIDDocForIndentityByID(ctx context.Context, ns, id string) (*DIDDocument, error) {
+func (nm *networkMap) GetDIDDocForIdentityByID(ctx context.Context, ns, id string) (*DIDDocument, error) {
 	identity, err := nm.GetIdentityByID(ctx, ns, id)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (nm *networkMap) GetDIDDocForIndentityByID(ctx context.Context, ns, id stri
 	return nm.generateDIDDocument(ctx, identity)
 }
 
-func (nm *networkMap) GetDIDDocForIndentityByDID(ctx context.Context, did string) (*DIDDocument, error) {
+func (nm *networkMap) GetDIDDocForIdentityByDID(ctx context.Context, did string) (*DIDDocument, error) {
 	identity, err := nm.GetIdentityByDID(ctx, did)
 	if err != nil {
 		return nil, err

--- a/internal/networkmap/did_test.go
+++ b/internal/networkmap/did_test.go
@@ -79,7 +79,7 @@ func TestDIDGenerationOK(t *testing.T) {
 		verifierUnknown,
 	}, nil, nil)
 
-	doc, err := nm.GetDIDDocForIndentityByID(nm.ctx, org1.Namespace, org1.ID.String())
+	doc, err := nm.GetDIDDocForIdentityByID(nm.ctx, org1.Namespace, org1.ID.String())
 	assert.NoError(t, err)
 	assert.Equal(t, &DIDDocument{
 		Context: []string{
@@ -127,7 +127,7 @@ func TestDIDGenerationGetVerifiersFail(t *testing.T) {
 	mdi.On("GetIdentityByID", nm.ctx, mock.Anything).Return(org1, nil)
 	mdi.On("GetVerifiers", nm.ctx, mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
 
-	_, err := nm.GetDIDDocForIndentityByID(nm.ctx, org1.Namespace, org1.ID.String())
+	_, err := nm.GetDIDDocForIdentityByID(nm.ctx, org1.Namespace, org1.ID.String())
 	assert.Regexp(t, "pop", err)
 }
 
@@ -140,7 +140,7 @@ func TestDIDGenerationGetIdentityFail(t *testing.T) {
 	mdi := nm.database.(*databasemocks.Plugin)
 	mdi.On("GetIdentityByID", nm.ctx, mock.Anything).Return(nil, fmt.Errorf("pop"))
 
-	_, err := nm.GetDIDDocForIndentityByID(nm.ctx, org1.Namespace, org1.ID.String())
+	_, err := nm.GetDIDDocForIdentityByID(nm.ctx, org1.Namespace, org1.ID.String())
 	assert.Regexp(t, "pop", err)
 }
 
@@ -153,7 +153,7 @@ func TestDIDGenerationGetIdentityByDIDFail(t *testing.T) {
 	mii := nm.identity.(*identitymanagermocks.Manager)
 	mii.On("CachedIdentityLookupMustExist", nm.ctx, mock.Anything).Return(nil, false, fmt.Errorf("pop"))
 
-	_, err := nm.GetDIDDocForIndentityByDID(nm.ctx, org1.DID)
+	_, err := nm.GetDIDDocForIdentityByDID(nm.ctx, org1.DID)
 	assert.Regexp(t, "pop", err)
 }
 
@@ -172,6 +172,6 @@ func TestDIDGenerationGetIdentityByDIDFailVerifiers(t *testing.T) {
 	mdi := nm.database.(*databasemocks.Plugin)
 	mdi.On("GetVerifiers", nm.ctx, mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
 
-	_, err := nm.GetDIDDocForIndentityByDID(nm.ctx, org1.DID)
+	_, err := nm.GetDIDDocForIdentityByDID(nm.ctx, org1.DID)
 	assert.Regexp(t, "pop", err)
 }

--- a/internal/networkmap/manager.go
+++ b/internal/networkmap/manager.go
@@ -56,9 +56,7 @@ type Manager interface {
 	GetVerifierByHash(ctx context.Context, ns, hash string) (*fftypes.Verifier, error)
 	GetDIDDocForIdentityByID(ctx context.Context, ns, id string) (*DIDDocument, error)
 	GetDIDDocForIdentityByDID(ctx context.Context, did string) (*DIDDocument, error)
-
-	Start() error
-	WaitStop()
+	UpdateIdentityGauges(ctx context.Context)
 }
 
 type networkMap struct {
@@ -89,13 +87,4 @@ func NewNetworkMap(ctx context.Context, di database.Plugin, bm broadcast.Manager
 	)
 
 	return nm, nil
-}
-
-func (nm *networkMap) Start() error {
-	go nm.networkMetricsLoop()
-	return nil
-}
-
-func (nm *networkMap) WaitStop() {
-	nm.cancelCtx()
 }

--- a/internal/networkmap/manager.go
+++ b/internal/networkmap/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/firefly/internal/broadcast"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/internal/identity"
+	"github.com/hyperledger/firefly/internal/metrics"
 	"github.com/hyperledger/firefly/internal/syncasync"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/dataexchange"
@@ -30,6 +31,8 @@ import (
 )
 
 type Manager interface {
+	Start() error
+
 	RegisterOrganization(ctx context.Context, org *fftypes.IdentityCreateDTO, waitConfirm bool) (identity *fftypes.Identity, err error)
 	RegisterNode(ctx context.Context, waitConfirm bool) (node *fftypes.Identity, err error)
 	RegisterNodeOrganization(ctx context.Context, waitConfirm bool) (org *fftypes.Identity, err error)
@@ -52,8 +55,8 @@ type Manager interface {
 	GetIdentityVerifiers(ctx context.Context, ns, id string, filter database.AndFilter) ([]*fftypes.Verifier, *database.FilterResult, error)
 	GetVerifiers(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Verifier, *database.FilterResult, error)
 	GetVerifierByHash(ctx context.Context, ns, hash string) (*fftypes.Verifier, error)
-	GetDIDDocForIndentityByID(ctx context.Context, ns, id string) (*DIDDocument, error)
-	GetDIDDocForIndentityByDID(ctx context.Context, did string) (*DIDDocument, error)
+	GetDIDDocForIdentityByID(ctx context.Context, ns, id string) (*DIDDocument, error)
+	GetDIDDocForIdentityByDID(ctx context.Context, did string) (*DIDDocument, error)
 }
 
 type networkMap struct {
@@ -63,9 +66,10 @@ type networkMap struct {
 	exchange  dataexchange.Plugin
 	identity  identity.Manager
 	syncasync syncasync.Bridge
+	metrics   metrics.Manager
 }
 
-func NewNetworkMap(ctx context.Context, di database.Plugin, bm broadcast.Manager, dx dataexchange.Plugin, im identity.Manager, sa syncasync.Bridge) (Manager, error) {
+func NewNetworkMap(ctx context.Context, di database.Plugin, bm broadcast.Manager, dx dataexchange.Plugin, im identity.Manager, sa syncasync.Bridge, mm metrics.Manager) (Manager, error) {
 	if di == nil || bm == nil || dx == nil || im == nil {
 		return nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError)
 	}
@@ -77,6 +81,15 @@ func NewNetworkMap(ctx context.Context, di database.Plugin, bm broadcast.Manager
 		exchange:  dx,
 		identity:  im,
 		syncasync: sa,
+		metrics:   mm,
 	}
+
 	return nm, nil
+}
+
+func (nm *networkMap) Start() error {
+	if nm.metrics.IsMetricsEnabled() {
+		go nm.networkMetricsLoop()
+	}
+	return nil
 }

--- a/internal/networkmap/metrics.go
+++ b/internal/networkmap/metrics.go
@@ -1,0 +1,65 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkmap
+
+import (
+	"context"
+	"time"
+
+	"github.com/hyperledger/firefly/pkg/database"
+	"github.com/hyperledger/firefly/pkg/log"
+)
+
+func (nm *networkMap) updateIdentityGauges(ctx context.Context) error {
+	_, iRes, iErr := nm.GetIdentitiesGlobal(ctx, database.IdentityQueryFactory.NewFilter(ctx).And())
+	if iErr != nil {
+		nm.metrics.SetNetworkIdentities(-1, "any")
+		return iErr
+	}
+	nm.metrics.SetNetworkIdentities(*iRes.TotalCount, "any")
+
+	_, oRes, oErr := nm.GetOrganizations(ctx, database.IdentityQueryFactory.NewFilter(ctx).And())
+	if oErr != nil {
+		nm.metrics.SetNetworkIdentities(-1, "organization")
+		return oErr
+	}
+	nm.metrics.SetNetworkIdentities(*oRes.TotalCount, "organization")
+
+	_, nRes, nErr := nm.GetNodes(ctx, database.IdentityQueryFactory.NewFilter(ctx).And())
+	if nErr != nil {
+		nm.metrics.SetNetworkIdentities(-1, "node")
+		return nErr
+	}
+	nm.metrics.SetNetworkIdentities(*nRes.TotalCount, "node")
+
+	return nil
+}
+
+func (nm *networkMap) networkMetricsLoop() {
+	ctx := log.WithLogField(nm.ctx, "role", "networkmap")
+	ctx = log.WithLogField(ctx, "loop", "metrics")
+
+	for {
+		log.L(ctx).Debug("Sleeping for networkmap metrics loop")
+		time.Sleep(30 * time.Second)
+		if nm.metrics.IsMetricsEnabled() {
+			if err := nm.updateIdentityGauges(ctx); err != nil {
+				log.L(ctx).Error("Failed to observe network metrics", err)
+			}
+		}
+	}
+}

--- a/internal/networkmap/metrics.go
+++ b/internal/networkmap/metrics.go
@@ -55,10 +55,11 @@ func (nm *networkMap) networkMetricsLoop() {
 	log.L(ctx).Info("Starting network metrics loop")
 	loop := true
 	for loop {
-		log.L(ctx).Debug("Sleeping for networkmap metrics loop")
+		log.L(ctx).Trace("Sleeping for networkmap metrics loop")
 		select {
 		case <-time.After(30 * time.Second):
 			if nm.metrics.IsMetricsEnabled() {
+				log.L(ctx).Trace("Updating networkmap metrics")
 				if err := nm.updateIdentityGauges(ctx); err != nil {
 					log.L(ctx).Error("Failed to observe network metrics", err)
 				}

--- a/internal/orchestrator/bound_callbacks.go
+++ b/internal/orchestrator/bound_callbacks.go
@@ -17,7 +17,9 @@
 package orchestrator
 
 import (
+	"context"
 	"github.com/hyperledger/firefly/internal/events"
+	"github.com/hyperledger/firefly/internal/networkmap"
 	"github.com/hyperledger/firefly/internal/operations"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/dataexchange"
@@ -32,6 +34,7 @@ type boundCallbacks struct {
 	ss sharedstorage.Plugin
 	ei events.EventManager
 	om operations.Manager
+	nm networkmap.Manager
 }
 
 func (bc *boundCallbacks) BlockchainOpUpdate(plugin blockchain.Plugin, operationID *fftypes.UUID, txState blockchain.TransactionStatus, blockchainTXID, errorMessage string, opOutput fftypes.JSONObject) {
@@ -89,4 +92,8 @@ func (bc *boundCallbacks) SharedStorageBatchDownloaded(ns, payloadRef string, da
 
 func (bc *boundCallbacks) SharedStorageBlobDownloaded(hash fftypes.Bytes32, size int64, payloadRef string) {
 	bc.ei.SharedStorageBlobDownloaded(bc.ss, hash, size, payloadRef)
+}
+
+func (bc *boundCallbacks) IdentityClaimConfirmed(ctx context.Context) {
+	bc.nm.UpdateIdentityGauges(ctx)
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -241,6 +241,9 @@ func (or *orchestrator) Start() error {
 		err = or.sharedDownload.Start()
 	}
 	if err == nil {
+		err = or.networkmap.Start()
+	}
+	if err == nil {
 		for _, el := range or.tokens {
 			if err = el.Start(); err != nil {
 				break
@@ -582,7 +585,7 @@ func (or *orchestrator) initComponents(ctx context.Context) (err error) {
 	}
 
 	if or.networkmap == nil {
-		or.networkmap, err = networkmap.NewNetworkMap(ctx, or.database, or.broadcast, or.dataexchange, or.identity, or.syncasync)
+		or.networkmap, err = networkmap.NewNetworkMap(ctx, or.database, or.broadcast, or.dataexchange, or.identity, or.syncasync, or.metrics)
 		if err != nil {
 			return err
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -285,6 +285,10 @@ func (or *orchestrator) WaitStop() {
 		or.adminEvents.WaitStop()
 		or.adminEvents = nil
 	}
+	if or.networkmap != nil {
+		or.networkmap.WaitStop()
+		or.networkmap = nil
+	}
 	or.started = false
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -213,6 +213,7 @@ func (or *orchestrator) Init(ctx context.Context, cancelCtx context.CancelFunc) 
 	or.bc.dx = or.dataexchange
 	or.bc.ss = or.sharedstorage
 	or.bc.om = or.operations
+	or.bc.nm = or.networkmap
 	return err
 }
 
@@ -239,9 +240,6 @@ func (or *orchestrator) Start() error {
 	}
 	if err == nil {
 		err = or.sharedDownload.Start()
-	}
-	if err == nil {
-		err = or.networkmap.Start()
 	}
 	if err == nil {
 		for _, el := range or.tokens {
@@ -284,10 +282,6 @@ func (or *orchestrator) WaitStop() {
 	if or.adminEvents != nil {
 		or.adminEvents.WaitStop()
 		or.adminEvents = nil
-	}
-	if or.networkmap != nil {
-		or.networkmap.WaitStop()
-		or.networkmap = nil
 	}
 	or.started = false
 }


### PR DESCRIPTION
Adds a background loop to the `networkmap` manager which periodically fetches all identities, orgs, and nodes and then updates gauges to reflect their current counts.

The intent is that a network operator aggregating metrics could observe the number of identities / nodes / orgs according to each org / node and ensure they are in-sync to detect any issues. Failure to fetch the identities results in the gauge returning `-1`.

This is different from our other counters which are concerned with reflecting the number of times the FireFly process itself has processed a certain event or performed a certain operation. These gauges are meant to provide a Prometheus-native way to observe some of the database state.