### PR TITLE
Enhancements to migration/network version behavior

### DIFF
--- a/internal/events/network_action.go
+++ b/internal/events/network_action.go
@@ -17,24 +17,20 @@
 package events
 
 import (
-	"context"
-
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
 func (em *eventManager) actionTerminate(bi blockchain.Plugin, event *blockchain.Event) error {
-	return em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
-		ns, err := em.database.GetNamespace(ctx, core.LegacySystemNamespace)
-		if err != nil {
-			return err
-		}
-		if err := bi.TerminateContract(ctx, &ns.Contracts, event); err != nil {
-			return err
-		}
-		return em.database.UpsertNamespace(ctx, ns, true)
-	})
+	ns, err := em.database.GetNamespace(em.ctx, core.LegacySystemNamespace)
+	if err != nil {
+		return err
+	}
+	if err := bi.TerminateContract(em.ctx, &ns.Contracts, event); err != nil {
+		return err
+	}
+	return em.database.UpsertNamespace(em.ctx, ns, true)
 }
 
 func (em *eventManager) BlockchainNetworkAction(bi blockchain.Plugin, action string, event *blockchain.Event, signingKey *core.VerifierRef) error {

--- a/internal/events/network_action_test.go
+++ b/internal/events/network_action_test.go
@@ -52,7 +52,7 @@ func TestNetworkAction(t *testing.T) {
 		return be.ProtocolID == "0001"
 	})).Return(nil)
 	mdi.On("InsertEvent", em.ctx, mock.Anything).Return(nil)
-	mdi.On("GetNamespace", em.ctx, "ff_system").Return(&core.Namespace{}, nil)
+	mdi.On("GetNamespaces", em.ctx, mock.Anything).Return([]*core.Namespace{{}}, nil, nil)
 	mdi.On("UpsertNamespace", em.ctx, mock.AnythingOfType("*core.Namespace"), true).Return(nil)
 	mbi.On("TerminateContract", em.ctx, mock.AnythingOfType("*core.FireFlyContracts"), mock.AnythingOfType("*blockchain.Event")).Return(nil)
 
