### PR TITLE
set message header type for broadcast/private

### DIFF
--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -41,6 +41,7 @@ func (bm *broadcastManager) NewBroadcast(ns string, in *fftypes.MessageInOut) sy
 
 func (bm *broadcastManager) BroadcastMessage(ctx context.Context, ns string, in *fftypes.MessageInOut, waitConfirm bool) (out *fftypes.Message, err error) {
 	broadcast := bm.NewBroadcast(ns, in)
+	in.Header.Type = fftypes.MessageTypeBroadcast
 	if bm.metrics.IsMetricsEnabled() {
 		bm.metrics.MessageSubmitted(&in.Message)
 	}

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -41,6 +41,7 @@ func (pm *privateMessaging) NewMessage(ns string, in *fftypes.MessageInOut) sysm
 
 func (pm *privateMessaging) SendMessage(ctx context.Context, ns string, in *fftypes.MessageInOut, waitConfirm bool) (out *fftypes.Message, err error) {
 	message := pm.NewMessage(ns, in)
+	in.Header.Type = fftypes.MessageTypePrivate
 	if pm.metrics.IsMetricsEnabled() {
 		pm.metrics.MessageSubmitted(&in.Message)
 	}


### PR DESCRIPTION
FireFly now sets the message type for any broadcast or private messages
sent via the API.