### PR TITLE
Deprecate default value for "ffdx"

### DIFF
--- a/internal/coreconfig/coreconfig.go
+++ b/internal/coreconfig/coreconfig.go
@@ -312,7 +312,6 @@ func setDefaults() {
 	viper.SetDefault(string(CorsAllowedOrigins), []string{"*"})
 	viper.SetDefault(string(CorsEnabled), true)
 	viper.SetDefault(string(CorsMaxAge), 600)
-	viper.SetDefault(string(DataexchangeType), "ffdx")
 	viper.SetDefault(string(HistogramsMaxChartRows), 100)
 	viper.SetDefault(string(DebugPort), -1)
 	viper.SetDefault(string(DownloadWorkerCount), 10)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -359,6 +359,10 @@ func (or *orchestrator) initDatabaseCheckPreinit(ctx context.Context) (err error
 
 func (or *orchestrator) initDataExchange(ctx context.Context) (err error) {
 	dxPlugin := config.GetString(coreconfig.DataexchangeType)
+	if dxPlugin == "" {
+		dxPlugin = "ffdx"
+		log.L(ctx).Warnf("The default value for %s has been deprecated - please explicitly set it to \"ffdx\"", coreconfig.DataexchangeType)
+	}
 	if or.dataexchange == nil {
 		pluginName := dxPlugin
 		if or.dataexchange, err = dxfactory.GetPlugin(ctx, pluginName); err != nil {


### PR DESCRIPTION
This default value will be totally removed in v1.1+ due to #878. Deprecating it on the v1.0.x train will give a cleaner migration path forward.