### PR TITLE
Omit "connector" from token transfer/approval inputs

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -10431,11 +10431,6 @@ paths:
                     of the approval.  See your chosen token connector documentation
                     for details
                   type: object
-                connector:
-                  description: The name of the token connector, as specified in the
-                    FireFly core configuration file. Required on input when there
-                    are more than one token connectors configured
-                  type: string
                 info:
                   additionalProperties:
                     description: Token connector specific information about the approval
@@ -10820,11 +10815,6 @@ paths:
                     for the token pool should be considered when inputting the amount.
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
-                  type: string
-                connector:
-                  description: The name of the token connector, as specified in the
-                    FireFly core configuration file. Required on input when there
-                    are more than one token connectors configured
                   type: string
                 from:
                   description: The source account for the transfer. On input defaults
@@ -11244,11 +11234,6 @@ paths:
                     for the token pool should be considered when inputting the amount.
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
-                  type: string
-                connector:
-                  description: The name of the token connector, as specified in the
-                    FireFly core configuration file. Required on input when there
-                    are more than one token connectors configured
                   type: string
                 key:
                   description: The blockchain signing key for the transfer. On input
@@ -12450,11 +12435,6 @@ paths:
                     for the token pool should be considered when inputting the amount.
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
-                  type: string
-                connector:
-                  description: The name of the token connector, as specified in the
-                    FireFly core configuration file. Required on input when there
-                    are more than one token connectors configured
                   type: string
                 from:
                   description: The source account for the transfer. On input defaults

