### PR TITLE
Fix link to events reference

### DIFF
--- a/docs/reference/types/_includes/event_description.md
+++ b/docs/reference/types/_includes/event_description.md
@@ -1,6 +1,6 @@
 Every Event emitted by FireFly shares a common structure.
 
-> See [Events](../(events.md) for a reference for how the overall event bus
+> See [Events](../events.html) for a reference for how the overall event bus
 in Hyperledger FireFly operates, and descriptions of all the sub-categories
 of events.
 


### PR DESCRIPTION
Signed-off-by: Peter Broadhurst <peter.broadhurst@kaleido.io>