@@ -140,7 +140,7 @@ func TestActionTerminateQueryFail(t *testing.T) {
 	mbi := &blockchainmocks.Plugin{}
 	mdi := em.database.(*databasemocks.Plugin)
 
-	mdi.On("GetNamespace", em.ctx, "ff_system").Return(nil, fmt.Errorf("pop"))
+	mdi.On("GetNamespaces", em.ctx, mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
 
 	err := em.actionTerminate(mbi, &blockchain.Event{})
 	assert.EqualError(t, err, "pop")
@@ -156,7 +156,7 @@ func TestActionTerminateFail(t *testing.T) {
 	mbi := &blockchainmocks.Plugin{}
 	mdi := em.database.(*databasemocks.Plugin)
 
-	mdi.On("GetNamespace", em.ctx, "ff_system").Return(&core.Namespace{}, nil)
+	mdi.On("GetNamespaces", em.ctx, mock.Anything).Return([]*core.Namespace{{}}, nil, nil)
 	mbi.On("TerminateContract", em.ctx, mock.AnythingOfType("*core.FireFlyContracts"), mock.AnythingOfType("*blockchain.Event")).Return(fmt.Errorf("pop"))
 
 	err := em.actionTerminate(mbi, &blockchain.Event{})
@@ -173,7 +173,7 @@ func TestActionTerminateUpsertFail(t *testing.T) {
 	mbi := &blockchainmocks.Plugin{}
 	mdi := em.database.(*databasemocks.Plugin)
 
-	mdi.On("GetNamespace", em.ctx, "ff_system").Return(&core.Namespace{}, nil)
+	mdi.On("GetNamespaces", em.ctx, mock.Anything).Return([]*core.Namespace{{}}, nil, nil)
 	mdi.On("UpsertNamespace", em.ctx, mock.AnythingOfType("*core.Namespace"), true).Return(fmt.Errorf("pop"))
 	mbi.On("TerminateContract", em.ctx, mock.AnythingOfType("*core.FireFlyContracts"), mock.AnythingOfType("*blockchain.Event")).Return(nil)
 

--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -391,13 +391,9 @@ func (im *identityManager) cachedIdentityLookupByVerifierRef(ctx context.Context
 	if err != nil {
 		return nil, err
 	} else if verifier == nil {
-		if namespace != core.LegacySystemNamespace {
-			if version, err := im.blockchain.NetworkVersion(ctx); err != nil {
-				return nil, err
-			} else if version == 1 {
-				// For V1 networks, fall back to SystemNamespace for looking up identities
-				return im.cachedIdentityLookupByVerifierRef(ctx, core.LegacySystemNamespace, verifierRef)
-			}
+		if namespace != core.LegacySystemNamespace && im.blockchain.NetworkVersion(ctx) == 1 {
+			// For V1 networks, fall back to SystemNamespace for looking up identities
+			return im.cachedIdentityLookupByVerifierRef(ctx, core.LegacySystemNamespace, verifierRef)
 		}
 		return nil, err
 	}

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -170,7 +170,7 @@ func TestResolveInputSigningIdentityAnonymousKeyWithAuthorOk(t *testing.T) {
 
 	mbi := im.blockchain.(*blockchainmocks.Plugin)
 	mbi.On("NormalizeSigningKey", ctx, "mykey123").Return("fullkey123", nil)
-	mbi.On("NetworkVersion", ctx).Return(1, nil)
+	mbi.On("NetworkVersion", ctx).Return(1)
 
 	idID := fftypes.NewUUID()
 
@@ -209,7 +209,7 @@ func TestResolveInputSigningIdentityKeyWithNoAuthorFail(t *testing.T) {
 
 	mbi := im.blockchain.(*blockchainmocks.Plugin)
 	mbi.On("NormalizeSigningKey", ctx, "mykey123").Return("fullkey123", nil)
-	mbi.On("NetworkVersion", ctx).Return(1, nil)
+	mbi.On("NetworkVersion", ctx).Return(1)
 
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetVerifierByValue", ctx, core.VerifierTypeEthAddress, "ns1", "fullkey123").Return(nil, nil)
@@ -275,7 +275,7 @@ func TestResolveInputSigningIdentityByKeyNotFound(t *testing.T) {
 
 	mbi := im.blockchain.(*blockchainmocks.Plugin)
 	mbi.On("NormalizeSigningKey", ctx, "mykey123").Return("fullkey123", nil)
-	mbi.On("NetworkVersion", ctx).Return(1, nil)
+	mbi.On("NetworkVersion", ctx).Return(1)
 
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetVerifierByValue", ctx, core.VerifierTypeEthAddress, "ns1", "fullkey123").
@@ -571,38 +571,11 @@ func TestResolveDefaultSigningIdentityNotFound(t *testing.T) {
 	}
 
 	mbi := im.blockchain.(*blockchainmocks.Plugin)
-	mbi.On("NetworkVersion", ctx).Return(1, nil)
+	mbi.On("NetworkVersion", ctx).Return(1)
 
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetVerifierByValue", ctx, core.VerifierTypeEthAddress, "ns1", "key12345").Return(nil, nil)
 	mdi.On("GetVerifierByValue", ctx, core.VerifierTypeEthAddress, core.LegacySystemNamespace, "key12345").Return(nil, nil)
-
-	mns := im.namespace.(*namespacemocks.Manager)
-	mns.On("GetDefaultKey", "ns1").Return("")
-	mns.On("GetMultipartyConfig", "ns1", coreconfig.OrgName).Return("org1")
-
-	err := im.resolveDefaultSigningIdentity(ctx, "ns1", &core.SignerRef{})
-	assert.Regexp(t, "FF10281", err)
-
-	mbi.AssertExpectations(t)
-	mdi.AssertExpectations(t)
-	mns.AssertExpectations(t)
-
-}
-
-func TestResolveDefaultSigningIdentityVersionError(t *testing.T) {
-
-	ctx, im := newTestIdentityManager(t)
-	im.multipartyRootVerifier["ns1"] = &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "key12345",
-	}
-
-	mbi := im.blockchain.(*blockchainmocks.Plugin)
-	mbi.On("NetworkVersion", ctx).Return(1, fmt.Errorf("pop"))
-
-	mdi := im.database.(*databasemocks.Plugin)
-	mdi.On("GetVerifierByValue", ctx, core.VerifierTypeEthAddress, "ns1", "key12345").Return(nil, nil)
 
 	mns := im.namespace.(*namespacemocks.Manager)
 	mns.On("GetDefaultKey", "ns1").Return("")
@@ -642,7 +615,7 @@ func TestResolveDefaultSigningIdentitySystemFallback(t *testing.T) {
 	}
 
 	mbi := im.blockchain.(*blockchainmocks.Plugin)
-	mbi.On("NetworkVersion", ctx).Return(1, nil)
+	mbi.On("NetworkVersion", ctx).Return(1)
 
 	mdi := im.database.(*databasemocks.Plugin)
 	mdi.On("GetVerifierByValue", ctx, core.VerifierTypeEthAddress, "ns1", "key12345").Return(nil, nil)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -51,6 +51,7 @@ type metricsManager struct {
 }
 
 func (mm *metricsManager) Start() error {
+	Registry() // ensure registry is initialized
 	return nil
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -224,6 +224,9 @@ func (or *orchestrator) Init(ctx context.Context, cancelCtx context.CancelFunc) 
 
 func (or *orchestrator) Start() (err error) {
 	if err == nil {
+		err = or.metrics.Start()
+	}
+	if err == nil {
 		err = or.batch.Start()
 	}
 	var ns *core.Namespace
@@ -264,9 +267,6 @@ func (or *orchestrator) Start() (err error) {
 				break
 			}
 		}
-	}
-	if err == nil {
-		err = or.metrics.Start()
 	}
 	or.started = true
 	return err

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -983,6 +983,7 @@ func TestStartBatchFail(t *testing.T) {
 	coreconfig.Reset()
 	or := newTestOrchestrator()
 	defer or.cleanup(t)
+	or.mmi.On("Start").Return(nil)
 	or.mba.On("Start").Return(fmt.Errorf("pop"))
 	err := or.Start()
 	assert.EqualError(t, err, "pop")
@@ -1002,6 +1003,7 @@ func TestStartTokensFail(t *testing.T) {
 	or.mpm.On("Start").Return(nil)
 	or.msd.On("Start").Return(nil)
 	or.mom.On("Start").Return(nil)
+	or.mmi.On("Start").Return(nil)
 	or.mti.On("Start").Return(fmt.Errorf("pop"))
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
 	err := or.Start()
@@ -1017,6 +1019,7 @@ func TestStartBlockchainsFail(t *testing.T) {
 	or.mbi.On("ConfigureContract", mock.Anything, &core.FireFlyContracts{}).Return(nil)
 	or.mbi.On("Start").Return(fmt.Errorf("pop"))
 	or.mba.On("Start").Return(nil)
+	or.mmi.On("Start").Return(nil)
 	err := or.Start()
 	assert.EqualError(t, err, "pop")
 }
@@ -1029,6 +1032,7 @@ func TestStartBlockchainsConfigureFail(t *testing.T) {
 	or.mdi.On("GetNamespace", mock.Anything, "ff_system").Return(&core.Namespace{}, nil)
 	or.mbi.On("ConfigureContract", mock.Anything, &core.FireFlyContracts{}).Return(fmt.Errorf("pop"))
 	or.mba.On("Start").Return(nil)
+	or.mmi.On("Start").Return(nil)
 	err := or.Start()
 	assert.EqualError(t, err, "pop")
 }

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -188,7 +188,7 @@ func (_m *Plugin) Name() string {
 }
 
 // NetworkVersion provides a mock function with given fields: ctx
-func (_m *Plugin) NetworkVersion(ctx context.Context) (int, error) {
+func (_m *Plugin) NetworkVersion(ctx context.Context) int {
 	ret := _m.Called(ctx)
 
 	var r0 int
@@ -198,14 +198,7 @@ func (_m *Plugin) NetworkVersion(ctx context.Context) (int, error) {
 		r0 = ret.Get(0).(int)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // NormalizeContractLocation provides a mock function with given fields: ctx, location

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -91,7 +91,7 @@ type Plugin interface {
 	GenerateEventSignature(ctx context.Context, event *core.FFIEventDefinition) string
 
 	// NetworkVersion returns the version of the network rules being used by this plugin
-	NetworkVersion(ctx context.Context) (int, error)
+	NetworkVersion(ctx context.Context) int
 }
 
 const FireFlyActionPrefix = "firefly:"


### PR DESCRIPTION
Network version is loaded during blockchain plugin init, instead of lazily. This is (soon) going to be needed at manager initialization time, so might as well load it once upfront.

Since we currently have a single blockchain plugin that services all namespaces, any termination/migration event is recorded against ALL namespaces (rather than arbitrarily recording it against ff_system only).