### PR TITLE
docker workflow for release-1.0 branch

### DIFF
--- a/.github/workflows/docker_release_branch.yml
+++ b/.github/workflows/docker_release_branch.yml
@@ -1,0 +1,37 @@
+name: Docker Release Branch Build
+
+on:
+  push:
+    branches:
+      - release-1.0
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set build tag
+        id: build_tag_generator
+        run: |
+          RELEASE_TAG=$(curl https://api.github.com/repos/hyperledger/firefly/releases/latest -s | jq .tag_name -r)
+          BUILD_TAG=$RELEASE_TAG-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER
+          echo ::set-output name=BUILD_TAG::$BUILD_TAG
+
+      - name: Build
+        run: |
+          make DOCKER_ARGS="\
+            --build-arg BUILD_VERSION=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
+            --build-arg GIT_REF=$GITHUB_SHA \
+            --label commit=$GITHUB_SHA \
+            --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+            --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
+            --tag ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }}" \
+            docker
+
+      - name: Push docker image
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker push ghcr.io/hyperledger/firefly:${{ steps.build_tag_generator.outputs.BUILD_TAG }}


### PR DESCRIPTION
This workflow will build and push docker images off of the `release-1.0` branch. These images can then be used for running integration tests.