### PR TITLE
surface URI as parameter for token mint

### DIFF
--- a/docs/reference/types/tokentransfer.md
+++ b/docs/reference/types/tokentransfer.md
@@ -66,6 +66,7 @@ nav_order: 11
 | `created` | The creation time of the transfer | [`FFTime`](simpletypes#fftime) |
 | `tx` | If submitted via FireFly, this will reference the UUID of the FireFly transaction (if the token connector in use supports attaching data) | [`TransactionRef`](#transactionref) |
 | `blockchainEvent` | The UUID of the blockchain event | [`UUID`](simpletypes#uuid) |
+| `config` | Input only field, with token connector specific configuration of the transfer. See your chosen token connector documentation for details | [`JSONObject`](simpletypes#jsonobject) |
 
 ## TransactionRef
 

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -22785,6 +22785,15 @@ paths:
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
                   type: string
+                config:
+                  additionalProperties:
+                    description: Input only field, with token connector specific configuration
+                      of the transfer. See your chosen token connector documentation
+                      for details
+                  description: Input only field, with token connector specific configuration
+                    of the transfer. See your chosen token connector documentation
+                    for details
+                  type: object
                 from:
                   description: The source account for the transfer. On input defaults
                     to the value of 'key'
@@ -23214,6 +23223,15 @@ paths:
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
                   type: string
+                config:
+                  additionalProperties:
+                    description: Input only field, with token connector specific configuration
+                      of the transfer. See your chosen token connector documentation
+                      for details
+                  description: Input only field, with token connector specific configuration
+                    of the transfer. See your chosen token connector documentation
+                    for details
+                  type: object
                 from:
                   description: The source account for the transfer. On input defaults
                     to the value of 'key'
@@ -24421,6 +24439,15 @@ paths:
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
                   type: string
+                config:
+                  additionalProperties:
+                    description: Input only field, with token connector specific configuration
+                      of the transfer. See your chosen token connector documentation
+                      for details
+                  description: Input only field, with token connector specific configuration
+                    of the transfer. See your chosen token connector documentation
+                    for details
+                  type: object
                 from:
                   description: The source account for the transfer. On input defaults
                     to the value of 'key'
@@ -30135,6 +30162,15 @@ paths:
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
                   type: string
+                config:
+                  additionalProperties:
+                    description: Input only field, with token connector specific configuration
+                      of the transfer. See your chosen token connector documentation
+                      for details
+                  description: Input only field, with token connector specific configuration
+                    of the transfer. See your chosen token connector documentation
+                    for details
+                  type: object
                 from:
                   description: The source account for the transfer. On input defaults
                     to the value of 'key'
@@ -30546,6 +30582,15 @@ paths:
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
                   type: string
+                config:
+                  additionalProperties:
+                    description: Input only field, with token connector specific configuration
+                      of the transfer. See your chosen token connector documentation
+                      for details
+                  description: Input only field, with token connector specific configuration
+                    of the transfer. See your chosen token connector documentation
+                    for details
+                  type: object
                 key:
                   description: The blockchain signing key for the transfer. On input
                     defaults to the first signing key of the organization that operates
@@ -31714,6 +31759,15 @@ paths:
                     For example, with 18 decimals a fractional balance of 10.234 will
                     be specified as 10,234,000,000,000,000,000
                   type: string
+                config:
+                  additionalProperties:
+                    description: Input only field, with token connector specific configuration
+                      of the transfer. See your chosen token connector documentation
+                      for details
+                  description: Input only field, with token connector specific configuration
+                    of the transfer. See your chosen token connector documentation
+                    for details
+                  type: object
                 from:
                   description: The source account for the transfer. On input defaults
                     to the value of 'key'

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -22940,6 +22940,9 @@ paths:
                   description: The index of the token within the pool that this transfer
                     applies to
                   type: string
+                uri:
+                  description: The URI of the token this transfer applies to
+                  type: string
               type: object
       responses:
         "200":
@@ -23365,6 +23368,9 @@ paths:
                 tokenIndex:
                   description: The index of the token within the pool that this transfer
                     applies to
+                  type: string
+                uri:
+                  description: The URI of the token this transfer applies to
                   type: string
               type: object
       responses:
@@ -24569,6 +24575,9 @@ paths:
                 tokenIndex:
                   description: The index of the token within the pool that this transfer
                     applies to
+                  type: string
+                uri:
+                  description: The URI of the token this transfer applies to
                   type: string
               type: object
       responses:
@@ -30277,6 +30286,9 @@ paths:
                   description: The index of the token within the pool that this transfer
                     applies to
                   type: string
+                uri:
+                  description: The URI of the token this transfer applies to
+                  type: string
               type: object
       responses:
         "200":
@@ -30684,6 +30696,9 @@ paths:
                 tokenIndex:
                   description: The index of the token within the pool that this transfer
                     applies to
+                  type: string
+                uri:
+                  description: The URI of the token this transfer applies to
                   type: string
               type: object
       responses:
@@ -31853,6 +31868,9 @@ paths:
                 tokenIndex:
                   description: The index of the token within the pool that this transfer
                     applies to
+                  type: string
+                uri:
+                  description: The URI of the token this transfer applies to
                   type: string
               type: object
       responses:

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -565,6 +565,7 @@ var (
 	TokenTransferCreated         = ffm("TokenTransfer.created", "The creation time of the transfer")
 	TokenTransferTX              = ffm("TokenTransfer.tx", "If submitted via FireFly, this will reference the UUID of the FireFly transaction (if the token connector in use supports attaching data)")
 	TokenTransferBlockchainEvent = ffm("TokenTransfer.blockchainEvent", "The UUID of the blockchain event")
+	TokenTransferConfig          = ffm("TokenTransfer.config", "Input only field, with token connector specific configuration of the transfer. See your chosen token connector documentation for details")
 
 	// TokenTransferInput field descriptions
 	TokenTransferInputMessage = ffm("TokenTransferInput.message", "You can specify a message to correlate with the transfer, which can be of type broadcast or private. Your chosen token connector and on-chain smart contract must support on-chain/off-chain correlation by taking a `data` input on the transfer")

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -147,35 +147,38 @@ type activatePool struct {
 }
 
 type mintTokens struct {
-	PoolLocator string `json:"poolLocator"`
-	TokenIndex  string `json:"tokenIndex,omitempty"`
-	To          string `json:"to"`
-	Amount      string `json:"amount"`
-	RequestID   string `json:"requestId,omitempty"`
-	Signer      string `json:"signer"`
-	Data        string `json:"data,omitempty"`
-	URI         string `json:"uri,omitempty"`
+	PoolLocator string             `json:"poolLocator"`
+	TokenIndex  string             `json:"tokenIndex,omitempty"`
+	To          string             `json:"to"`
+	Amount      string             `json:"amount"`
+	RequestID   string             `json:"requestId,omitempty"`
+	Signer      string             `json:"signer"`
+	Data        string             `json:"data,omitempty"`
+	URI         string             `json:"uri,omitempty"`
+	Config      fftypes.JSONObject `json:"config"`
 }
 
 type burnTokens struct {
-	PoolLocator string `json:"poolLocator"`
-	TokenIndex  string `json:"tokenIndex,omitempty"`
-	From        string `json:"from"`
-	Amount      string `json:"amount"`
-	RequestID   string `json:"requestId,omitempty"`
-	Signer      string `json:"signer"`
-	Data        string `json:"data,omitempty"`
+	PoolLocator string             `json:"poolLocator"`
+	TokenIndex  string             `json:"tokenIndex,omitempty"`
+	From        string             `json:"from"`
+	Amount      string             `json:"amount"`
+	RequestID   string             `json:"requestId,omitempty"`
+	Signer      string             `json:"signer"`
+	Data        string             `json:"data,omitempty"`
+	Config      fftypes.JSONObject `json:"config"`
 }
 
 type transferTokens struct {
-	PoolLocator string `json:"poolLocator"`
-	TokenIndex  string `json:"tokenIndex,omitempty"`
-	From        string `json:"from"`
-	To          string `json:"to"`
-	Amount      string `json:"amount"`
-	RequestID   string `json:"requestId,omitempty"`
-	Signer      string `json:"signer"`
-	Data        string `json:"data,omitempty"`
+	PoolLocator string             `json:"poolLocator"`
+	TokenIndex  string             `json:"tokenIndex,omitempty"`
+	From        string             `json:"from"`
+	To          string             `json:"to"`
+	Amount      string             `json:"amount"`
+	RequestID   string             `json:"requestId,omitempty"`
+	Signer      string             `json:"signer"`
+	Data        string             `json:"data,omitempty"`
+	Config      fftypes.JSONObject `json:"config"`
 }
 
 type tokenApproval struct {
@@ -665,6 +668,7 @@ func (ft *FFTokens) MintTokens(ctx context.Context, nsOpID string, poolLocator s
 			Signer:      mint.Key,
 			Data:        string(data),
 			URI:         mint.URI,
+			Config:      mint.Config,
 		}).
 		SetError(&errRes).
 		Post("/api/v1/mint")
@@ -691,6 +695,7 @@ func (ft *FFTokens) BurnTokens(ctx context.Context, nsOpID string, poolLocator s
 			RequestID:   nsOpID,
 			Signer:      burn.Key,
 			Data:        string(data),
+			Config:      burn.Config,
 		}).
 		SetError(&errRes).
 		Post("/api/v1/burn")
@@ -718,6 +723,7 @@ func (ft *FFTokens) TransferTokens(ctx context.Context, nsOpID string, poolLocat
 			RequestID:   nsOpID,
 			Signer:      transfer.Key,
 			Data:        string(data),
+			Config:      transfer.Config,
 		}).
 		SetError(&errRes).
 		Post("/api/v1/transfer")

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -154,7 +154,7 @@ type mintTokens struct {
 	RequestID   string `json:"requestId,omitempty"`
 	Signer      string `json:"signer"`
 	Data        string `json:"data,omitempty"`
-	URI         string `json:"uri"`
+	URI         string `json:"uri,omitempty"`
 }
 
 type burnTokens struct {

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -154,6 +154,7 @@ type mintTokens struct {
 	RequestID   string `json:"requestId,omitempty"`
 	Signer      string `json:"signer"`
 	Data        string `json:"data,omitempty"`
+	URI         string `json:"uri"`
 }
 
 type burnTokens struct {
@@ -663,6 +664,7 @@ func (ft *FFTokens) MintTokens(ctx context.Context, nsOpID string, poolLocator s
 			RequestID:   nsOpID,
 			Signer:      mint.Key,
 			Data:        string(data),
+			URI:         mint.URI,
 		}).
 		SetError(&errRes).
 		Post("/api/v1/mint")

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -535,6 +535,7 @@ func TestMintTokens(t *testing.T) {
 			ID:   fftypes.NewUUID(),
 			Type: core.TransactionTypeTokenTransfer,
 		},
+		URI: "FLAPFLIP",
 	}
 	opID := fftypes.NewUUID()
 	nsOpID := "ns1:" + opID.String()
@@ -554,6 +555,7 @@ func TestMintTokens(t *testing.T) {
 					"tx":     mint.TX.ID.String(),
 					"txtype": core.TransactionTypeTokenTransfer.String(),
 				}.String(),
+				"uri": "FLAPFLIP",
 			}, body)
 
 			res := &http.Response{

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -536,6 +536,9 @@ func TestMintTokens(t *testing.T) {
 			Type: core.TransactionTypeTokenTransfer,
 		},
 		URI: "FLAPFLIP",
+		Config: fftypes.JSONObject{
+			"foo": "bar",
+		},
 	}
 	opID := fftypes.NewUUID()
 	nsOpID := "ns1:" + opID.String()
@@ -550,7 +553,10 @@ func TestMintTokens(t *testing.T) {
 				"to":          "user1",
 				"amount":      "10",
 				"signer":      "0x123",
-				"requestId":   "ns1:" + opID.String(),
+				"config": map[string]interface{}{
+					"foo": "bar",
+				},
+				"requestId": "ns1:" + opID.String(),
 				"data": fftypes.JSONObject{
 					"tx":     mint.TX.ID.String(),
 					"txtype": core.TransactionTypeTokenTransfer.String(),
@@ -668,6 +674,9 @@ func TestBurnTokens(t *testing.T) {
 			ID:   fftypes.NewUUID(),
 			Type: core.TransactionTypeTokenTransfer,
 		},
+		Config: fftypes.JSONObject{
+			"foo": "bar",
+		},
 	}
 	opID := fftypes.NewUUID()
 	nsOpID := "ns1:" + opID.String()
@@ -683,7 +692,10 @@ func TestBurnTokens(t *testing.T) {
 				"from":        "user1",
 				"amount":      "10",
 				"signer":      "0x123",
-				"requestId":   "ns1:" + opID.String(),
+				"config": map[string]interface{}{
+					"foo": "bar",
+				},
+				"requestId": "ns1:" + opID.String(),
 				"data": fftypes.JSONObject{
 					"tx":     burn.TX.ID.String(),
 					"txtype": core.TransactionTypeTokenTransfer.String(),
@@ -733,6 +745,9 @@ func TestTransferTokens(t *testing.T) {
 			ID:   fftypes.NewUUID(),
 			Type: core.TransactionTypeTokenTransfer,
 		},
+		Config: fftypes.JSONObject{
+			"foo": "bar",
+		},
 	}
 	opID := fftypes.NewUUID()
 	nsOpID := "ns1:" + opID.String()
@@ -749,7 +764,10 @@ func TestTransferTokens(t *testing.T) {
 				"to":          "user2",
 				"amount":      "10",
 				"signer":      "0x123",
-				"requestId":   "ns1:" + opID.String(),
+				"config": map[string]interface{}{
+					"foo": "bar",
+				},
+				"requestId": "ns1:" + opID.String(),
 				"data": fftypes.JSONObject{
 					"tx":     transfer.TX.ID.String(),
 					"txtype": core.TransactionTypeTokenTransfer.String(),

--- a/pkg/core/tokentransfer.go
+++ b/pkg/core/tokentransfer.go
@@ -27,23 +27,24 @@ var (
 )
 
 type TokenTransfer struct {
-	Type            TokenTransferType `ffstruct:"TokenTransfer" json:"type" ffenum:"tokentransfertype" ffexcludeinput:"true"`
-	LocalID         *fftypes.UUID     `ffstruct:"TokenTransfer" json:"localId,omitempty" ffexcludeinput:"true"`
-	Pool            *fftypes.UUID     `ffstruct:"TokenTransfer" json:"pool,omitempty"`
-	TokenIndex      string            `ffstruct:"TokenTransfer" json:"tokenIndex,omitempty"`
-	URI             string            `ffstruct:"TokenTransfer" json:"uri,omitempty"`
-	Connector       string            `ffstruct:"TokenTransfer" json:"connector,omitempty" ffexcludeinput:"true"`
-	Namespace       string            `ffstruct:"TokenTransfer" json:"namespace,omitempty" ffexcludeinput:"true"`
-	Key             string            `ffstruct:"TokenTransfer" json:"key,omitempty"`
-	From            string            `ffstruct:"TokenTransfer" json:"from,omitempty" ffexcludeinput:"postTokenMint"`
-	To              string            `ffstruct:"TokenTransfer" json:"to,omitempty" ffexcludeinput:"postTokenBurn"`
-	Amount          fftypes.FFBigInt  `ffstruct:"TokenTransfer" json:"amount"`
-	ProtocolID      string            `ffstruct:"TokenTransfer" json:"protocolId,omitempty" ffexcludeinput:"true"`
-	Message         *fftypes.UUID     `ffstruct:"TokenTransfer" json:"message,omitempty"`
-	MessageHash     *fftypes.Bytes32  `ffstruct:"TokenTransfer" json:"messageHash,omitempty" ffexcludeinput:"true"`
-	Created         *fftypes.FFTime   `ffstruct:"TokenTransfer" json:"created,omitempty" ffexcludeinput:"true"`
-	TX              TransactionRef    `ffstruct:"TokenTransfer" json:"tx" ffexcludeinput:"true"`
-	BlockchainEvent *fftypes.UUID     `ffstruct:"TokenTransfer" json:"blockchainEvent,omitempty" ffexcludeinput:"true"`
+	Type            TokenTransferType  `ffstruct:"TokenTransfer" json:"type" ffenum:"tokentransfertype" ffexcludeinput:"true"`
+	LocalID         *fftypes.UUID      `ffstruct:"TokenTransfer" json:"localId,omitempty" ffexcludeinput:"true"`
+	Pool            *fftypes.UUID      `ffstruct:"TokenTransfer" json:"pool,omitempty"`
+	TokenIndex      string             `ffstruct:"TokenTransfer" json:"tokenIndex,omitempty"`
+	URI             string             `ffstruct:"TokenTransfer" json:"uri,omitempty"`
+	Connector       string             `ffstruct:"TokenTransfer" json:"connector,omitempty" ffexcludeinput:"true"`
+	Namespace       string             `ffstruct:"TokenTransfer" json:"namespace,omitempty" ffexcludeinput:"true"`
+	Key             string             `ffstruct:"TokenTransfer" json:"key,omitempty"`
+	From            string             `ffstruct:"TokenTransfer" json:"from,omitempty" ffexcludeinput:"postTokenMint"`
+	To              string             `ffstruct:"TokenTransfer" json:"to,omitempty" ffexcludeinput:"postTokenBurn"`
+	Amount          fftypes.FFBigInt   `ffstruct:"TokenTransfer" json:"amount"`
+	ProtocolID      string             `ffstruct:"TokenTransfer" json:"protocolId,omitempty" ffexcludeinput:"true"`
+	Message         *fftypes.UUID      `ffstruct:"TokenTransfer" json:"message,omitempty"`
+	MessageHash     *fftypes.Bytes32   `ffstruct:"TokenTransfer" json:"messageHash,omitempty" ffexcludeinput:"true"`
+	Created         *fftypes.FFTime    `ffstruct:"TokenTransfer" json:"created,omitempty" ffexcludeinput:"true"`
+	TX              TransactionRef     `ffstruct:"TokenTransfer" json:"tx" ffexcludeinput:"true"`
+	BlockchainEvent *fftypes.UUID      `ffstruct:"TokenTransfer" json:"blockchainEvent,omitempty" ffexcludeinput:"true"`
+	Config          fftypes.JSONObject `ffstruct:"TokenTransfer" json:"config,omitempty" ffexcludeoutput:"true"` // for REST calls only (not stored)
 }
 
 type TokenTransferInput struct {

--- a/pkg/core/tokentransfer.go
+++ b/pkg/core/tokentransfer.go
@@ -31,7 +31,7 @@ type TokenTransfer struct {
 	LocalID         *fftypes.UUID     `ffstruct:"TokenTransfer" json:"localId,omitempty" ffexcludeinput:"true"`
 	Pool            *fftypes.UUID     `ffstruct:"TokenTransfer" json:"pool,omitempty"`
 	TokenIndex      string            `ffstruct:"TokenTransfer" json:"tokenIndex,omitempty"`
-	URI             string            `ffstruct:"TokenTransfer" json:"uri,omitempty" ffexcludeinput:"true"`
+	URI             string            `ffstruct:"TokenTransfer" json:"uri,omitempty"`
 	Connector       string            `ffstruct:"TokenTransfer" json:"connector,omitempty" ffexcludeinput:"true"`
 	Namespace       string            `ffstruct:"TokenTransfer" json:"namespace,omitempty" ffexcludeinput:"true"`
 	Key             string            `ffstruct:"TokenTransfer" json:"key,omitempty"`


### PR DESCRIPTION
These changes also include added an optional `config` parameter, that is passed to directly to the token connectors without validation. 