### PR TITLE
Add additional test suite for running E2E tests without tokenTestSuite against specific Firefly namespace

### DIFF
--- a/test/e2e/ethereum_namespace_no_tokens_test.go
+++ b/test/e2e/ethereum_namespace_no_tokens_test.go
@@ -1,0 +1,28 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestEthereumNamespaceNoTokensE2ESuite(t *testing.T) {
+	suite.Run(t, new(OnChainOffChainTestSuite))
+	suite.Run(t, new(EthereumContractTestSuite))
+}

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -40,7 +40,7 @@ func (suite *TokensTestSuite) SetupSuite() {
 }
 
 func (suite *TokensTestSuite) BeforeTest(suiteName, testName string) {
-	if suite.connector != "" {
+	if suite.connector != "none" {
 		suite.testState = beforeE2ETest(suite.T())
 	} else {
 		suite.T().Skip("tokenProvider not specified, skipping TokensTestSuite")

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -36,15 +36,15 @@ type TokensTestSuite struct {
 func (suite *TokensTestSuite) SetupSuite() {
 	suite.testState = beforeE2ETest(suite.T())
 	stack := readStackFile(suite.T())
-	if stack.TokenProviders[0] != "" {
-		suite.connector = stack.TokenProviders[0]
-	} else {
-		suite.T().Skip("tokenProvider not specified, skipping TokensTestSuite")
-	}
+	suite.connector = stack.TokenProviders[0]
 }
 
 func (suite *TokensTestSuite) BeforeTest(suiteName, testName string) {
-	suite.testState = beforeE2ETest(suite.T())
+	if suite.connector != "" {
+		suite.testState = beforeE2ETest(suite.T())
+	} else {
+		suite.T().Skip("tokenProvider not specified, skipping TokensTestSuite")
+	}
 }
 
 func (suite *TokensTestSuite) TestE2EFungibleTokensAsync() {

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -40,10 +40,10 @@ func (suite *TokensTestSuite) SetupSuite() {
 }
 
 func (suite *TokensTestSuite) BeforeTest(suiteName, testName string) {
-	if suite.connector != "none" {
-		suite.testState = beforeE2ETest(suite.T())
-	} else {
+	if suite.connector == "none" {
 		suite.T().Skip("tokenProvider not specified, skipping TokensTestSuite")
+	} else {
+		suite.testState = beforeE2ETest(suite.T())
 	}
 }
 

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -36,7 +36,11 @@ type TokensTestSuite struct {
 func (suite *TokensTestSuite) SetupSuite() {
 	suite.testState = beforeE2ETest(suite.T())
 	stack := readStackFile(suite.T())
-	suite.connector = stack.TokenProviders[0]
+	if stack.TokenProviders[0] != "" {
+		suite.connector = stack.TokenProviders[0]
+	} else {
+		suite.T().Skip("tokenProvider not specified, skipping TokensTestSuite")
+	}
 }
 
 func (suite *TokensTestSuite) BeforeTest(suiteName, testName string) {

--- a/test/e2e/tokens_test.go
+++ b/test/e2e/tokens_test.go
@@ -40,11 +40,7 @@ func (suite *TokensTestSuite) SetupSuite() {
 }
 
 func (suite *TokensTestSuite) BeforeTest(suiteName, testName string) {
-	if suite.connector == "none" {
-		suite.T().Skip("tokenProvider not specified, skipping TokensTestSuite")
-	} else {
-		suite.testState = beforeE2ETest(suite.T())
-	}
+	suite.testState = beforeE2ETest(suite.T())
 }
 
 func (suite *TokensTestSuite) TestE2EFungibleTokensAsync() {


### PR DESCRIPTION
Can call test suite directly to run without token test suite.