--- a/internal/apiserver/route_get_token_connectors.go
+++ b/internal/apiserver/route_get_token_connectors.go
@@ -39,6 +39,6 @@ var getTokenConnectors = &oapispec.Route{
 	JSONOutputValue: func() interface{} { return []*fftypes.TokenConnector{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
-		return getOr(r.Ctx).Assets().GetTokenConnectors(r.Ctx, r.PP["ns"])
+		return getOr(r.Ctx).Assets().GetTokenConnectors(r.Ctx, r.PP["ns"]), nil
 	},
 }

--- a/internal/assets/manager_test.go
+++ b/internal/assets/manager_test.go
@@ -125,14 +125,7 @@ func TestGetTokenConnectors(t *testing.T) {
 	am, cancel := newTestAssets(t)
 	defer cancel()
 
-	_, err := am.GetTokenConnectors(context.Background(), "ns1")
-	assert.NoError(t, err)
-}
-
-func TestGetTokenConnectorsBadNamespace(t *testing.T) {
-	am, cancel := newTestAssets(t)
-	defer cancel()
-
-	_, err := am.GetTokenConnectors(context.Background(), "")
-	assert.Regexp(t, "FF00140", err)
+	connectors := am.GetTokenConnectors(context.Background(), "ns1")
+	assert.Equal(t, 1, len(connectors))
+	assert.Equal(t, "magic-tokens", connectors[0].Name)
 }

--- a/internal/assets/token_pool.go
+++ b/internal/assets/token_pool.go
@@ -43,7 +43,7 @@ func (am *assetManager) CreateTokenPool(ctx context.Context, ns string, pool *ff
 	pool.Namespace = ns
 
 	if pool.Connector == "" {
-		connector, err := am.getTokenConnectorName(ctx, ns)
+		connector, err := am.getDefaultTokenConnector(ctx, ns)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/assets/token_pool_test.go
+++ b/internal/assets/token_pool_test.go
@@ -85,7 +85,7 @@ func TestCreateTokenPoolDuplicateName(t *testing.T) {
 	mdi.AssertExpectations(t)
 }
 
-func TestCreateTokenPoolUnknownConnectorSuccess(t *testing.T) {
+func TestCreateTokenPoolDefaultConnectorSuccess(t *testing.T) {
 	am, cancel := newTestAssets(t)
 	defer cancel()
 
@@ -118,7 +118,7 @@ func TestCreateTokenPoolUnknownConnectorSuccess(t *testing.T) {
 	mom.AssertExpectations(t)
 }
 
-func TestCreateTokenPoolUnknownConnectorNoConnectors(t *testing.T) {
+func TestCreateTokenPoolDefaultConnectorNoConnectors(t *testing.T) {
 	am, cancel := newTestAssets(t)
 	defer cancel()
 
@@ -140,7 +140,7 @@ func TestCreateTokenPoolUnknownConnectorNoConnectors(t *testing.T) {
 	mdm.AssertExpectations(t)
 }
 
-func TestCreateTokenPoolUnknownConnectorMultipleConnectors(t *testing.T) {
+func TestCreateTokenPoolDefaultConnectorMultipleConnectors(t *testing.T) {
 	am, cancel := newTestAssets(t)
 	defer cancel()
 

--- a/mocks/assetmocks/manager.go
+++ b/mocks/assetmocks/manager.go
@@ -207,7 +207,7 @@ func (_m *Manager) GetTokenBalances(ctx context.Context, ns string, filter datab
 }
 
 // GetTokenConnectors provides a mock function with given fields: ctx, ns
-func (_m *Manager) GetTokenConnectors(ctx context.Context, ns string) ([]*fftypes.TokenConnector, error) {
+func (_m *Manager) GetTokenConnectors(ctx context.Context, ns string) []*fftypes.TokenConnector {
 	ret := _m.Called(ctx, ns)
 
 	var r0 []*fftypes.TokenConnector
@@ -219,14 +219,7 @@ func (_m *Manager) GetTokenConnectors(ctx context.Context, ns string) ([]*fftype
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, ns)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // GetTokenPool provides a mock function with given fields: ctx, ns, connector, poolName

--- a/pkg/fftypes/tokenapproval.go
+++ b/pkg/fftypes/tokenapproval.go
@@ -25,7 +25,7 @@ type TokenApproval struct {
 	LocalID         *UUID          `ffstruct:"TokenApproval" json:"localId,omitempty" ffexcludeinput:"true"`
 	Pool            *UUID          `ffstruct:"TokenApproval" json:"pool,omitempty"`
 	TokenIndex      string         `ffstruct:"TokenApproval" json:"tokenIndex,omitempty"`
-	Connector       string         `ffstruct:"TokenApproval" json:"connector,omitempty"`
+	Connector       string         `ffstruct:"TokenApproval" json:"connector,omitempty" ffexcludeinput:"true"`
 	Key             string         `ffstruct:"TokenApproval" json:"key,omitempty"`
 	Operator        string         `ffstruct:"TokenApproval" json:"operator,omitempty"`
 	Approved        bool           `ffstruct:"TokenApproval" json:"approved"`

--- a/pkg/fftypes/tokentransfer.go
+++ b/pkg/fftypes/tokentransfer.go
@@ -30,7 +30,7 @@ type TokenTransfer struct {
 	Pool            *UUID             `ffstruct:"TokenTransfer" json:"pool,omitempty"`
 	TokenIndex      string            `ffstruct:"TokenTransfer" json:"tokenIndex,omitempty"`
 	URI             string            `ffstruct:"TokenTransfer" json:"uri,omitempty" ffexcludeinput:"true"`
-	Connector       string            `ffstruct:"TokenTransfer" json:"connector,omitempty"`
+	Connector       string            `ffstruct:"TokenTransfer" json:"connector,omitempty" ffexcludeinput:"true"`
 	Namespace       string            `ffstruct:"TokenTransfer" json:"namespace,omitempty" ffexcludeinput:"true"`
 	Key             string            `ffstruct:"TokenTransfer" json:"key,omitempty"`
 	From            string            `ffstruct:"TokenTransfer" json:"from,omitempty" ffexcludeinput:"postTokenMint"`


### PR DESCRIPTION
This should always be inferred from the token pool.

Fixes #768