### PR TITLE
Fix links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions to the FireFly Project in many forms, and
 there's always plenty to do!
 
 Please visit the
-[contributors guide](https://hyperledger.github.io/firefly//contributors/contributors.html) in the
+[contributors guide](https://hyperledger.github.io/firefly//contributors/index.html) in the
 docs to learn how to make contributions to this exciting project.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The FireFly API for digital assets, data flows, and blockchain transactions make
 
 The best place to learn about FireFly is in the [documentation](https://hyperledger.github.io/firefly).
 
-There you will find our [Getting Started Guide](https://hyperledger.github.io/firefly/gettingstarted/gettingstarted.html),
+There you will find our [Getting Started Guide](https://hyperledger.github.io/firefly/gettingstarted/),
 which will get you a running FireFly network of Supernodes on your local machine in a few minutes.
 
 Your development environment will come with:


### PR DESCRIPTION
I deleted the previous branch when i noticed my git credentials had not been updated in my signed commits.
This PR still addresses the two links.