### PR TITLE
Support tokens only namespaces

### DIFF
--- a/internal/apiserver/route_get_contract_api_by_name.go
+++ b/internal/apiserver/route_get_contract_api_by_name.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -37,6 +38,9 @@ var getContractAPIByName = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.ContractAPI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return cr.or.Contracts().GetContractAPI(cr.ctx, cr.apiBaseURL, r.PP["apiName"])
 		},

--- a/internal/apiserver/route_get_contract_api_interface.go
+++ b/internal/apiserver/route_get_contract_api_interface.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 )
 
 var getContractAPIInterface = &ffapi.Route{
@@ -37,6 +38,9 @@ var getContractAPIInterface = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return cr.or.Contracts().GetContractAPIInterface(cr.ctx, r.PP["apiName"])
 		},

--- a/internal/apiserver/route_get_contract_api_listeners.go
+++ b/internal/apiserver/route_get_contract_api_listeners.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/hyperledger/firefly/pkg/database"
 )
@@ -39,6 +40,9 @@ var getContractAPIListeners = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return []*core.ContractListener{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		FilterFactory: database.ContractListenerQueryFactory,
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return filterResult(cr.or.Contracts().GetContractAPIListeners(cr.ctx, r.PP["apiName"], r.PP["eventPath"], cr.filter))

--- a/internal/apiserver/route_get_contract_apis.go
+++ b/internal/apiserver/route_get_contract_apis.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/hyperledger/firefly/pkg/database"
 )
@@ -36,6 +37,9 @@ var getContractAPIs = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return []*core.ContractAPI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		FilterFactory: database.ContractAPIQueryFactory,
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return filterResult(cr.or.Contracts().GetContractAPIs(cr.ctx, cr.apiBaseURL, cr.filter))

--- a/internal/apiserver/route_get_contract_interface.go
+++ b/internal/apiserver/route_get_contract_interface.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 )
 
 var getContractInterface = &ffapi.Route{
@@ -40,6 +41,9 @@ var getContractInterface = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			interfaceID, err := fftypes.ParseUUID(cr.ctx, r.PP["interfaceId"])
 			if err != nil {

--- a/internal/apiserver/route_get_contract_interface_name_version.go
+++ b/internal/apiserver/route_get_contract_interface_name_version.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 )
 
 var getContractInterfaceNameVersion = &ffapi.Route{
@@ -41,6 +42,9 @@ var getContractInterfaceNameVersion = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			if strings.EqualFold(r.QP["fetchchildren"], "true") {
 				return cr.or.Contracts().GetFFIWithChildren(cr.ctx, r.PP["name"], r.PP["version"])

--- a/internal/apiserver/route_get_contract_interface_test.go
+++ b/internal/apiserver/route_get_contract_interface_test.go
@@ -32,6 +32,7 @@ import (
 func TestGetContractInterfaceBadID(t *testing.T) {
 	o, r := newTestAPIServer()
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	input := core.Datatype{}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(&input)

--- a/internal/apiserver/route_get_contract_interfaces.go
+++ b/internal/apiserver/route_get_contract_interfaces.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/database"
 )
 
@@ -36,6 +37,9 @@ var getContractInterfaces = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return []*fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		FilterFactory: database.FFIQueryFactory,
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return filterResult(cr.or.Contracts().GetFFIs(cr.ctx, cr.filter))

--- a/internal/apiserver/route_get_contract_listener_by_name_or_id.go
+++ b/internal/apiserver/route_get_contract_listener_by_name_or_id.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -37,6 +38,9 @@ var getContractListenerByNameOrID = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.ContractListener{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return cr.or.Contracts().GetContractListenerByNameOrID(cr.ctx, r.PP["nameOrId"])
 		},

--- a/internal/apiserver/route_get_contract_listeners.go
+++ b/internal/apiserver/route_get_contract_listeners.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/hyperledger/firefly/pkg/database"
 )
@@ -36,6 +37,9 @@ var getContractListeners = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return []*core.ContractListener{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		FilterFactory: database.ContractListenerQueryFactory,
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return filterResult(cr.or.Contracts().GetContractListeners(cr.ctx, cr.filter))

--- a/internal/apiserver/route_post_contract_api_invoke.go
+++ b/internal/apiserver/route_post_contract_api_invoke.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -41,6 +42,9 @@ var postContractAPIInvoke = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.Operation{} },
 	JSONOutputCodes: []int{http.StatusOK, http.StatusAccepted},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)

--- a/internal/apiserver/route_post_contract_api_listeners.go
+++ b/internal/apiserver/route_post_contract_api_listeners.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -38,6 +39,9 @@ var postContractAPIListeners = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.ContractListener{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return cr.or.Contracts().AddContractAPIListener(cr.ctx, r.PP["apiName"], r.PP["eventPath"], r.Input.(*core.ContractListener))
 		},

--- a/internal/apiserver/route_post_contract_api_query.go
+++ b/internal/apiserver/route_post_contract_api_query.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -38,6 +39,9 @@ var postContractAPIQuery = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return make(map[string]interface{}) },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			req := r.Input.(*core.ContractCallRequest)
 			req.Type = core.CallTypeQuery

--- a/internal/apiserver/route_post_contract_interface_generate.go
+++ b/internal/apiserver/route_post_contract_interface_generate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 )
 
 var postContractInterfaceGenerate = &ffapi.Route{
@@ -35,6 +36,9 @@ var postContractInterfaceGenerate = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			generationRequest := r.Input.(*fftypes.FFIGenerationRequest)
 			return cr.or.Contracts().GenerateFFI(cr.ctx, generationRequest)

--- a/internal/apiserver/route_post_contract_invoke.go
+++ b/internal/apiserver/route_post_contract_invoke.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -38,6 +39,9 @@ var postContractInvoke = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.Operation{} },
 	JSONOutputCodes: []int{http.StatusOK, http.StatusAccepted},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)

