### PR TITLE
Use docker buildx for multiarch builds

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -13,6 +13,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Set up qemu emulators
+        run: |
+          docker run --rm --privileged tonistiigi/binfmt --install all
+
+      - name: Docker login
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
       - name: Set build tag
         id: build_tag_generator
         run: |
@@ -28,18 +40,7 @@ jobs:
             --label commit=$GITHUB_SHA \
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
-            --tag ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }}" \
-            docker
-
-      - name: Tag release
-        run: docker tag ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }} ghcr.io/hyperledger/firefly:head
-
-      - name: Push docker image
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }}
-
-      - name: Push head tag
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:head
+            --tag ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
+            --tag ghcr.io/hyperledger/firefly:head \
+            --push" \
+            docker-multiarch

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -12,6 +12,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Set up qemu emulators
+        run: |
+          docker run --rm --privileged tonistiigi/binfmt --install all
+      
+      - name: Set latest tag
+        if: github.event.action == 'released'
+        run: |
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }} --tag ghcr.io/hyperledger/firefly:latest" >> $GITHUB_ENV
+
+      - name: Set alpha tag
+        if: github.event.action == 'prereleased' && contains(github.ref, 'alpha')
+        run: |
+            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }} --tag ghcr.io/hyperledger/firefly:alpha" >> $GITHUB_ENV
+
+      - name: Set beta tag
+        if: github.event.action == 'prereleased' && contains(github.ref, 'beta')
+        run: |
+            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }} --tag ghcr.io/hyperledger/firefly:beta" >> $GITHUB_ENV
+
+      - name: Set rc tag
+        if: github.event.action == 'prereleased' && contains(github.ref, 'rc')
+        run: |
+            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }} --tag ghcr.io/hyperledger/firefly:rc" >> $GITHUB_ENV
+
       - name: Build
         run: |
           make DOCKER_ARGS="\
@@ -21,58 +49,7 @@ jobs:
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${GITHUB_REF##*/} \
             --tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} \
-            --tag ghcr.io/hyperledger/firefly:head" \
-            docker
-
-      - name: Push docker image
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:${GITHUB_REF##*/}
-
-      - name: Push head tag
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:head
-
-      - name: Tag latest release
-        if: github.event.action == 'released'
-        run: docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:latest
-
-      - name: Push latest tag
-        if: github.event.action == 'released'
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:latest
-
-      - name: Tag alpha release
-        if: github.event.action == 'prereleased' && contains(github.ref, 'alpha')
-        run: |
-          docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:alpha
-
-      - name: Push alpha tag
-        if: github.event.action == 'prereleased' && contains(github.ref, 'alpha')
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:alpha
-
-      - name: Tag beta release
-        if: github.event.action == 'prereleased' && contains(github.ref, 'beta')
-        run: |
-          docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:beta
-
-      - name: Push beta tag
-        if: github.event.action == 'prereleased' && contains(github.ref, 'beta')
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:beta
-
-      - name: Tag rc release
-        if: github.event.action == 'prereleased' && contains(github.ref, 'rc')
-        run: |
-          docker tag ghcr.io/hyperledger/firefly:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly:rc
-
-      - name: Push rc tag
-        if: github.event.action == 'prereleased' && contains(github.ref, 'rc')
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly:rc
+            --tag ghcr.io/hyperledger/firefly:head \
+            ${{ env.DOCKER_TAGS }}" \
+            --push
+           docker-multiarch

--- a/Makefile
+++ b/Makefile
@@ -99,5 +99,7 @@ manifest:
 		./manifestgen.sh
 docker:
 		./docker_build.sh $(DOCKER_ARGS)
+docker-multiarch:
+		./docker_build.sh --platform linux/amd64,linux/arm64 $(DOCKER_ARGS) 
 docs: .ALWAYS
 		cd docs && bundle install && bundle exec jekyll build && bundle exec htmlproofer --disable-external --allow-hash-href --assume-extension ./_site --url-swap '^/firefly/:/' --url-ignore /127.0.0.1/,/localhost/

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -36,7 +36,8 @@ echo BASE_TAG=$BASE_TAG
 echo UI_TAG=$UI_TAG
 echo UI_RELEASE=$UI_RELEASE
 
-docker build \
+docker buildx create --name firefly --use
+docker buildx build \
     -t hyperledger/firefly \
     --build-arg FIREFLY_BUILDER_TAG=$FIREFLY_BUILDER_TAG \
     --build-arg FABRIC_BUILDER_TAG=$FABRIC_BUILDER_TAG \
@@ -47,3 +48,4 @@ docker build \
     --build-arg UI_RELEASE=$UI_RELEASE \
     $@ \
     .
+docker buildx rm firefly 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -48,4 +48,4 @@ docker buildx build \
     --build-arg UI_RELEASE=$UI_RELEASE \
     $@ \
     .
-docker buildx rm firefly 
+docker buildx rm firefly

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -88,7 +88,7 @@ if [ "$CREATE_STACK" == "true" ]; then
 fi
 
 if [ "$BUILD_FIREFLY" == "true" ]; then
-  make -C ../.. docker
+  make -C ../.. DOCKER_ARGS="--load" docker
   checkOk $?
 fi
 


### PR DESCRIPTION
This PR switches to the `docker buildx` command for building images for multiple CPU architectures. Currently, the build jobs are set up to build `linux/amd64` and `linux/arm64`. This is set in the `Makefile`. Because building a Docker image for a non-native CPU architecture is very slow (because it's emulated), mutiarch builds are not the default when running `make docker`. Instead a new command, `make docker-multiarch` has been added, which is used by our GitHub Actions.

> **NOTE:** From my testing `docker buildx` seems to return status 0, despite the fact that it may have failed to push to a repository. This can result in false positives for our GitHub Actions. I looked into this and it seems to be an open issue with `buildx` https://github.com/docker/buildx/issues/732