### PR TITLE
default fabconnect calls to async

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,12 +74,12 @@ jobs:
       - name: Check the docs for broken links (root)
         if: github.event_name == 'pull_request'
         working-directory: docs
-        run: bundle exec htmlproofer --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/:/' --url-ignore /127.0.0.1/,/localhost/
+        run: bundle exec htmlproofer --disable-external --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/:/' --url-ignore /127.0.0.1/,/localhost/
 
       - name: Check the docs for broken links (version)
         if: github.event_name != 'pull_request'
         working-directory: docs
-        run: bundle exec htmlproofer --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/${{ env.DOCS_VERSION }}/:/' --url-ignore /127.0.0.1/,/localhost/
+        run: bundle exec htmlproofer --disable-external --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/${{ env.DOCS_VERSION }}/:/' --url-ignore /127.0.0.1/,/localhost/
 
       - name: Deploy docs (version)
         if: github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -100,4 +100,4 @@ manifest:
 docker:
 		./docker_build.sh $(DOCKER_ARGS)
 docs: .ALWAYS
-		cd docs && bundle install && bundle exec jekyll build && bundle exec htmlproofer --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/:/' --url-ignore /127.0.0.1/,/localhost/
+		cd docs && bundle install && bundle exec jekyll build && bundle exec htmlproofer --disable-external --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/:/' --url-ignore /127.0.0.1/,/localhost/

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -544,6 +544,7 @@ func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, m
 	res, err := f.client.R().
 		SetContext(ctx).
 		SetBody(in).
+		SetHeader("x-firefly-sync", "false").
 		SetError(&resErr).
 		Post("/transactions")
 	if err != nil || !res.IsSuccess() {


### PR DESCRIPTION
The fabconnect default for `/transactions` is synchronous. The fabric plugin currently expects async responses, so adding the `x-firefly-sync` header.