--- a/internal/apiserver/route_post_contract_query.go
+++ b/internal/apiserver/route_post_contract_query.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -35,6 +36,9 @@ var postContractQuery = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return make(map[string]interface{}) },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			req := r.Input.(*core.ContractCallRequest)
 			req.Type = core.CallTypeQuery

--- a/internal/apiserver/route_post_new_contract_api.go
+++ b/internal/apiserver/route_post_new_contract_api.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -38,6 +39,9 @@ var postNewContractAPI = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.ContractAPI{} },
 	JSONOutputCodes: []int{http.StatusOK, http.StatusAccepted},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)

--- a/internal/apiserver/route_post_new_contract_api_test.go
+++ b/internal/apiserver/route_post_new_contract_api_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hyperledger/firefly/mocks/contractmocks"
 	"github.com/hyperledger/firefly/mocks/definitionsmocks"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,7 @@ func TestPostNewContractAPI(t *testing.T) {
 	o, r := newTestAPIServer()
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	o.On("DefinitionSender").Return(mds)
 	input := core.Datatype{}
 	var buf bytes.Buffer
@@ -50,6 +52,7 @@ func TestPostNewContractAPISync(t *testing.T) {
 	o, r := newTestAPIServer()
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	o.On("DefinitionSender").Return(mds)
 	input := core.Datatype{}
 	var buf bytes.Buffer

--- a/internal/apiserver/route_post_new_contract_interface.go
+++ b/internal/apiserver/route_post_new_contract_interface.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 )
 
 var postNewContractInterface = &ffapi.Route{
@@ -38,6 +39,9 @@ var postNewContractInterface = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &fftypes.FFI{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)

--- a/internal/apiserver/route_post_new_contract_interface_test.go
+++ b/internal/apiserver/route_post_new_contract_interface_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hyperledger/firefly/mocks/contractmocks"
 	"github.com/hyperledger/firefly/mocks/definitionsmocks"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,7 @@ func TestPostNewContractInterface(t *testing.T) {
 	o, r := newTestAPIServer()
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	o.On("DefinitionSender").Return(mds)
 	input := core.Datatype{}
 	var buf bytes.Buffer
@@ -50,6 +52,7 @@ func TestPostNewContractInterfaceSync(t *testing.T) {
 	o, r := newTestAPIServer()
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	o.On("DefinitionSender").Return(mds)
 	input := core.Datatype{}
 	var buf bytes.Buffer

--- a/internal/apiserver/route_post_new_contract_listener.go
+++ b/internal/apiserver/route_post_new_contract_listener.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -35,6 +36,9 @@ var postNewContractListener = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.ContractListener{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			return cr.or.Contracts().AddContractListener(cr.ctx, r.Input.(*core.ContractListenerInput))
 		},

--- a/internal/apiserver/route_put_contract_api.go
+++ b/internal/apiserver/route_put_contract_api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -41,6 +42,9 @@ var putContractAPI = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.ContractAPI{} },
 	JSONOutputCodes: []int{http.StatusOK, http.StatusAccepted},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.Contracts() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)

--- a/internal/apiserver/route_put_contract_api_test.go
+++ b/internal/apiserver/route_put_contract_api_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hyperledger/firefly/mocks/contractmocks"
 	"github.com/hyperledger/firefly/mocks/definitionsmocks"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,7 @@ func TestPutContractAPI(t *testing.T) {
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
 	o.On("DefinitionSender").Return(mds)
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	input := core.Datatype{}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(&input)
@@ -51,6 +53,7 @@ func TestPutContractAPISync(t *testing.T) {
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
 	o.On("DefinitionSender").Return(mds)
+	o.On("Contracts").Return(&contractmocks.Manager{})
 	input := core.Datatype{}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(&input)

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -256,4 +256,5 @@ var (
 	MsgActionNotSupported                 = ffe("FF10414", "This action is not supported in this namespace", 400)
 	MsgMessagesNotSupported               = ffe("FF10415", "Messages are not supported in this namespace", 400)
 	MsgInvalidSubscriptionForNetwork      = ffe("FF10416", "Subscription name '%s' is invalid according to multiparty network rules in effect (network version=%d)")
+	MsgBlockchainNotConfigured            = ffe("FF10417", "No blockchain plugin configured", 400)
 )

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -256,5 +256,5 @@ var (
 	MsgActionNotSupported                 = ffe("FF10414", "This action is not supported in this namespace", 400)
 	MsgMessagesNotSupported               = ffe("FF10415", "Messages are not supported in this namespace", 400)
 	MsgInvalidSubscriptionForNetwork      = ffe("FF10416", "Subscription name '%s' is invalid according to multiparty network rules in effect (network version=%d)")
-	MsgBlockchainNotConfigured            = ffe("FF10417", "No blockchain plugin configured", 400)
+	MsgBlockchainNotConfigured            = ffe("FF10417", "No blockchain plugin configured")
 )

--- a/internal/definitions/handler.go
+++ b/internal/definitions/handler.go
@@ -80,16 +80,16 @@ type definitionHandler struct {
 	namespace  string
 	multiparty bool
 	database   database.Plugin
-	blockchain blockchain.Plugin
+	blockchain blockchain.Plugin   // optional
 	exchange   dataexchange.Plugin // optional
 	data       data.Manager
 	identity   identity.Manager
 	assets     assets.Manager
-	contracts  contracts.Manager
+	contracts  contracts.Manager // optional
 }
 
 func newDefinitionHandler(ctx context.Context, ns string, multiparty bool, di database.Plugin, bi blockchain.Plugin, dx dataexchange.Plugin, dm data.Manager, im identity.Manager, am assets.Manager, cm contracts.Manager) (*definitionHandler, error) {
-	if di == nil || bi == nil || dm == nil || im == nil || am == nil || cm == nil {
+	if di == nil || dm == nil || im == nil || am == nil {
 		return nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError, "DefinitionHandler")
 	}
 	return &definitionHandler{

--- a/internal/definitions/sender.go
+++ b/internal/definitions/sender.go
@@ -53,7 +53,7 @@ type definitionSender struct {
 	broadcast  broadcast.Manager // optional
 	identity   identity.Manager
 	data       data.Manager
-	contracts  contracts.Manager
+	contracts  contracts.Manager // optional
 	handler    *definitionHandler
 }
 
@@ -71,8 +71,8 @@ func fakeBatch(ctx context.Context, handler func(context.Context, *core.BatchSta
 }
 
 func NewDefinitionSender(ctx context.Context, ns string, multiparty bool, di database.Plugin, bi blockchain.Plugin, dx dataexchange.Plugin, bm broadcast.Manager, im identity.Manager, dm data.Manager, am assets.Manager, cm contracts.Manager) (Sender, Handler, error) {
-	if di == nil || im == nil || dm == nil || cm == nil {
-		return nil, nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError)
+	if di == nil || im == nil || dm == nil {
+		return nil, nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError, "DefinitionSender")
 	}
 	ds := &definitionSender{
 		ctx:        ctx,

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -99,12 +99,12 @@ type eventManager struct {
 	data                  data.Manager
 	subManager            *subscriptionManager
 	retry                 retry.Retry
-	aggregator            *aggregator
+	aggregator            *aggregator              // optional
 	broadcast             broadcast.Manager        // optional
 	messaging             privatemessaging.Manager // optional
 	assets                assets.Manager
 	sharedDownload        shareddownload.Manager // optional
-	blobReceiver          *blobReceiver
+	blobReceiver          *blobReceiver          // optional
 	newEventNotifier      *eventNotifier
 	newPinNotifier        *eventNotifier
 	defaultTransport      string
@@ -116,7 +116,7 @@ type eventManager struct {
 }
 
 func NewEventManager(ctx context.Context, ns string, ni sysmessaging.LocalNodeInfo, di database.Plugin, bi blockchain.Plugin, im identity.Manager, dh definitions.Handler, dm data.Manager, ds definitions.Sender, bm broadcast.Manager, pm privatemessaging.Manager, am assets.Manager, sd shareddownload.Manager, mm metrics.Manager, txHelper txcommon.Helper, transports map[string]events.Plugin, mp multiparty.Manager) (EventManager, error) {
-	if ni == nil || di == nil || bi == nil || im == nil || dh == nil || dm == nil || ds == nil || am == nil {
+	if ni == nil || di == nil || im == nil || dh == nil || dm == nil || ds == nil || am == nil {
 		return nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError, "EventManager")
 	}
 	newPinNotifier := newEventNotifier(ctx, "pins")
@@ -144,14 +144,16 @@ func NewEventManager(ctx context.Context, ns string, ni sysmessaging.LocalNodeIn
 		defaultTransport:      config.GetString(coreconfig.EventTransportsDefault),
 		newEventNotifier:      newEventNotifier,
 		newPinNotifier:        newPinNotifier,
-		aggregator:            newAggregator(ctx, ns, di, bi, pm, dh, im, dm, newPinNotifier, mm),
 		metrics:               mm,
 		chainListenerCache:    ccache.New(ccache.Configure().MaxSize(config.GetByteSize(coreconfig.EventListenerTopicCacheSize))),
 		chainListenerCacheTTL: config.GetDuration(coreconfig.EventListenerTopicCacheTTL),
 	}
 	ie, _ := eifactory.GetPlugin(ctx, system.SystemEventsTransport)
 	em.internalEvents = ie.(*system.Events)
-	em.blobReceiver = newBlobReceiver(ctx, em.aggregator)
+	if bi != nil {
+		em.aggregator = newAggregator(ctx, ns, di, bi, pm, dh, im, dm, newPinNotifier, mm)
+		em.blobReceiver = newBlobReceiver(ctx, em.aggregator)
+	}
 
 	var err error
 	if em.subManager, err = newSubscriptionManager(ctx, ns, di, dm, newEventNotifier, bm, pm, txHelper, transports); err != nil {
@@ -164,8 +166,10 @@ func NewEventManager(ctx context.Context, ns string, ni sysmessaging.LocalNodeIn
 func (em *eventManager) Start() (err error) {
 	err = em.subManager.start()
 	if err == nil {
-		em.aggregator.start()
-		em.blobReceiver.start()
+		if em.aggregator != nil {
+			em.aggregator.start()
+			em.blobReceiver.start()
+		}
 	}
 	return err
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -458,10 +458,12 @@ func (or *orchestrator) initManagers(ctx context.Context) (err error) {
 		}
 	}
 
-	if or.contracts == nil {
-		or.contracts, err = contracts.NewContractManager(ctx, or.namespace, or.database(), or.blockchain(), or.identity, or.operations, or.txHelper, or.syncasync)
-		if err != nil {
-			return err
+	if or.blockchain() != nil {
+		if or.contracts == nil {
+			or.contracts, err = contracts.NewContractManager(ctx, or.namespace, or.database(), or.blockchain(), or.identity, or.operations, or.txHelper, or.syncasync)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Now, multiparty-disabled namespaces can run without a blockchain plugin:
 * All contract routes will be disabled
 * Identity normalizations that rely on a blockchain plugin will either default to the specified input/default key or fail
 * `aggregator` is not started within `EventManager`