### PR TITLE
Remove redundant payloadRef field on Batch Pin

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1510,10 +1510,6 @@ paths:
                       description: The UUID of the node that generated the batch
                       format: uuid
                       type: string
-                    payloadRef:
-                      description: For broadcast batches, this is the reference to
-                        the binary batch in shared storage
-                      type: string
                     tx:
                       description: The FireFly transaction associated with this batch
                       properties:
@@ -1597,10 +1593,6 @@ paths:
                   node:
                     description: The UUID of the node that generated the batch
                     format: uuid
-                    type: string
-                  payloadRef:
-                    description: For broadcast batches, this is the reference to the
-                      binary batch in shared storage
                     type: string
                   tx:
                     description: The FireFly transaction associated with this batch
@@ -10512,10 +10504,6 @@ paths:
                       description: The UUID of the node that generated the batch
                       format: uuid
                       type: string
-                    payloadRef:
-                      description: For broadcast batches, this is the reference to
-                        the binary batch in shared storage
-                      type: string
                     tx:
                       description: The FireFly transaction associated with this batch
                       properties:
@@ -10606,10 +10594,6 @@ paths:
                   node:
                     description: The UUID of the node that generated the batch
                     format: uuid
-                    type: string
-                  payloadRef:
-                    description: For broadcast batches, this is the reference to the
-                      binary batch in shared storage
                     type: string
                   tx:
                     description: The FireFly transaction associated with this batch

--- a/pkg/core/batch.go
+++ b/pkg/core/batch.go
@@ -78,11 +78,10 @@ type Batch struct {
 // BatchPersisted is the structure written to the database
 type BatchPersisted struct {
 	BatchHeader
-	Hash       *fftypes.Bytes32 `ffstruct:"Batch" json:"hash"`
-	Manifest   *fftypes.JSONAny `ffstruct:"Batch" json:"manifest"`
-	TX         TransactionRef   `ffstruct:"Batch" json:"tx"`
-	PayloadRef string           `ffstruct:"Batch" json:"payloadRef,omitempty"`
-	Confirmed  *fftypes.FFTime  `ffstruct:"Batch" json:"confirmed"`
+	Hash      *fftypes.Bytes32 `ffstruct:"Batch" json:"hash"`
+	Manifest  *fftypes.JSONAny `ffstruct:"Batch" json:"manifest"`
+	TX        TransactionRef   `ffstruct:"Batch" json:"tx"`
+	Confirmed *fftypes.FFTime  `ffstruct:"Batch" json:"confirmed"`
 }
 
 // BatchPayload contains the full JSON of the messages and data, but


### PR DESCRIPTION
This field is not used by any code.

There was a vision that storing the `payloadRef` on broadcast batches for reference, but this was never implementing. Meaning this field is cruft.

Currently the right way to find the payload reference, is to look at the upload/download operations for the batch.