### PR TITLE
fabconnect async calls + setting broadcast/private message header types

### DIFF
--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -598,6 +598,7 @@ func (f *Fabric) invokeContractMethod(ctx context.Context, channel, chaincode, m
 	res, err := f.client.R().
 		SetContext(ctx).
 		SetBody(in).
+		SetHeader("x-firefly-sync", "false").
 		SetError(&resErr).
 		Post("/transactions")
 	if err != nil || !res.IsSuccess() {

--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -42,6 +42,7 @@ func (bm *broadcastManager) NewBroadcast(ns string, in *core.MessageInOut) sysme
 
 func (bm *broadcastManager) BroadcastMessage(ctx context.Context, ns string, in *core.MessageInOut, waitConfirm bool) (out *core.Message, err error) {
 	broadcast := bm.NewBroadcast(ns, in)
+	in.Header.Type = fftypes.MessageTypeBroadcast
 	if bm.metrics.IsMetricsEnabled() {
 		bm.metrics.MessageSubmitted(&in.Message)
 	}

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -42,6 +42,7 @@ func (pm *privateMessaging) NewMessage(ns string, in *core.MessageInOut) sysmess
 
 func (pm *privateMessaging) SendMessage(ctx context.Context, ns string, in *core.MessageInOut, waitConfirm bool) (out *core.Message, err error) {
 	message := pm.NewMessage(ns, in)
+	in.Header.Type = fftypes.MessageTypePrivate
 	if pm.metrics.IsMetricsEnabled() {
 		pm.metrics.MessageSubmitted(&in.Message)
 	}


### PR DESCRIPTION
This PR adds two changes included in future release `1.0.2` into upstream firefly.

https://github.com/hyperledger/firefly/pull/838
https://github.com/hyperledger/firefly/pull/836
