### PR TITLE
Add new Docker tags for release channels

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -24,22 +24,58 @@ jobs:
             --tag ghcr.io/hyperledger/firefly:head" \
             docker
 
-      - name: Tag release
-        if: github.event.action == 'released'
-        run: docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:latest
-
       - name: Push docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           docker push ghcr.io/hyperledger/firefly:${GITHUB_REF##*/}
-      
+
       - name: Push head tag
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           docker push ghcr.io/hyperledger/firefly:head
+
+      - name: Tag latest release
+        if: github.event.action == 'released'
+        run: docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:latest
 
       - name: Push latest tag
         if: github.event.action == 'released'
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           docker push ghcr.io/hyperledger/firefly:latest
+
+      - name: Tag alpha release
+        if: github.event.action == 'prereleased' && contains(env.GITHUB_REF, 'alpha')
+        run: |
+          echo ${{ env.GITHUB_REF }}
+          docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:alpha
+
+      - name: Push alpha tag
+        if: github.event.action == 'prereleased' && contains(env.GITHUB_REF, 'alpha')
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker push ghcr.io/hyperledger/firefly:alpha
+
+      - name: Tag beta release
+        if: github.event.action == 'prereleased' && contains(env.GITHUB_REF, 'beta')
+        run: |
+          echo ${{ env.GITHUB_REF }}
+          docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:beta
+
+      - name: Push beta tag
+        if: github.event.action == 'prereleased' && contains(env.GITHUB_REF, 'beta')
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker push ghcr.io/hyperledger/firefly:beta
+
+      - name: Tag rc release
+        if: github.event.action == 'prereleased' && contains(env.GITHUB_REF, 'rc')
+        run: |
+          echo ${{ env.GITHUB_REF }}
+          docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:rc
+
+      - name: Push rc tag
+        if: github.event.action == 'prereleased' && contains(env.GITHUB_REF, 'rc')
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker push ghcr.io/hyperledger/firefly:rc


### PR DESCRIPTION
This PR adds several new Docker tags which are used conditionally based on the git tag used when a GitHub release is created. The rules are as follows:

- If the release is a pre-release,
  - and the tag contains the string `alpha` then `alpha` tag will be applied to the Docker image
  - or if the tag contains the string `beta` then the `beta` tag will be applied to the Docker image
  - or if the tag contains the string `rc` then the `rc` tag will be applied to the Docker image
- Or if the release is _not_ a pre-release,
  - The `latest` tag will be applied to the Docker image
- The `head` tag will always be applied to the image