### PR TITLE
sync core with firefly-common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hyperledger/firefly-common v0.1.2
+	github.com/hyperledger/firefly-common v0.1.4
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/karlseguin/ccache v2.0.3+incompatible
 	github.com/karlseguin/expect v1.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,8 @@ github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKEN
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/firefly-common v0.1.2 h1:zwz7WAHrK5we8bku7FO1rGZSFY+N4sDO3fWrabsnL+E=
-github.com/hyperledger/firefly-common v0.1.2/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
+github.com/hyperledger/firefly-common v0.1.4 h1:wjZgYZohimKVlBxF3lZmrymVbHwgUIZQshQtE2AQvgQ=
+github.com/hyperledger/firefly-common v0.1.4/go.mod h1:ytB+404+Qg00wJKx602Yi/V6Spx9d0g65lZR9y5fzlo=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/internal/adminevents/manager_test.go
+++ b/internal/adminevents/manager_test.go
@@ -40,10 +40,10 @@ func newTestAdminEventsManager(t *testing.T) (ae *adminEventManager, ws *webSock
 	ae = NewAdminEventManager(context.Background()).(*adminEventManager)
 	svr := httptest.NewServer(http.HandlerFunc(ae.ServeHTTPWebSocketListener))
 
-	clientPrefix := config.NewPluginConfig("ut.wsclient")
-	wsclient.InitPrefix(clientPrefix)
-	clientPrefix.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s", svr.Listener.Addr()))
-	wsConfig := wsclient.GenerateConfigFromPrefix(clientPrefix)
+	clientConfig := config.RootSection("ut.wsclient")
+	wsclient.InitConfig(clientConfig)
+	clientConfig.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s", svr.Listener.Addr()))
+	wsConfig := wsclient.GenerateConfig(clientConfig)
 
 	wsc, err := wsclient.New(ae.ctx, wsConfig, nil, nil)
 	assert.NoError(t, err)

--- a/internal/apiserver/metrics_server.go
+++ b/internal/apiserver/metrics_server.go
@@ -25,7 +25,7 @@ const (
 	MetricsPath    = "path"
 )
 
-func initMetricsConfPrefix(prefix config.Prefix) {
-	prefix.AddKnownKey(MetricsEnabled, true)
-	prefix.AddKnownKey(MetricsPath, "/metrics")
+func initMetricsConfig(config config.Section) {
+	config.AddKnownKey(MetricsEnabled, true)
+	config.AddKnownKey(MetricsPath, "/metrics")
 }

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -77,8 +77,8 @@ func TestStartStopServer(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()
 	InitConfig()
-	apiConfigPrefix.Set(httpserver.HTTPConfPort, 0)
-	adminConfigPrefix.Set(httpserver.HTTPConfPort, 0)
+	apiConfig.Set(httpserver.HTTPConfPort, 0)
+	adminConfig.Set(httpserver.HTTPConfPort, 0)
 	config.Set(coreconfig.UIPath, "test")
 	config.Set(coreconfig.AdminEnabled, true)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -96,7 +96,7 @@ func TestStartAPIFail(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()
 	InitConfig()
-	apiConfigPrefix.Set(httpserver.HTTPConfAddress, "...://")
+	apiConfig.Set(httpserver.HTTPConfAddress, "...://")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // server will immediately shut down
 	as := NewAPIServer()
@@ -110,7 +110,7 @@ func TestStartAdminFail(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()
 	InitConfig()
-	adminConfigPrefix.Set(httpserver.HTTPConfAddress, "...://")
+	adminConfig.Set(httpserver.HTTPConfAddress, "...://")
 	config.Set(coreconfig.AdminEnabled, true)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // server will immediately shut down
@@ -127,7 +127,7 @@ func TestStartAdminWSHandler(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()
 	InitConfig()
-	adminConfigPrefix.Set(httpserver.HTTPConfAddress, "...://")
+	adminConfig.Set(httpserver.HTTPConfAddress, "...://")
 	config.Set(coreconfig.AdminEnabled, true)
 	as := NewAPIServer().(*apiServer)
 	mor := &orchestratormocks.Orchestrator{}
@@ -147,7 +147,7 @@ func TestStartMetricsFail(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()
 	InitConfig()
-	metricsConfigPrefix.Set(httpserver.HTTPConfAddress, "...://")
+	metricsConfig.Set(httpserver.HTTPConfAddress, "...://")
 	config.Set(coreconfig.MetricsEnabled, true)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // server will immediately shut down

--- a/internal/batchpin/batchpin_test.go
+++ b/internal/batchpin/batchpin_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var utConfPrefix = config.NewPluginConfig("metrics")
+var utConfig = config.RootSection("metrics")
 
 func newTestBatchPinSubmitter(t *testing.T, enableMetrics bool) *batchPinSubmitter {
 	coreconfig.Reset()

--- a/internal/blockchain/bifactory/factory.go
+++ b/internal/blockchain/bifactory/factory.go
@@ -32,9 +32,9 @@ var pluginsByName = map[string]func() blockchain.Plugin{
 	(*fabric.Fabric)(nil).Name():     func() blockchain.Plugin { return &fabric.Fabric{} },
 }
 
-func InitPrefix(prefix config.Prefix) {
+func InitConfig(config config.Section) {
 	for name, plugin := range pluginsByName {
-		plugin().InitPrefix(prefix.SubPrefix(name))
+		plugin().InitConfig(config.SubSection(name))
 	}
 }
 

--- a/internal/blockchain/ethereum/address_resolver.go
+++ b/internal/blockchain/ethereum/address_resolver.go
@@ -53,24 +53,24 @@ type addressResolverInserts struct {
 	Key string
 }
 
-func newAddressResolver(ctx context.Context, prefix config.Prefix) (ar *addressResolver, err error) {
+func newAddressResolver(ctx context.Context, config config.Section) (ar *addressResolver, err error) {
 
 	ar = &addressResolver{
-		retainOriginal: prefix.GetBool(AddressResolverRetainOriginal),
-		method:         prefix.GetString(AddressResolverMethod),
-		responseField:  prefix.GetString(AddressResolverResponseField),
-		client:         ffresty.New(ctx, prefix),
-		cache:          ccache.New(ccache.Configure().MaxSize(prefix.GetInt64(AddressResolverCacheSize))),
-		cacheTTL:       prefix.GetDuration(AddressResolverCacheTTL),
+		retainOriginal: config.GetBool(AddressResolverRetainOriginal),
+		method:         config.GetString(AddressResolverMethod),
+		responseField:  config.GetString(AddressResolverResponseField),
+		client:         ffresty.New(ctx, config),
+		cache:          ccache.New(ccache.Configure().MaxSize(config.GetInt64(AddressResolverCacheSize))),
+		cacheTTL:       config.GetDuration(AddressResolverCacheTTL),
 	}
 
-	urlTemplateString := prefix.GetString(AddressResolverURLTemplate)
+	urlTemplateString := config.GetString(AddressResolverURLTemplate)
 	ar.urlTemplate, err = template.New(AddressResolverURLTemplate).Option("missingkey=error").Parse(urlTemplateString)
 	if err != nil {
 		return nil, i18n.NewError(ctx, coremsgs.MsgGoTemplateCompileFailed, AddressResolverURLTemplate, err)
 	}
 
-	bodyTemplateString := prefix.GetString(AddressResolverBodyTemplate)
+	bodyTemplateString := config.GetString(AddressResolverBodyTemplate)
 	if bodyTemplateString != "" {
 		ar.bodyTemplate, err = template.New(AddressResolverBodyTemplate).Option("missingkey=error").Parse(bodyTemplateString)
 		if err != nil {

--- a/internal/blockchain/ethereum/config.go
+++ b/internal/blockchain/ethereum/config.go
@@ -75,9 +75,9 @@ const (
 	FFTMConfigKey = "fftm"
 )
 
-func (e *Ethereum) InitPrefix(prefix config.Prefix) {
-	ethconnectConf := prefix.SubPrefix(EthconnectConfigKey)
-	wsclient.InitPrefix(ethconnectConf)
+func (e *Ethereum) InitConfig(config config.Section) {
+	ethconnectConf := config.SubSection(EthconnectConfigKey)
+	wsclient.InitConfig(ethconnectConf)
 	ethconnectConf.AddKnownKey(EthconnectConfigInstancePath)
 	ethconnectConf.AddKnownKey(EthconnectConfigTopic)
 	ethconnectConf.AddKnownKey(EthconnectConfigBatchSize, defaultBatchSize)
@@ -86,11 +86,11 @@ func (e *Ethereum) InitPrefix(prefix config.Prefix) {
 	ethconnectConf.AddKnownKey(EthconnectPrefixLong, defaultPrefixLong)
 	ethconnectConf.AddKnownKey(EthconnectConfigFromBlock, defaultFromBlock)
 
-	fftmConf := prefix.SubPrefix(FFTMConfigKey)
-	ffresty.InitPrefix(fftmConf)
+	fftmConf := config.SubSection(FFTMConfigKey)
+	ffresty.InitConfig(fftmConf)
 
-	addressResolverConf := prefix.SubPrefix(AddressResolverConfigKey)
-	ffresty.InitPrefix(addressResolverConf)
+	addressResolverConf := config.SubSection(AddressResolverConfigKey)
+	ffresty.InitConfig(addressResolverConf)
 	addressResolverConf.AddKnownKey(AddressResolverRetainOriginal)
 	addressResolverConf.AddKnownKey(AddressResolverMethod, defaultAddressResolverMethod)
 	addressResolverConf.AddKnownKey(AddressResolverURLTemplate)

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -156,10 +156,10 @@ func (e *Ethereum) VerifierType() core.VerifierType {
 	return core.VerifierTypeEthAddress
 }
 
-func (e *Ethereum) Init(ctx context.Context, prefix config.Prefix, callbacks blockchain.Callbacks, metrics metrics.Manager) (err error) {
-	ethconnectConf := prefix.SubPrefix(EthconnectConfigKey)
-	addressResolverConf := prefix.SubPrefix(AddressResolverConfigKey)
-	fftmConf := prefix.SubPrefix(FFTMConfigKey)
+func (e *Ethereum) Init(ctx context.Context, config config.Section, callbacks blockchain.Callbacks, metrics metrics.Manager) (err error) {
+	ethconnectConf := config.SubSection(EthconnectConfigKey)
+	addressResolverConf := config.SubSection(AddressResolverConfigKey)
+	fftmConf := config.SubSection(FFTMConfigKey)
 
 	e.ctx = log.WithLogField(ctx, "proto", "ethereum")
 	e.callbacks = callbacks
@@ -214,7 +214,7 @@ func (e *Ethereum) Init(ctx context.Context, prefix config.Prefix, callbacks blo
 	e.prefixShort = ethconnectConf.GetString(EthconnectPrefixShort)
 	e.prefixLong = ethconnectConf.GetString(EthconnectPrefixLong)
 
-	wsConfig := wsclient.GenerateConfigFromPrefix(ethconnectConf)
+	wsConfig := wsclient.GenerateConfig(ethconnectConf)
 
 	if wsConfig.WSKeyPath == "" {
 		wsConfig.WSKeyPath = "/ws"

--- a/internal/blockchain/fabric/config.go
+++ b/internal/blockchain/fabric/config.go
@@ -51,9 +51,9 @@ const (
 	FabconnectPrefixLong = "prefixLong"
 )
 
-func (f *Fabric) InitPrefix(prefix config.Prefix) {
-	fabconnectConf := prefix.SubPrefix(FabconnectConfigKey)
-	wsclient.InitPrefix(fabconnectConf)
+func (f *Fabric) InitConfig(config config.Section) {
+	fabconnectConf := config.SubSection(FabconnectConfigKey)
+	wsclient.InitConfig(fabconnectConf)
 	fabconnectConf.AddKnownKey(FabconnectConfigDefaultChannel)
 	fabconnectConf.AddKnownKey(FabconnectConfigChaincode)
 	fabconnectConf.AddKnownKey(FabconnectConfigSigner)

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -160,8 +160,8 @@ func (f *Fabric) VerifierType() core.VerifierType {
 	return core.VerifierTypeMSPIdentity
 }
 
-func (f *Fabric) Init(ctx context.Context, prefix config.Prefix, callbacks blockchain.Callbacks, metrics metrics.Manager) (err error) {
-	fabconnectConf := prefix.SubPrefix(FabconnectConfigKey)
+func (f *Fabric) Init(ctx context.Context, config config.Section, callbacks blockchain.Callbacks, metrics metrics.Manager) (err error) {
+	fabconnectConf := config.SubSection(FabconnectConfigKey)
 
 	f.ctx = log.WithLogField(ctx, "proto", "fabric")
 	f.callbacks = callbacks
@@ -191,7 +191,7 @@ func (f *Fabric) Init(ctx context.Context, prefix config.Prefix, callbacks block
 		GlobalSequencer: true,
 	}
 
-	wsConfig := wsclient.GenerateConfigFromPrefix(fabconnectConf)
+	wsConfig := wsclient.GenerateConfig(fabconnectConf)
 
 	if wsConfig.WSKeyPath == "" {
 		wsConfig.WSKeyPath = "/ws"

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -42,14 +42,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var utConfPrefix = config.NewPluginConfig("fab_unit_tests")
-var utFabconnectConf = utConfPrefix.SubPrefix(FabconnectConfigKey)
+var utConfig = config.RootSection("fab_unit_tests")
+var utFabconnectConf = utConfig.SubSection(FabconnectConfigKey)
 var signer = "orgMSP::x509::CN=signer001,OU=client::CN=fabric-ca"
 
 func resetConf() {
 	coreconfig.Reset()
 	e := &Fabric{}
-	e.InitPrefix(utConfPrefix)
+	e.InitConfig(utConfig)
 }
 
 func newTestFabric() (*Fabric, func()) {
@@ -106,7 +106,7 @@ func TestInitMissingURL(t *testing.T) {
 	e, cancel := newTestFabric()
 	defer cancel()
 	resetConf()
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 	assert.Regexp(t, "FF10138.*url", err)
 }
 
@@ -117,7 +117,7 @@ func TestInitMissingChaincode(t *testing.T) {
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 	assert.Regexp(t, "FF10138.*chaincode", err)
 }
 
@@ -129,7 +129,7 @@ func TestInitMissingTopic(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigChaincode, "Firefly")
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 	assert.Regexp(t, "FF10138.*topic", err)
 }
 
@@ -172,7 +172,7 @@ func TestInitAllNewStreamsAndWSEvent(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "fabric", e.Name())
@@ -211,7 +211,7 @@ func TestWSInitFail(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 	assert.Regexp(t, "FF00149", err)
 
 }
@@ -252,7 +252,7 @@ func TestInitAllExistingStreams(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 
 	assert.Equal(t, 2, httpmock.GetTotalCallCount())
 	assert.Equal(t, "es12345", e.initInfo.stream.ID)
@@ -282,7 +282,7 @@ func TestStreamQueryError(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 
 	assert.Regexp(t, "FF10284", err)
 	assert.Regexp(t, "pop", err)
@@ -311,7 +311,7 @@ func TestStreamCreateError(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 
 	assert.Regexp(t, "FF10284", err)
 	assert.Regexp(t, "pop", err)
@@ -342,7 +342,7 @@ func TestSubQueryError(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 
 	assert.Regexp(t, "FF10284", err)
 	assert.Regexp(t, "pop", err)
@@ -375,7 +375,7 @@ func TestSubQueryCreateError(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfPrefix, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
+	err := e.Init(e.ctx, utConfig, &blockchainmocks.Callbacks{}, &metricsmocks.Manager{})
 
 	assert.Regexp(t, "FF10284", err)
 	assert.Regexp(t, "pop", err)

--- a/internal/database/difactory/factory.go
+++ b/internal/database/difactory/factory.go
@@ -25,9 +25,9 @@ import (
 	"github.com/hyperledger/firefly/pkg/database"
 )
 
-func InitPrefix(prefix config.Prefix) {
+func InitConfig(config config.Section) {
 	for name, plugin := range pluginsByName {
-		plugin().InitPrefix(prefix.SubPrefix(name))
+		plugin().InitConfig(config.SubSection(name))
 	}
 }
 

--- a/internal/database/postgres/config.go
+++ b/internal/database/postgres/config.go
@@ -25,7 +25,7 @@ const (
 	defaultConnectionLimitPostgreSQL = 50
 )
 
-func (psql *Postgres) InitPrefix(prefix config.Prefix) {
-	psql.SQLCommon.InitPrefix(psql, prefix)
-	prefix.SetDefault(sqlcommon.SQLConfMaxConnections, defaultConnectionLimitPostgreSQL)
+func (psql *Postgres) InitConfig(config config.Section) {
+	psql.SQLCommon.InitConfig(psql, config)
+	config.SetDefault(sqlcommon.SQLConfMaxConnections, defaultConnectionLimitPostgreSQL)
 }

--- a/internal/database/postgres/postgres.go
+++ b/internal/database/postgres/postgres.go
@@ -37,9 +37,9 @@ type Postgres struct {
 	sqlcommon.SQLCommon
 }
 
-func (psql *Postgres) Init(ctx context.Context, prefix config.Prefix, callbacks database.Callbacks) error {
+func (psql *Postgres) Init(ctx context.Context, config config.Section, callbacks database.Callbacks) error {
 	capabilities := &database.Capabilities{}
-	return psql.SQLCommon.Init(ctx, psql, prefix, callbacks, capabilities)
+	return psql.SQLCommon.Init(ctx, psql, config, callbacks, capabilities)
 }
 
 func (psql *Postgres) Name() string {

--- a/internal/database/postgres/postgres_test.go
+++ b/internal/database/postgres/postgres_test.go
@@ -30,10 +30,10 @@ import (
 func TestPostgresProvider(t *testing.T) {
 	psql := &Postgres{}
 	dcb := &databasemocks.Callbacks{}
-	prefix := config.NewPluginConfig("unittest")
-	psql.InitPrefix(prefix)
-	prefix.Set(sqlcommon.SQLConfDatasourceURL, "!bad connection")
-	err := psql.Init(context.Background(), prefix, dcb)
+	config := config.RootSection("unittest")
+	psql.InitConfig(config)
+	config.Set(sqlcommon.SQLConfDatasourceURL, "!bad connection")
+	err := psql.Init(context.Background(), config, dcb)
 	assert.NoError(t, err)
 	_, err = psql.GetMigrationDriver(psql.DB())
 	assert.Error(t, err)

--- a/internal/database/sqlcommon/config.go
+++ b/internal/database/sqlcommon/config.go
@@ -43,12 +43,12 @@ const (
 	defaultMigrationsDirectoryTemplate = "./db/migrations/%s"
 )
 
-func (s *SQLCommon) InitPrefix(provider Provider, prefix config.Prefix) {
-	prefix.AddKnownKey(SQLConfMigrationsAuto, false)
-	prefix.AddKnownKey(SQLConfDatasourceURL)
-	prefix.AddKnownKey(SQLConfMigrationsDirectory, fmt.Sprintf(defaultMigrationsDirectoryTemplate, provider.MigrationsDir()))
-	prefix.AddKnownKey(SQLConfMaxConnections) // some providers set a default
-	prefix.AddKnownKey(SQLConfMaxConnIdleTime, "1m")
-	prefix.AddKnownKey(SQLConfMaxIdleConns) // defaults to the max connections
-	prefix.AddKnownKey(SQLConfMaxConnLifetime)
+func (s *SQLCommon) InitConfig(provider Provider, config config.Section) {
+	config.AddKnownKey(SQLConfMigrationsAuto, false)
+	config.AddKnownKey(SQLConfDatasourceURL)
+	config.AddKnownKey(SQLConfMigrationsDirectory, fmt.Sprintf(defaultMigrationsDirectoryTemplate, provider.MigrationsDir()))
+	config.AddKnownKey(SQLConfMaxConnections) // some providers set a default
+	config.AddKnownKey(SQLConfMaxConnIdleTime, "1m")
+	config.AddKnownKey(SQLConfMaxIdleConns) // defaults to the max connections
+	config.AddKnownKey(SQLConfMaxConnLifetime)
 }

--- a/internal/database/sqlcommon/provider_mock_test.go
+++ b/internal/database/sqlcommon/provider_mock_test.go
@@ -35,7 +35,7 @@ type mockProvider struct {
 	SQLCommon
 	callbacks    *databasemocks.Callbacks
 	capabilities *database.Capabilities
-	prefix       config.Prefix
+	config       config.Section
 
 	mockDB *sql.DB
 	mdb    sqlmock.Sqlmock
@@ -51,17 +51,17 @@ func newMockProvider() *mockProvider {
 	mp := &mockProvider{
 		capabilities: &database.Capabilities{},
 		callbacks:    &databasemocks.Callbacks{},
-		prefix:       config.NewPluginConfig("unittest.mockdb"),
+		config:       config.RootSection("unittest.mockdb"),
 	}
-	mp.SQLCommon.InitPrefix(mp, mp.prefix)
-	mp.prefix.Set(SQLConfMaxConnections, 10)
+	mp.SQLCommon.InitConfig(mp, mp.config)
+	mp.config.Set(SQLConfMaxConnections, 10)
 	mp.mockDB, mp.mdb, _ = sqlmock.New()
 	return mp
 }
 
 // init is a convenience to init for tests that aren't testing init itself
 func (mp *mockProvider) init() (*mockProvider, sqlmock.Sqlmock) {
-	_ = mp.Init(context.Background(), mp, mp.prefix, mp.callbacks, mp.capabilities)
+	_ = mp.Init(context.Background(), mp, mp.config, mp.callbacks, mp.capabilities)
 	return mp, mp.mdb
 }
 

--- a/internal/database/sqlcommon/provider_sqlitego_test.go
+++ b/internal/database/sqlcommon/provider_sqlitego_test.go
@@ -39,7 +39,7 @@ import (
 type sqliteGoTestProvider struct {
 	SQLCommon
 
-	prefix       config.Prefix
+	config       config.Section
 	t            *testing.T
 	callbacks    *databasemocks.Callbacks
 	capabilities *database.Capabilities
@@ -51,17 +51,17 @@ func newSQLiteTestProvider(t *testing.T) (*sqliteGoTestProvider, func()) {
 		t:            t,
 		callbacks:    &databasemocks.Callbacks{},
 		capabilities: &database.Capabilities{},
-		prefix:       config.NewPluginConfig("unittest.db"),
+		config:       config.RootSection("unittest.db"),
 	}
-	tp.SQLCommon.InitPrefix(tp, tp.prefix)
+	tp.SQLCommon.InitConfig(tp, tp.config)
 	dir, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
-	tp.prefix.Set(SQLConfDatasourceURL, "file::memory:")
-	tp.prefix.Set(SQLConfMigrationsAuto, true)
-	tp.prefix.Set(SQLConfMigrationsDirectory, "../../../db/migrations/sqlite")
-	tp.prefix.Set(SQLConfMaxConnections, 1)
+	tp.config.Set(SQLConfDatasourceURL, "file::memory:")
+	tp.config.Set(SQLConfMigrationsAuto, true)
+	tp.config.Set(SQLConfMigrationsDirectory, "../../../db/migrations/sqlite")
+	tp.config.Set(SQLConfMaxConnections, 1)
 
-	err = tp.Init(context.Background(), tp, tp.prefix, tp.callbacks, tp.capabilities)
+	err = tp.Init(context.Background(), tp, tp.config, tp.callbacks, tp.capabilities)
 	assert.NoError(tp.t, err)
 
 	return tp, func() {

--- a/internal/database/sqlcommon/sqlcommon_test.go
+++ b/internal/database/sqlcommon/sqlcommon_test.go
@@ -45,15 +45,15 @@ func TestInitSQLCommonMissingOptions(t *testing.T) {
 func TestInitSQLCommonOpenFailed(t *testing.T) {
 	mp := newMockProvider()
 	mp.openError = fmt.Errorf("pop")
-	err := mp.SQLCommon.Init(context.Background(), mp, mp.prefix, mp.callbacks, mp.capabilities)
+	err := mp.SQLCommon.Init(context.Background(), mp, mp.config, mp.callbacks, mp.capabilities)
 	assert.Regexp(t, "FF10112.*pop", err)
 }
 
 func TestInitSQLCommonMigrationOpenFailed(t *testing.T) {
 	mp := newMockProvider()
-	mp.prefix.Set(SQLConfMigrationsAuto, true)
+	mp.config.Set(SQLConfMigrationsAuto, true)
 	mp.getMigrationDriverError = fmt.Errorf("pop")
-	err := mp.SQLCommon.Init(context.Background(), mp, mp.prefix, mp.callbacks, mp.capabilities)
+	err := mp.SQLCommon.Init(context.Background(), mp, mp.config, mp.callbacks, mp.capabilities)
 	assert.Regexp(t, "FF10163.*pop", err)
 }
 

--- a/internal/database/sqlite3/config.go
+++ b/internal/database/sqlite3/config.go
@@ -28,7 +28,7 @@ const (
 	defaultConnectionLimitSQLite = 1
 )
 
-func (sqlite *SQLite3) InitPrefix(prefix config.Prefix) {
-	sqlite.SQLCommon.InitPrefix(sqlite, prefix)
-	prefix.SetDefault(sqlcommon.SQLConfMaxConnections, defaultConnectionLimitSQLite)
+func (sqlite *SQLite3) InitConfig(config config.Section) {
+	sqlite.SQLCommon.InitConfig(sqlite, config)
+	config.SetDefault(sqlcommon.SQLConfMaxConnections, defaultConnectionLimitSQLite)
 }

--- a/internal/database/sqlite3/sqlite3.go
+++ b/internal/database/sqlite3/sqlite3.go
@@ -46,7 +46,7 @@ func connHook(conn *sqlite3.SQLiteConn) error {
 	return err
 }
 
-func (sqlite *SQLite3) Init(ctx context.Context, prefix config.Prefix, callbacks database.Callbacks) error {
+func (sqlite *SQLite3) Init(ctx context.Context, config config.Section, callbacks database.Callbacks) error {
 	capabilities := &database.Capabilities{}
 	if !ffSQLiteRegistered {
 		sql.Register("sqlite3_ff",
@@ -55,7 +55,7 @@ func (sqlite *SQLite3) Init(ctx context.Context, prefix config.Prefix, callbacks
 			})
 		ffSQLiteRegistered = true
 	}
-	return sqlite.SQLCommon.Init(ctx, sqlite, prefix, callbacks, capabilities)
+	return sqlite.SQLCommon.Init(ctx, sqlite, config, callbacks, capabilities)
 }
 
 func (sqlite *SQLite3) Name() string {

--- a/internal/database/sqlite3/sqlite3_test.go
+++ b/internal/database/sqlite3/sqlite3_test.go
@@ -33,10 +33,10 @@ import (
 func TestSQLite3GoProvider(t *testing.T) {
 	sqlite := &SQLite3{}
 	dcb := &databasemocks.Callbacks{}
-	prefix := config.NewPluginConfig("unittest")
-	sqlite.InitPrefix(prefix)
-	prefix.Set(sqlcommon.SQLConfDatasourceURL, "!wrong://")
-	err := sqlite.Init(context.Background(), prefix, dcb)
+	config := config.RootSection("unittest")
+	sqlite.InitConfig(config)
+	config.Set(sqlcommon.SQLConfDatasourceURL, "!wrong://")
+	err := sqlite.Init(context.Background(), config, dcb)
 	assert.NoError(t, err)
 	_, err = sqlite.GetMigrationDriver(sqlite.DB())
 	assert.Error(t, err)

--- a/internal/dataexchange/dxfactory/factory.go
+++ b/internal/dataexchange/dxfactory/factory.go
@@ -35,9 +35,9 @@ var pluginsByName = map[string]func() dataexchange.Plugin{
 	NewFFDXPluginName: func() dataexchange.Plugin { return &ffdx.FFDX{} },
 }
 
-func InitPrefix(prefix config.Prefix) {
+func InitConfig(config config.Section) {
 	for name, plugin := range pluginsByName {
-		plugin().InitPrefix(prefix.SubPrefix(name))
+		plugin().InitConfig(config.SubSection(name))
 	}
 }
 

--- a/internal/dataexchange/ffdx/config.go
+++ b/internal/dataexchange/ffdx/config.go
@@ -28,8 +28,8 @@ const (
 	DataExchangeInitEnabled = "initEnabled"
 )
 
-func (h *FFDX) InitPrefix(prefix config.Prefix) {
-	wsclient.InitPrefix(prefix)
-	prefix.AddKnownKey(DataExchangeManifestEnabled, false)
-	prefix.AddKnownKey(DataExchangeInitEnabled, false)
+func (h *FFDX) InitConfig(config config.Section) {
+	wsclient.InitConfig(config)
+	config.AddKnownKey(DataExchangeManifestEnabled, false)
+	config.AddKnownKey(DataExchangeInitEnabled, false)
 }

--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -108,25 +108,25 @@ func (h *FFDX) Name() string {
 	return "ffdx"
 }
 
-func (h *FFDX) Init(ctx context.Context, prefix config.Prefix, nodes []fftypes.JSONObject, callbacks dataexchange.Callbacks) (err error) {
+func (h *FFDX) Init(ctx context.Context, config config.Section, nodes []fftypes.JSONObject, callbacks dataexchange.Callbacks) (err error) {
 	h.ctx = log.WithLogField(ctx, "dx", "https")
 	h.callbacks = callbacks
 	h.ackChannel = make(chan *ack)
 
-	h.needsInit = prefix.GetBool(DataExchangeInitEnabled)
+	h.needsInit = config.GetBool(DataExchangeInitEnabled)
 
-	if prefix.GetString(ffresty.HTTPConfigURL) == "" {
+	if config.GetString(ffresty.HTTPConfigURL) == "" {
 		return i18n.NewError(ctx, coremsgs.MsgMissingPluginConfig, "url", "dataexchange.ffdx")
 	}
 
 	h.nodes = nodes
 
-	h.client = ffresty.New(h.ctx, prefix)
+	h.client = ffresty.New(h.ctx, config)
 	h.capabilities = &dataexchange.Capabilities{
-		Manifest: prefix.GetBool(DataExchangeManifestEnabled),
+		Manifest: config.GetBool(DataExchangeManifestEnabled),
 	}
 
-	wsConfig := wsclient.GenerateConfigFromPrefix(prefix)
+	wsConfig := wsclient.GenerateConfig(config)
 
 	h.wsconn, err = wsclient.New(ctx, wsConfig, h.beforeConnect, nil)
 	if err != nil {

--- a/internal/events/eifactory/factory.go
+++ b/internal/events/eifactory/factory.go
@@ -42,9 +42,9 @@ func init() {
 	}
 }
 
-func InitPrefix(prefix config.Prefix) {
+func InitConfig(config config.Section) {
 	for _, plugin := range plugins {
-		plugin.InitPrefix(prefix.SubPrefix(plugin.Name()))
+		plugin.InitConfig(config.SubSection(plugin.Name()))
 	}
 }
 

--- a/internal/events/event_manager_test.go
+++ b/internal/events/event_manager_test.go
@@ -397,8 +397,8 @@ func TestAddInternalListener(t *testing.T) {
 	cbs.On("RegisterConnection", mock.Anything, mock.Anything).Return(nil)
 	cbs.On("EphemeralSubscription", mock.Anything, "ns1", mock.Anything, mock.Anything).Return(nil)
 
-	conf := config.NewPluginConfig("ut.events")
-	ie.InitPrefix(conf)
+	conf := config.RootSection("ut.events")
+	ie.InitConfig(conf)
 	ie.Init(em.ctx, conf, cbs)
 	em.internalEvents = ie
 	defer cancel()

--- a/internal/events/subscription_manager.go
+++ b/internal/events/subscription_manager.go
@@ -145,9 +145,9 @@ func (sm *subscriptionManager) loadTransports() error {
 func (sm *subscriptionManager) initTransports() error {
 	var err error
 	for _, ei := range sm.transports {
-		prefix := config.NewPluginConfig("events").SubPrefix(ei.Name())
-		ei.InitPrefix(prefix)
-		err = ei.Init(sm.ctx, prefix, &boundCallbacks{sm: sm, ei: ei})
+		config := config.RootSection("events").SubSection(ei.Name())
+		ei.InitConfig(config)
+		err = ei.Init(sm.ctx, config, &boundCallbacks{sm: sm, ei: ei})
 		if err != nil {
 			return err
 		}

--- a/internal/events/subscription_manager_test.go
+++ b/internal/events/subscription_manager_test.go
@@ -49,7 +49,7 @@ func newTestSubManager(t *testing.T, mei *eventsmocks.Plugin) (*subscriptionMana
 	ctx, cancel := context.WithCancel(context.Background())
 	mei.On("Name").Return("ut")
 	mei.On("Capabilities").Return(&events.Capabilities{}).Maybe()
-	mei.On("InitPrefix", mock.Anything).Return()
+	mei.On("InitConfig", mock.Anything).Return()
 	mei.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("GetEvents", mock.Anything, mock.Anything, mock.Anything).Return([]*core.Event{}, nil, nil).Maybe()
 	mdi.On("GetOffset", mock.Anything, mock.Anything, mock.Anything).Return(&core.Offset{RowID: 3333333, Current: 0}, nil).Maybe()
@@ -182,7 +182,7 @@ func TestSubManagerBadPlugin(t *testing.T) {
 func TestSubManagerTransportInitError(t *testing.T) {
 	mei := &eventsmocks.Plugin{}
 	mei.On("Name").Return("ut")
-	mei.On("InitPrefix", mock.Anything).Return()
+	mei.On("InitConfig", mock.Anything).Return()
 	mei.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	sm, cancel := newTestSubManager(t, mei)

--- a/internal/events/system/config.go
+++ b/internal/events/system/config.go
@@ -29,6 +29,6 @@ const (
 	SystemEventsConfReadAhead = "readAhead"
 )
 
-func (se *Events) InitPrefix(prefix config.Prefix) {
-	prefix.AddKnownKey(SystemEventsConfReadAhead, readAhead)
+func (se *Events) InitConfig(config config.Section) {
+	config.AddKnownKey(SystemEventsConfReadAhead, readAhead)
 }

--- a/internal/events/system/events.go
+++ b/internal/events/system/events.go
@@ -46,13 +46,13 @@ type EventListener func(event *core.EventDelivery) error
 
 func (se *Events) Name() string { return SystemEventsTransport }
 
-func (se *Events) Init(ctx context.Context, prefix config.Prefix, callbacks events.Callbacks) (err error) {
+func (se *Events) Init(ctx context.Context, config config.Section, callbacks events.Callbacks) (err error) {
 	*se = Events{
 		ctx:          ctx,
 		capabilities: &events.Capabilities{},
 		callbacks:    callbacks,
 		listeners:    make(map[string][]EventListener),
-		readAhead:    uint16(prefix.GetInt(SystemEventsConfReadAhead)),
+		readAhead:    uint16(config.GetInt(SystemEventsConfReadAhead)),
 		connID:       fftypes.ShortID(),
 	}
 	// We have a single logical connection, that matches all subscriptions

--- a/internal/events/system/events_test.go
+++ b/internal/events/system/events_test.go
@@ -40,9 +40,9 @@ func newTestEvents(t *testing.T) (se *Events, cancel func()) {
 	}
 	se = &Events{}
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	svrPrefix := config.NewPluginConfig("ut.events")
-	se.InitPrefix(svrPrefix)
-	se.Init(ctx, svrPrefix, cbs)
+	config := config.RootSection("ut.events")
+	se.InitConfig(config)
+	se.Init(ctx, config, cbs)
 	assert.Equal(t, "system", se.Name())
 	assert.NotNil(t, se.Capabilities())
 	assert.NotNil(t, se.GetOptionsSchema(se.ctx))

--- a/internal/events/webhooks/config.go
+++ b/internal/events/webhooks/config.go
@@ -21,6 +21,6 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffresty"
 )
 
-func (wh *WebHooks) InitPrefix(prefix config.Prefix) {
-	ffresty.InitPrefix(prefix)
+func (wh *WebHooks) InitConfig(config config.Section) {
+	ffresty.InitConfig(config)
 }

--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -63,12 +63,12 @@ type whResponse struct {
 
 func (wh *WebHooks) Name() string { return "webhooks" }
 
-func (wh *WebHooks) Init(ctx context.Context, prefix config.Prefix, callbacks events.Callbacks) (err error) {
+func (wh *WebHooks) Init(ctx context.Context, config config.Section, callbacks events.Callbacks) (err error) {
 	*wh = WebHooks{
 		ctx:          ctx,
 		capabilities: &events.Capabilities{},
 		callbacks:    callbacks,
-		client:       ffresty.New(ctx, prefix),
+		client:       ffresty.New(ctx, config),
 		connID:       fftypes.ShortID(),
 	}
 	// We have a single logical connection, that matches all subscriptions

--- a/internal/events/webhooks/webhooks_test.go
+++ b/internal/events/webhooks/webhooks_test.go
@@ -45,9 +45,9 @@ func newTestWebHooks(t *testing.T) (wh *WebHooks, cancel func()) {
 	}
 	wh = &WebHooks{}
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	svrPrefix := config.NewPluginConfig("ut.webhooks")
-	wh.InitPrefix(svrPrefix)
-	wh.Init(ctx, svrPrefix, cbs)
+	svrConfig := config.RootSection("ut.webhooks")
+	wh.InitConfig(svrConfig)
+	wh.Init(ctx, svrConfig, cbs)
 	assert.Equal(t, "webhooks", wh.Name())
 	assert.NotNil(t, wh.Capabilities())
 	assert.NotNil(t, wh.GetOptionsSchema(wh.ctx))

--- a/internal/events/websockets/config.go
+++ b/internal/events/websockets/config.go
@@ -29,8 +29,8 @@ const (
 	WriteBufferSize = "writeBufferSize"
 )
 
-func (ws *WebSockets) InitPrefix(prefix config.Prefix) {
-	prefix.AddKnownKey(ReadBufferSize, bufferSizeDefault)
-	prefix.AddKnownKey(WriteBufferSize, bufferSizeDefault)
+func (ws *WebSockets) InitConfig(config config.Section) {
+	config.AddKnownKey(ReadBufferSize, bufferSizeDefault)
+	config.AddKnownKey(WriteBufferSize, bufferSizeDefault)
 
 }

--- a/internal/events/websockets/websockets.go
+++ b/internal/events/websockets/websockets.go
@@ -41,15 +41,15 @@ type WebSockets struct {
 
 func (ws *WebSockets) Name() string { return "websockets" }
 
-func (ws *WebSockets) Init(ctx context.Context, prefix config.Prefix, callbacks events.Callbacks) error {
+func (ws *WebSockets) Init(ctx context.Context, config config.Section, callbacks events.Callbacks) error {
 	*ws = WebSockets{
 		ctx:          ctx,
 		connections:  make(map[string]*websocketConnection),
 		capabilities: &events.Capabilities{},
 		callbacks:    callbacks,
 		upgrader: websocket.Upgrader{
-			ReadBufferSize:  int(prefix.GetByteSize(ReadBufferSize)),
-			WriteBufferSize: int(prefix.GetByteSize(WriteBufferSize)),
+			ReadBufferSize:  int(config.GetByteSize(ReadBufferSize)),
+			WriteBufferSize: int(config.GetByteSize(WriteBufferSize)),
 			CheckOrigin: func(r *http.Request) bool {
 				// Cors is handled by the API server that wraps this handler
 				return true

--- a/internal/events/websockets/websockets_test.go
+++ b/internal/events/websockets/websockets_test.go
@@ -44,9 +44,9 @@ func newTestWebsockets(t *testing.T, cbs *eventsmocks.Callbacks, queryParams ...
 
 	ws = &WebSockets{}
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	svrPrefix := config.NewPluginConfig("ut.websockets")
-	ws.InitPrefix(svrPrefix)
-	ws.Init(ctx, svrPrefix, cbs)
+	svrConfig := config.RootSection("ut.websockets")
+	ws.InitConfig(svrConfig)
+	ws.Init(ctx, svrConfig, cbs)
 	assert.Equal(t, "websockets", ws.Name())
 	assert.NotNil(t, ws.Capabilities())
 	assert.NotNil(t, ws.GetOptionsSchema(context.Background()))
@@ -54,14 +54,14 @@ func newTestWebsockets(t *testing.T, cbs *eventsmocks.Callbacks, queryParams ...
 
 	svr := httptest.NewServer(ws)
 
-	clientPrefix := config.NewPluginConfig("ut.wsclient")
-	wsclient.InitPrefix(clientPrefix)
+	clientConfig := config.RootSection("ut.wsclient")
+	wsclient.InitConfig(clientConfig)
 	qs := ""
 	if len(queryParams) > 0 {
 		qs = fmt.Sprintf("?%s", strings.Join(queryParams, "&"))
 	}
-	clientPrefix.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s%s", svr.Listener.Addr(), qs))
-	wsConfig := wsclient.GenerateConfigFromPrefix(clientPrefix)
+	clientConfig.Set(ffresty.HTTPConfigURL, fmt.Sprintf("http://%s%s", svr.Listener.Addr(), qs))
+	wsConfig := wsclient.GenerateConfig(clientConfig)
 
 	wsc, err := wsclient.New(ctx, wsConfig, nil, nil)
 	assert.NoError(t, err)

--- a/internal/identity/iifactory/factory.go
+++ b/internal/identity/iifactory/factory.go
@@ -31,9 +31,9 @@ var pluginsByName = map[string]func() identity.Plugin{
 	(*tbd.TBD)(nil).Name(): func() identity.Plugin { return &tbd.TBD{} },
 }
 
-func InitPrefix(prefix config.Prefix) {
+func InitConfig(config config.Section) {
 	for name, plugin := range pluginsByName {
-		plugin().InitPrefix(prefix.SubPrefix(name))
+		plugin().InitConfig(config.SubSection(name))
 	}
 }
 

--- a/internal/identity/tbd/config.go
+++ b/internal/identity/tbd/config.go
@@ -20,5 +20,5 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/config"
 )
 
-func (tbd *TBD) InitPrefix(prefix config.Prefix) {
+func (tbd *TBD) InitConfig(config config.Section) {
 }

--- a/internal/identity/tbd/tbd.go
+++ b/internal/identity/tbd/tbd.go
@@ -33,7 +33,7 @@ func (tbd *TBD) Name() string {
 	return "onchain" // For backwards compatibility with previous config that might have specified "onchain"
 }
 
-func (tbd *TBD) Init(ctx context.Context, prefix config.Prefix, callbacks identity.Callbacks) (err error) {
+func (tbd *TBD) Init(ctx context.Context, config config.Section, callbacks identity.Callbacks) (err error) {
 	tbd.callbacks = callbacks
 	tbd.capabilities = &identity.Capabilities{}
 	return nil

--- a/internal/identity/tbd/tbd_test.go
+++ b/internal/identity/tbd/tbd_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var utConfPrefix = config.NewPluginConfig("onchain_unit_tests")
+var utConfig = config.RootSection("onchain_unit_tests")
 
 func TestInit(t *testing.T) {
 	var oc identity.Plugin = &TBD{}
-	oc.InitPrefix(utConfPrefix)
-	err := oc.Init(context.Background(), utConfPrefix, &identitymocks.Callbacks{})
+	oc.InitConfig(utConfig)
+	err := oc.Init(context.Background(), utConfig, &identitymocks.Callbacks{})
 	assert.NoError(t, err)
 	assert.Equal(t, "onchain", oc.Name())
 	err = oc.Start()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -312,7 +312,7 @@ func TestBadDataExchangePlugin(t *testing.T) {
 
 func TestBadDataExchangeInitFail(t *testing.T) {
 	or := newTestOrchestrator()
-	dxfactory.InitPrefix(dataexchangeConfig)
+	dxfactory.InitConfig(dataexchangeConfig)
 	viper.Set("dataexchange.ffdx.url", "https://test")
 	or.mdi.On("GetConfigRecords", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.ConfigRecord{}, nil, nil)
 	or.mdi.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -328,7 +328,7 @@ func TestBadDataExchangeInitFail(t *testing.T) {
 
 func TestDataExchangePluginOldName(t *testing.T) {
 	or := newTestOrchestrator()
-	dxfactory.InitPrefix(dataexchangeConfig)
+	dxfactory.InitConfig(dataexchangeConfig)
 	viper.Set("dataexchange.https.url", "https://test")
 	or.dataexchange = nil
 	or.mdi.On("GetConfigRecords", mock.Anything, mock.Anything, mock.Anything).Return([]*fftypes.ConfigRecord{}, nil, nil)
@@ -336,7 +336,7 @@ func TestDataExchangePluginOldName(t *testing.T) {
 	or.mbi.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mii.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -346,7 +346,7 @@ func TestDataExchangePluginOldName(t *testing.T) {
 
 func TestBadTokensPlugin(t *testing.T) {
 	or := newTestOrchestrator()
-	tifactory.InitPrefix(tokensConfig)
+	tifactory.InitConfig(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName, "text")
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "wrong")
 	config.Set("tokens", []fftypes.JSONObject{{}})
@@ -357,7 +357,7 @@ func TestBadTokensPlugin(t *testing.T) {
 	or.mii.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -380,7 +380,7 @@ func TestBadTokensPluginNoConnector(t *testing.T) {
 	or.mbi.On("VerifyIdentitySyntax", mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -391,7 +391,7 @@ func TestBadTokensPluginNoConnector(t *testing.T) {
 
 func TestBadTokensPluginNoName(t *testing.T) {
 	or := newTestOrchestrator()
-	tifactory.InitPrefix(tokensConfig)
+	tifactory.InitConfig(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName)
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "wrong")
 	config.Set("tokens", []fftypes.JSONObject{{}})
@@ -402,7 +402,7 @@ func TestBadTokensPluginNoName(t *testing.T) {
 	or.mii.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -413,7 +413,7 @@ func TestBadTokensPluginNoName(t *testing.T) {
 
 func TestBadTokensPluginInvalidName(t *testing.T) {
 	or := newTestOrchestrator()
-	tifactory.InitPrefix(tokensConfig)
+	tifactory.InitConfig(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName, "!wrong")
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "text")
 	config.Set("tokens", []fftypes.JSONObject{{}})
@@ -424,7 +424,7 @@ func TestBadTokensPluginInvalidName(t *testing.T) {
 	or.mii.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -435,7 +435,7 @@ func TestBadTokensPluginInvalidName(t *testing.T) {
 
 func TestBadTokensPluginNoType(t *testing.T) {
 	or := newTestOrchestrator()
-	tifactory.InitPrefix(tokensConfig)
+	tifactory.InitConfig(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName, "text")
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector)
 	config.Set("tokens", []fftypes.JSONObject{{}})
@@ -447,7 +447,7 @@ func TestBadTokensPluginNoType(t *testing.T) {
 	or.mbi.On("VerifyIdentitySyntax", mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -458,8 +458,8 @@ func TestBadTokensPluginNoType(t *testing.T) {
 
 func TestGoodTokensPlugin(t *testing.T) {
 	or := newTestOrchestrator()
-	tokensConfig = config.NewPluginConfig("tokens").Array()
-	tifactory.InitPrefix(tokensConfig)
+	tokensConfig = config.RootArray("tokens")
+	tifactory.InitConfig(tokensConfig)
 	tokensConfig.AddKnownKey(tokens.TokensConfigName, "test")
 	tokensConfig.AddKnownKey(tokens.TokensConfigConnector, "https")
 	tokensConfig.AddKnownKey(ffresty.HTTPConfigURL, "test")
@@ -471,7 +471,7 @@ func TestGoodTokensPlugin(t *testing.T) {
 	or.mii.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -730,7 +730,7 @@ func TestInitOK(t *testing.T) {
 	or.mbi.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mps.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -769,7 +769,7 @@ func TestInitDataExchangeWithNodes(t *testing.T) {
 	or := newTestOrchestrator()
 
 	or.mdi.On("GetIdentities", mock.Anything, mock.Anything).Return([]*core.Identity{{}}, nil, nil)
-	or.mdx.On("InitPrefix", mock.Anything).Return()
+	or.mdx.On("InitConfig", mock.Anything).Return()
 	or.mdx.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	err := or.initDataExchange(or.ctx)

--- a/internal/sharedstorage/ipfs/config.go
+++ b/internal/sharedstorage/ipfs/config.go
@@ -28,7 +28,7 @@ const (
 	IPFSConfGatewaySubconf = "gateway"
 )
 
-func (i *IPFS) InitPrefix(prefix config.Prefix) {
-	ffresty.InitPrefix(prefix.SubPrefix(IPFSConfAPISubconf))
-	ffresty.InitPrefix(prefix.SubPrefix(IPFSConfGatewaySubconf))
+func (i *IPFS) InitConfig(config config.Section) {
+	ffresty.InitConfig(config.SubSection(IPFSConfAPISubconf))
+	ffresty.InitConfig(config.SubSection(IPFSConfGatewaySubconf))
 }

--- a/internal/sharedstorage/ipfs/ipfs.go
+++ b/internal/sharedstorage/ipfs/ipfs.go
@@ -50,21 +50,21 @@ func (i *IPFS) Name() string {
 	return "ipfs"
 }
 
-func (i *IPFS) Init(ctx context.Context, prefix config.Prefix, callbacks sharedstorage.Callbacks) error {
+func (i *IPFS) Init(ctx context.Context, config config.Section, callbacks sharedstorage.Callbacks) error {
 
 	i.ctx = log.WithLogField(ctx, "sharedstorage", "ipfs")
 	i.callbacks = callbacks
 
-	apiPrefix := prefix.SubPrefix(IPFSConfAPISubconf)
-	if apiPrefix.GetString(ffresty.HTTPConfigURL) == "" {
-		return i18n.NewError(ctx, coremsgs.MsgMissingPluginConfig, apiPrefix.Resolve(ffresty.HTTPConfigURL), "ipfs")
+	apiConfig := config.SubSection(IPFSConfAPISubconf)
+	if apiConfig.GetString(ffresty.HTTPConfigURL) == "" {
+		return i18n.NewError(ctx, coremsgs.MsgMissingPluginConfig, apiConfig.Resolve(ffresty.HTTPConfigURL), "ipfs")
 	}
-	i.apiClient = ffresty.New(i.ctx, apiPrefix)
-	gwPrefix := prefix.SubPrefix(IPFSConfGatewaySubconf)
-	if gwPrefix.GetString(ffresty.HTTPConfigURL) == "" {
-		return i18n.NewError(ctx, coremsgs.MsgMissingPluginConfig, gwPrefix.Resolve(ffresty.HTTPConfigURL), "ipfs")
+	i.apiClient = ffresty.New(i.ctx, apiConfig)
+	gwConfig := config.SubSection(IPFSConfGatewaySubconf)
+	if gwConfig.GetString(ffresty.HTTPConfigURL) == "" {
+		return i18n.NewError(ctx, coremsgs.MsgMissingPluginConfig, gwConfig.Resolve(ffresty.HTTPConfigURL), "ipfs")
 	}
-	i.gwClient = ffresty.New(i.ctx, gwPrefix)
+	i.gwClient = ffresty.New(i.ctx, gwConfig)
 	i.capabilities = &sharedstorage.Capabilities{}
 	return nil
 }

--- a/internal/sharedstorage/ipfs/ipfs_test.go
+++ b/internal/sharedstorage/ipfs/ipfs_test.go
@@ -33,20 +33,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var utConfPrefix = config.NewPluginConfig("ipfs_unit_tests")
+var utConfig = config.RootSection("ipfs_unit_tests")
 
 func resetConf() {
 	coreconfig.Reset()
 	i := &IPFS{}
-	i.InitPrefix(utConfPrefix)
+	i.InitConfig(utConfig)
 }
 
 func TestInitMissingAPIURL(t *testing.T) {
 	i := &IPFS{}
 	resetConf()
 
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.Regexp(t, "FF10138", err)
 }
 
@@ -54,18 +54,18 @@ func TestInitMissingGWURL(t *testing.T) {
 	i := &IPFS{}
 	resetConf()
 
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.Regexp(t, "FF10138", err)
 }
 
 func TestInit(t *testing.T) {
 	i := &IPFS{}
 	resetConf()
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.Equal(t, "ipfs", i.Name())
 	assert.NoError(t, err)
 	assert.NotNil(t, i.Capabilities())
@@ -79,11 +79,11 @@ func TestIPFSUploadSuccess(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	resetConf()
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPCustomClient, mockedClient)
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPCustomClient, mockedClient)
 
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.NoError(t, err)
 
 	httpmock.RegisterResponder("POST", "http://localhost:12345/api/v0/add",
@@ -106,11 +106,11 @@ func TestIPFSUploadFail(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	resetConf()
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPCustomClient, mockedClient)
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPCustomClient, mockedClient)
 
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.NoError(t, err)
 
 	httpmock.RegisterResponder("POST", "http://localhost:12345/api/v0/add",
@@ -130,11 +130,11 @@ func TestIPFSDownloadSuccess(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	resetConf()
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPCustomClient, mockedClient)
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPCustomClient, mockedClient)
 
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.NoError(t, err)
 
 	data := []byte(`{"hello": "world"}`)
@@ -159,11 +159,11 @@ func TestIPFSDownloadFail(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	resetConf()
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPCustomClient, mockedClient)
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPCustomClient, mockedClient)
 
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.NoError(t, err)
 
 	httpmock.RegisterResponder("GET", "http://localhost:12345/ipfs/QmRAQfHNnknnz8S936M2yJGhhVNA6wXJ4jTRP3VXtptmmL",
@@ -182,11 +182,11 @@ func TestIPFSDownloadError(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	resetConf()
-	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
-	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(ffresty.HTTPCustomClient, mockedClient)
+	utConfig.SubSection(IPFSConfAPISubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPConfigURL, "http://localhost:12345")
+	utConfig.SubSection(IPFSConfGatewaySubconf).Set(ffresty.HTTPCustomClient, mockedClient)
 
-	err := i.Init(context.Background(), utConfPrefix, &sharedstoragemocks.Callbacks{})
+	err := i.Init(context.Background(), utConfig, &sharedstoragemocks.Callbacks{})
 	assert.NoError(t, err)
 
 	httpmock.RegisterResponder("GET", "http://localhost:12345/ipfs/QmRAQfHNnknnz8S936M2yJGhhVNA6wXJ4jTRP3VXtptmmL",

--- a/internal/sharedstorage/ssfactory/factory.go
+++ b/internal/sharedstorage/ssfactory/factory.go
@@ -30,9 +30,9 @@ var pluginsByName = map[string]func() sharedstorage.Plugin{
 	(*ipfs.IPFS)(nil).Name(): func() sharedstorage.Plugin { return &ipfs.IPFS{} },
 }
 
-func InitPrefix(prefix config.Prefix) {
+func InitConfig(config config.Section) {
 	for name, plugin := range pluginsByName {
-		plugin().InitPrefix(prefix.SubPrefix(name))
+		plugin().InitConfig(config.SubSection(name))
 	}
 }
 

--- a/internal/tokens/fftokens/config.go
+++ b/internal/tokens/fftokens/config.go
@@ -21,6 +21,6 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/wsclient"
 )
 
-func (ft *FFTokens) InitPrefix(prefix config.PrefixArray) {
-	wsclient.InitPrefix(prefix)
+func (ft *FFTokens) InitConfig(config config.ArraySection) {
+	wsclient.InitConfig(config)
 }

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -132,19 +132,19 @@ func (ft *FFTokens) Name() string {
 	return "fftokens"
 }
 
-func (ft *FFTokens) Init(ctx context.Context, name string, prefix config.Prefix, callbacks tokens.Callbacks) (err error) {
+func (ft *FFTokens) Init(ctx context.Context, name string, config config.Section, callbacks tokens.Callbacks) (err error) {
 	ft.ctx = log.WithLogField(ctx, "proto", "fftokens")
 	ft.callbacks = callbacks
 	ft.configuredName = name
 
-	if prefix.GetString(ffresty.HTTPConfigURL) == "" {
+	if config.GetString(ffresty.HTTPConfigURL) == "" {
 		return i18n.NewError(ctx, coremsgs.MsgMissingPluginConfig, "url", "tokens.fftokens")
 	}
 
-	ft.client = ffresty.New(ft.ctx, prefix)
+	ft.client = ffresty.New(ft.ctx, config)
 	ft.capabilities = &tokens.Capabilities{}
 
-	wsConfig := wsclient.GenerateConfigFromPrefix(prefix)
+	wsConfig := wsclient.GenerateConfig(config)
 
 	if wsConfig.WSKeyPath == "" {
 		wsConfig.WSKeyPath = "/api/ws"

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var utConfPrefix = config.NewPluginConfig("tokens").Array()
+var utConfig = config.RootArray("tokens")
 
 func newTestFFTokens(t *testing.T) (h *FFTokens, toServer, fromServer chan string, httpURL string, done func()) {
 	mockedClient := &http.Client{}
@@ -54,15 +54,15 @@ func newTestFFTokens(t *testing.T) (h *FFTokens, toServer, fromServer chan strin
 
 	coreconfig.Reset()
 	h = &FFTokens{}
-	h.InitPrefix(utConfPrefix)
+	h.InitConfig(utConfig)
 
-	utConfPrefix.AddKnownKey(tokens.TokensConfigName, "test")
-	utConfPrefix.AddKnownKey(tokens.TokensConfigPlugin, "fftokens")
-	utConfPrefix.AddKnownKey(ffresty.HTTPConfigURL, httpURL)
-	utConfPrefix.AddKnownKey(ffresty.HTTPCustomClient, mockedClient)
+	utConfig.AddKnownKey(tokens.TokensConfigName, "test")
+	utConfig.AddKnownKey(tokens.TokensConfigPlugin, "fftokens")
+	utConfig.AddKnownKey(ffresty.HTTPConfigURL, httpURL)
+	utConfig.AddKnownKey(ffresty.HTTPCustomClient, mockedClient)
 	config.Set("tokens", []fftypes.JSONObject{{}})
 
-	err := h.Init(context.Background(), "testtokens", utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
+	err := h.Init(context.Background(), "testtokens", utConfig.ArrayEntry(0), &tokenmocks.Callbacks{})
 	assert.NoError(t, err)
 	assert.Equal(t, "fftokens", h.Name())
 	assert.Equal(t, "testtokens", h.configuredName)
@@ -76,24 +76,24 @@ func newTestFFTokens(t *testing.T) (h *FFTokens, toServer, fromServer chan strin
 func TestInitBadURL(t *testing.T) {
 	coreconfig.Reset()
 	h := &FFTokens{}
-	h.InitPrefix(utConfPrefix)
+	h.InitConfig(utConfig)
 
-	utConfPrefix.AddKnownKey(tokens.TokensConfigName, "test")
-	utConfPrefix.AddKnownKey(tokens.TokensConfigPlugin, "fftokens")
-	utConfPrefix.AddKnownKey(ffresty.HTTPConfigURL, "::::////")
-	err := h.Init(context.Background(), "testtokens", utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
+	utConfig.AddKnownKey(tokens.TokensConfigName, "test")
+	utConfig.AddKnownKey(tokens.TokensConfigPlugin, "fftokens")
+	utConfig.AddKnownKey(ffresty.HTTPConfigURL, "::::////")
+	err := h.Init(context.Background(), "testtokens", utConfig.ArrayEntry(0), &tokenmocks.Callbacks{})
 	assert.Regexp(t, "FF00149", err)
 }
 
 func TestInitMissingURL(t *testing.T) {
 	coreconfig.Reset()
 	h := &FFTokens{}
-	h.InitPrefix(utConfPrefix)
+	h.InitConfig(utConfig)
 
-	utConfPrefix.AddKnownKey(tokens.TokensConfigName, "test")
-	utConfPrefix.AddKnownKey(tokens.TokensConfigPlugin, "fftokens")
-	utConfPrefix.AddKnownKey(ffresty.HTTPConfigURL, "")
-	err := h.Init(context.Background(), "testtokens", utConfPrefix.ArrayEntry(0), &tokenmocks.Callbacks{})
+	utConfig.AddKnownKey(tokens.TokensConfigName, "test")
+	utConfig.AddKnownKey(tokens.TokensConfigPlugin, "fftokens")
+	utConfig.AddKnownKey(ffresty.HTTPConfigURL, "")
+	err := h.Init(context.Background(), "testtokens", utConfig.ArrayEntry(0), &tokenmocks.Callbacks{})
 	assert.Regexp(t, "FF10138", err)
 }
 

--- a/internal/tokens/tifactory/factory.go
+++ b/internal/tokens/tifactory/factory.go
@@ -30,13 +30,13 @@ var pluginsByName = map[string]func() tokens.Plugin{
 	(*fftokens.FFTokens)(nil).Name(): func() tokens.Plugin { return &fftokens.FFTokens{} },
 }
 
-func InitPrefix(prefix config.PrefixArray) {
-	prefix.AddKnownKey(tokens.TokensConfigConnector)
-	prefix.AddKnownKey(tokens.TokensConfigPlugin)
-	prefix.AddKnownKey(tokens.TokensConfigName)
+func InitConfig(config config.ArraySection) {
+	config.AddKnownKey(tokens.TokensConfigConnector)
+	config.AddKnownKey(tokens.TokensConfigPlugin)
+	config.AddKnownKey(tokens.TokensConfigName)
 	for _, plugin := range pluginsByName {
 		// Accept a superset of configs allowed by all plugins
-		plugin().InitPrefix(prefix)
+		plugin().InitConfig(config)
 	}
 }
 

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -126,13 +126,13 @@ func (_m *Plugin) GetFFIParamValidator(ctx context.Context) (core.FFIParamValida
 	return r0, r1
 }
 
-// Init provides a mock function with given fields: ctx, prefix, callbacks, _a3
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks blockchain.Callbacks, _a3 metrics.Manager) error {
-	ret := _m.Called(ctx, prefix, callbacks, _a3)
+// Init provides a mock function with given fields: ctx, _a1, callbacks, _a3
+func (_m *Plugin) Init(ctx context.Context, _a1 config.Section, callbacks blockchain.Callbacks, _a3 metrics.Manager) error {
+	ret := _m.Called(ctx, _a1, callbacks, _a3)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, blockchain.Callbacks, metrics.Manager) error); ok {
-		r0 = rf(ctx, prefix, callbacks, _a3)
+	if rf, ok := ret.Get(0).(func(context.Context, config.Section, blockchain.Callbacks, metrics.Manager) error); ok {
+		r0 = rf(ctx, _a1, callbacks, _a3)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -140,9 +140,9 @@ func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks bloc
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.Prefix) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.Section) {
+	_m.Called(_a0)
 }
 
 // InvokeContract provides a mock function with given fields: ctx, operationID, signingKey, location, method, input

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2291,13 +2291,13 @@ func (_m *Plugin) GetVerifiers(ctx context.Context, filter database.Filter) ([]*
 	return r0, r1, r2
 }
 
-// Init provides a mock function with given fields: ctx, prefix, callbacks
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks database.Callbacks) error {
-	ret := _m.Called(ctx, prefix, callbacks)
+// Init provides a mock function with given fields: ctx, _a1, callbacks
+func (_m *Plugin) Init(ctx context.Context, _a1 config.Section, callbacks database.Callbacks) error {
+	ret := _m.Called(ctx, _a1, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, database.Callbacks) error); ok {
-		r0 = rf(ctx, prefix, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, config.Section, database.Callbacks) error); ok {
+		r0 = rf(ctx, _a1, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2305,9 +2305,9 @@ func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks data
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.Prefix) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.Section) {
+	_m.Called(_a0)
 }
 
 // InsertBlob provides a mock function with given fields: ctx, blob

--- a/mocks/dataexchangemocks/plugin.go
+++ b/mocks/dataexchangemocks/plugin.go
@@ -127,13 +127,13 @@ func (_m *Plugin) GetEndpointInfo(ctx context.Context) (fftypes.JSONObject, erro
 	return r0, r1
 }
 
-// Init provides a mock function with given fields: ctx, prefix, nodes, callbacks
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, nodes []fftypes.JSONObject, callbacks dataexchange.Callbacks) error {
-	ret := _m.Called(ctx, prefix, nodes, callbacks)
+// Init provides a mock function with given fields: ctx, _a1, nodes, callbacks
+func (_m *Plugin) Init(ctx context.Context, _a1 config.Section, nodes []fftypes.JSONObject, callbacks dataexchange.Callbacks) error {
+	ret := _m.Called(ctx, _a1, nodes, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, []fftypes.JSONObject, dataexchange.Callbacks) error); ok {
-		r0 = rf(ctx, prefix, nodes, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, config.Section, []fftypes.JSONObject, dataexchange.Callbacks) error); ok {
+		r0 = rf(ctx, _a1, nodes, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -141,9 +141,9 @@ func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, nodes []fftype
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.Prefix) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.Section) {
+	_m.Called(_a0)
 }
 
 // Name provides a mock function with given fields:

--- a/mocks/eventsmocks/plugin.go
+++ b/mocks/eventsmocks/plugin.go
@@ -63,13 +63,13 @@ func (_m *Plugin) GetOptionsSchema(_a0 context.Context) string {
 	return r0
 }
 
-// Init provides a mock function with given fields: ctx, prefix, callbacks
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks events.Callbacks) error {
-	ret := _m.Called(ctx, prefix, callbacks)
+// Init provides a mock function with given fields: ctx, _a1, callbacks
+func (_m *Plugin) Init(ctx context.Context, _a1 config.Section, callbacks events.Callbacks) error {
+	ret := _m.Called(ctx, _a1, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, events.Callbacks) error); ok {
-		r0 = rf(ctx, prefix, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, config.Section, events.Callbacks) error); ok {
+		r0 = rf(ctx, _a1, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -77,9 +77,9 @@ func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks even
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.Prefix) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.Section) {
+	_m.Called(_a0)
 }
 
 // Name provides a mock function with given fields:

--- a/mocks/identitymocks/plugin.go
+++ b/mocks/identitymocks/plugin.go
@@ -33,13 +33,13 @@ func (_m *Plugin) Capabilities() *identity.Capabilities {
 	return r0
 }
 
-// Init provides a mock function with given fields: ctx, prefix, callbacks
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks identity.Callbacks) error {
-	ret := _m.Called(ctx, prefix, callbacks)
+// Init provides a mock function with given fields: ctx, _a1, callbacks
+func (_m *Plugin) Init(ctx context.Context, _a1 config.Section, callbacks identity.Callbacks) error {
+	ret := _m.Called(ctx, _a1, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, identity.Callbacks) error); ok {
-		r0 = rf(ctx, prefix, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, config.Section, identity.Callbacks) error); ok {
+		r0 = rf(ctx, _a1, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -47,9 +47,9 @@ func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks iden
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.Prefix) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.Section) {
+	_m.Called(_a0)
 }
 
 // Name provides a mock function with given fields:

--- a/mocks/sharedstoragemocks/plugin.go
+++ b/mocks/sharedstoragemocks/plugin.go
@@ -58,13 +58,13 @@ func (_m *Plugin) DownloadData(ctx context.Context, payloadRef string) (io.ReadC
 	return r0, r1
 }
 
-// Init provides a mock function with given fields: ctx, prefix, callbacks
-func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks sharedstorage.Callbacks) error {
-	ret := _m.Called(ctx, prefix, callbacks)
+// Init provides a mock function with given fields: ctx, _a1, callbacks
+func (_m *Plugin) Init(ctx context.Context, _a1 config.Section, callbacks sharedstorage.Callbacks) error {
+	ret := _m.Called(ctx, _a1, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, config.Prefix, sharedstorage.Callbacks) error); ok {
-		r0 = rf(ctx, prefix, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, config.Section, sharedstorage.Callbacks) error); ok {
+		r0 = rf(ctx, _a1, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -72,9 +72,9 @@ func (_m *Plugin) Init(ctx context.Context, prefix config.Prefix, callbacks shar
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.Prefix) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.Section) {
+	_m.Called(_a0)
 }
 
 // Name provides a mock function with given fields:

--- a/mocks/tokenmocks/plugin.go
+++ b/mocks/tokenmocks/plugin.go
@@ -93,13 +93,13 @@ func (_m *Plugin) CreateTokenPool(ctx context.Context, opID *fftypes.UUID, pool 
 	return r0, r1
 }
 
-// Init provides a mock function with given fields: ctx, name, prefix, callbacks
-func (_m *Plugin) Init(ctx context.Context, name string, prefix config.Prefix, callbacks tokens.Callbacks) error {
-	ret := _m.Called(ctx, name, prefix, callbacks)
+// Init provides a mock function with given fields: ctx, name, _a2, callbacks
+func (_m *Plugin) Init(ctx context.Context, name string, _a2 config.Section, callbacks tokens.Callbacks) error {
+	ret := _m.Called(ctx, name, _a2, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, config.Prefix, tokens.Callbacks) error); ok {
-		r0 = rf(ctx, name, prefix, callbacks)
+	if rf, ok := ret.Get(0).(func(context.Context, string, config.Section, tokens.Callbacks) error); ok {
+		r0 = rf(ctx, name, _a2, callbacks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -107,9 +107,9 @@ func (_m *Plugin) Init(ctx context.Context, name string, prefix config.Prefix, c
 	return r0
 }
 
-// InitPrefix provides a mock function with given fields: prefix
-func (_m *Plugin) InitPrefix(prefix config.PrefixArray) {
-	_m.Called(prefix)
+// InitConfig provides a mock function with given fields: _a0
+func (_m *Plugin) InitConfig(_a0 config.ArraySection) {
+	_m.Called(_a0)
 }
 
 // MintTokens provides a mock function with given fields: ctx, opID, poolLocator, mint

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -29,12 +29,12 @@ import (
 type Plugin interface {
 	core.Named
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.Prefix)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.Section)
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, prefix config.Prefix, callbacks Callbacks, metrics metrics.Manager) error
+	Init(ctx context.Context, config config.Section, callbacks Callbacks, metrics metrics.Manager) error
 
 	// Blockchain interface must not deliver any events until start is called
 	Start() error

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -47,12 +47,12 @@ const (
 type Plugin interface {
 	PersistenceInterface // Split out to aid pluggability the next level down (SQL provider etc.)
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.Prefix)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.Section)
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, prefix config.Prefix, callbacks Callbacks) error
+	Init(ctx context.Context, config config.Section, callbacks Callbacks) error
 
 	// Capabilities returns capabilities - not called until after Init
 	Capabilities() *Capabilities

--- a/pkg/dataexchange/plugin.go
+++ b/pkg/dataexchange/plugin.go
@@ -57,11 +57,11 @@ import (
 type Plugin interface {
 	core.Named
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.Prefix)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.Section)
 
 	// Init initializes the plugin, with configuration
-	Init(ctx context.Context, prefix config.Prefix, nodes []fftypes.JSONObject, callbacks Callbacks) error
+	Init(ctx context.Context, config config.Section, nodes []fftypes.JSONObject, callbacks Callbacks) error
 
 	// Data exchange interface must not deliver any events until start is called
 	Start() error

--- a/pkg/events/plugin.go
+++ b/pkg/events/plugin.go
@@ -29,12 +29,12 @@ import (
 type Plugin interface {
 	core.Named
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.Prefix)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.Section)
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, prefix config.Prefix, callbacks Callbacks) error
+	Init(ctx context.Context, config config.Section, callbacks Callbacks) error
 
 	// Capabilities returns capabilities - not called until after Init
 	Capabilities() *Capabilities

--- a/pkg/identity/plugin.go
+++ b/pkg/identity/plugin.go
@@ -27,12 +27,12 @@ import (
 type Plugin interface {
 	core.Named
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.Prefix)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.Section)
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, prefix config.Prefix, callbacks Callbacks) error
+	Init(ctx context.Context, config config.Section, callbacks Callbacks) error
 
 	// Blockchain interface must not deliver any events until start is called
 	Start() error

--- a/pkg/sharedstorage/plugin.go
+++ b/pkg/sharedstorage/plugin.go
@@ -28,12 +28,12 @@ import (
 type Plugin interface {
 	core.Named
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.Prefix)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.Section)
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, prefix config.Prefix, callbacks Callbacks) error
+	Init(ctx context.Context, config config.Section, callbacks Callbacks) error
 
 	// Capabilities returns capabilities - not called until after Init
 	Capabilities() *Capabilities

--- a/pkg/tokens/plugin.go
+++ b/pkg/tokens/plugin.go
@@ -29,12 +29,12 @@ import (
 type Plugin interface {
 	core.Named
 
-	// InitPrefix initializes the set of configuration options that are valid, with defaults. Called on all plugins.
-	InitPrefix(prefix config.PrefixArray)
+	// InitConfig initializes the set of configuration options that are valid, with defaults. Called on all plugins.
+	InitConfig(config config.ArraySection)
 
 	// Init initializes the plugin, with configuration
 	// Returns the supported featureset of the interface
-	Init(ctx context.Context, name string, prefix config.Prefix, callbacks Callbacks) error
+	Init(ctx context.Context, name string, config config.Section, callbacks Callbacks) error
 
 	// Blockchain interface must not deliver any events until start is called
 	Start() error


### PR DESCRIPTION
Migration from older `Prefix` based configuration naming to the new `Config`/`Section` naming introduced in firefly-common v0.1.4

closes #802 
