### PR TITLE
Do not init apiserver config, until after config reset

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -88,7 +88,6 @@ func getOrchestrator() orchestrator.Orchestrator {
 
 // Execute is called by the main method of the package
 func Execute() error {
-	apiserver.InitConfig()
 	return rootCmd.Execute()
 }
 
@@ -96,6 +95,7 @@ func run() error {
 
 	// Read the configuration
 	coreconfig.Reset()
+	apiserver.InitConfig()
 	err := config.ReadConfig(configSuffix, cfgFile)
 
 	// Setup logging after reading config (even if failed), to output header correctly

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,6 @@ github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKEN
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/firefly-common v0.1.1 h1:8CVwSFJdxqq7Ztpk2mn2Ai2M4IA8VVpdnzY0FRi90LE=
-github.com/hyperledger/firefly-common v0.1.1/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
 github.com/hyperledger/firefly-common v0.1.2 h1:zwz7WAHrK5we8bku7FO1rGZSFY+N4sDO3fWrabsnL+E=
 github.com/hyperledger/firefly-common v0.1.2/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=


### PR DESCRIPTION
CORS defaults were not being applied any more, after #791 moved the initialization to be alongside all the rest of the HTTP server config.

We were initializing those config prefixes, before we were calling `coreconfig.Reset()`

![image](https://user-images.githubusercontent.com/6660217/167027739-9275f639-fa3e-4d8a-9ea9-a9e722ebabb4.png)