### PR TITLE
Define config schema for namespaces.predefined

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -83,7 +83,7 @@ func getOrchestrator() orchestrator.Orchestrator {
 	if _utOrchestrator != nil {
 		return _utOrchestrator
 	}
-	return orchestrator.NewOrchestrator()
+	return orchestrator.NewOrchestrator(true)
 }
 
 // Execute is called by the main method of the package

--- a/docs/config_docs_generate_test.go
+++ b/docs/config_docs_generate_test.go
@@ -25,15 +25,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly/internal/apiserver"
 	"github.com/hyperledger/firefly/internal/orchestrator"
-	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateConfigDocs(t *testing.T) {
 	// Initialize config of all plugins
-	orchestrator.NewOrchestrator()
+	orchestrator.NewOrchestrator(false)
 	apiserver.InitConfig()
 	f, err := os.Create(filepath.Join("reference", "config.md"))
 	assert.NoError(t, err)

--- a/docs/config_docs_test.go
+++ b/docs/config_docs_test.go
@@ -26,15 +26,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly/internal/apiserver"
 	"github.com/hyperledger/firefly/internal/orchestrator"
-	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigDocsUpToDate(t *testing.T) {
 	// Initialize config of all plugins
-	orchestrator.NewOrchestrator()
+	orchestrator.NewOrchestrator(false)
 	apiserver.InitConfig()
 	generatedConfig, err := config.GenerateConfigMarkdown(context.Background(), config.GetKnownKeys())
 	assert.NoError(t, err)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -619,6 +619,13 @@ nav_order: 3
 |default|The default namespace - must be in the predefined list|`string`|`<nil>`
 |predefined|A list of namespaces to ensure exists, without requiring a broadcast from the network|List `string`|`<nil>`
 
+## namespaces.predefined[]
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|description|A description for the namespace|`string`|`<nil>`
+|name|The name of the namespace (must be unique)|`string`|`<nil>`
+
 ## node
 
 |Key|Description|Type|Default Value|

--- a/internal/coreconfig/coreconfig.go
+++ b/internal/coreconfig/coreconfig.go
@@ -18,7 +18,6 @@ package coreconfig
 
 import (
 	"github.com/hyperledger/firefly-common/pkg/config"
-	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/spf13/viper"
 )
@@ -328,7 +327,6 @@ func setDefaults() {
 	viper.SetDefault(string(MessageWriterBatchTimeout), "10ms")
 	viper.SetDefault(string(MessageWriterCount), 5)
 	viper.SetDefault(string(NamespacesDefault), "default")
-	viper.SetDefault(string(NamespacesPredefined), fftypes.JSONObjectArray{{"name": "default", "description": "Default predefined namespace"}})
 	viper.SetDefault(string(OrchestratorStartupAttempts), 5)
 	viper.SetDefault(string(OpUpdateRetryInitDelay), "250ms")
 	viper.SetDefault(string(OpUpdateRetryMaxDelay), "1m")

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -175,8 +175,10 @@ var (
 	ConfigMetricsReadTimeout  = ffc("config.metrics.readTimeout", "The maximum time to wait when reading from an HTTP connection", i18n.TimeDurationType)
 	ConfigMetricsWriteTimeout = ffc("config.metrics.writeTimeout", "The maximum time to wait when writing to an HTTP connection", i18n.TimeDurationType)
 
-	ConfigNamespacesDefault    = ffc("config.namespaces.default", "The default namespace - must be in the predefined list", i18n.StringType)
-	ConfigNamespacesPredefined = ffc("config.namespaces.predefined", "A list of namespaces to ensure exists, without requiring a broadcast from the network", "List "+i18n.StringType)
+	ConfigNamespacesDefault               = ffc("config.namespaces.default", "The default namespace - must be in the predefined list", i18n.StringType)
+	ConfigNamespacesPredefined            = ffc("config.namespaces.predefined", "A list of namespaces to ensure exists, without requiring a broadcast from the network", "List "+i18n.StringType)
+	ConfigNamespacesPredefinedName        = ffc("config.namespaces.predefined[].name", "The name of the namespace (must be unique)", i18n.StringType)
+	ConfigNamespacesPredefinedDescription = ffc("config.namespaces.predefined[].description", "A description for the namespace", i18n.StringType)
 
 	ConfigNodeDescription = ffc("config.node.description", "The description of this FireFly node", i18n.StringType)
 	ConfigNodeName        = ffc("config.node.name", "The name of this FireFly node", i18n.StringType)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -148,11 +148,12 @@ func newTestOrchestrator() *testOrchestrator {
 	tor.mti.On("Name").Return("mock-tk").Maybe()
 	tor.mcm.On("Name").Return("mock-cm").Maybe()
 	tor.mmi.On("Name").Return("mock-mm").Maybe()
+	tor.orchestrator.InitNamespaceConfig(true)
 	return tor
 }
 
 func TestNewOrchestrator(t *testing.T) {
-	or := NewOrchestrator()
+	or := NewOrchestrator(true)
 	assert.NotNil(t, or)
 }
 
@@ -708,13 +709,11 @@ func TestInitNamespacesDefaultMissing(t *testing.T) {
 
 func TestInitNamespacesDupName(t *testing.T) {
 	or := newTestOrchestrator()
-	config.Set(coreconfig.NamespacesPredefined, fftypes.JSONObjectArray{
-		{"name": "ns1"},
-		{"name": "ns2"},
-		{"name": "ns2"},
-	})
+	namespaceConfig.AddKnownKey("predefined.0.name", "ns1")
+	namespaceConfig.AddKnownKey("predefined.1.name", "ns2")
+	namespaceConfig.AddKnownKey("predefined.2.name", "ns2")
 	config.Set(coreconfig.NamespacesDefault, "ns1")
-	nsList, err := or.getPrefdefinedNamespaces(context.Background())
+	nsList, err := or.getPredefinedNamespaces(context.Background())
 	assert.NoError(t, err)
 	assert.Len(t, nsList, 3)
 	assert.Equal(t, core.SystemNamespace, nsList[0].Name)


### PR DESCRIPTION
Makes the allowed subkeys clearer, especially if more are to be added in the future.