### PR TITLE
Possible to see clash on port 6000 for metrics server

### DIFF
--- a/test/data/config/firefly.core.yaml
+++ b/test/data/config/firefly.core.yaml
@@ -3,6 +3,8 @@ debug:
   port: 0
 http:
   port: 0
+metrics:
+  port: 0
 node:
   identity: 0x91d2b4381a4cd5c7c0f27565a7d4b829844c8635
 blockchain:


### PR DESCRIPTION
Saw a build failure in https://github.com/hyperledger/firefly/runs/6530517574?check_suite_focus=true

```
Error: FF00151: Unable to start listener on 127.0.0.1:6000: %!s(MISSING): listen tcp 127.0.0.1:6000: bind: address already in use
```

We have config to get a dynamically assigned port for these tests for `debug` and `http`, but not for `metrics`