### PR TITLE
Add node-specific suffix to DX endpoint "id"

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -201,13 +201,6 @@ func (e *Ethereum) AddFireflySubscription(ctx context.Context, namespace core.Na
 		return "", err
 	}
 
-	switch firstEvent {
-	case string(core.SubOptsFirstEventOldest):
-		firstEvent = "0"
-	case string(core.SubOptsFirstEventNewest):
-		firstEvent = "latest"
-	}
-
 	version, err := e.GetNetworkVersion(ctx, location)
 	if err != nil {
 		return "", err

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -290,7 +290,7 @@ func (dm *dataManager) getMessageData(ctx context.Context, msg *core.Message) (d
 			return nil, false, err
 		}
 		if d == nil {
-			log.L(ctx).Warnf("Message %v data %d mising", msg.Header.ID, i)
+			log.L(ctx).Warnf("Message %v data %d missing", msg.Header.ID, i)
 			foundAll = false
 			continue
 		}

--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -126,6 +126,7 @@ type sendMessage struct {
 	Message   string `json:"message"`
 	Recipient string `json:"recipient"`
 	RequestID string `json:"requestId"`
+	Sender    string `json:"sender"`
 }
 
 type transferBlob struct {
@@ -299,7 +300,7 @@ func (h *FFDX) DownloadBlob(ctx context.Context, payloadRef string) (content io.
 	return res.RawBody(), nil
 }
 
-func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID string, data []byte) (err error) {
+func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID string, senderID string, data []byte) (err error) {
 	if err := h.checkInitialized(ctx); err != nil {
 		return err
 	}
@@ -310,6 +311,7 @@ func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID string, data []by
 			Message:   string(data),
 			Recipient: peerID,
 			RequestID: nsOpID,
+			Sender:    senderID,
 		}).
 		SetResult(&responseData).
 		Post("/api/v1/messages")

--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -50,7 +48,6 @@ type FFDX struct {
 	initialized  bool
 	initMutex    sync.Mutex
 	nodes        map[string]*dxNode
-	nodesMutex   sync.Mutex
 	ackChannel   chan *ack
 }
 
@@ -76,9 +73,12 @@ func (cb *callbacks) OperationUpdate(ctx context.Context, update *core.Operation
 }
 
 func (cb *callbacks) DXEvent(ctx context.Context, namespace, recipient string, event dataexchange.DXEvent) {
-	cb.plugin.nodesMutex.Lock()
-	if node, ok := cb.plugin.nodes[recipient]; ok {
-		cb.plugin.nodesMutex.Unlock()
+	cb.plugin.initMutex.Lock()
+	nodeKey := namespace + ":" + recipient
+	node, ok := cb.plugin.nodes[nodeKey]
+	cb.plugin.initMutex.Unlock()
+
+	if ok {
 		key := namespace + ":" + node.Name
 		if handler, ok := cb.handlers[key]; ok {
 			handler.DXEvent(cb.plugin, event)
@@ -87,7 +87,6 @@ func (cb *callbacks) DXEvent(ctx context.Context, namespace, recipient string, e
 			event.Ack()
 		}
 	} else {
-		cb.plugin.nodesMutex.Unlock()
 		log.L(ctx).Errorf("Unknown local node for DX event '%s' recipient=%s", event.EventID(), recipient)
 		event.Ack()
 	}
@@ -110,11 +109,6 @@ func splitBlobPath(path string) (prefix, namespace, id string) {
 func joinBlobPath(namespace, id string) string {
 	return fmt.Sprintf("%s/%s", namespace, id)
 }
-
-const (
-	dxHTTPHeaderHash = "dx-hash"
-	dxHTTPHeaderSize = "dx-size"
-)
 
 type msgType string
 
@@ -203,14 +197,6 @@ func (h *FFDX) Init(ctx context.Context, config config.Section) (err error) {
 	return nil
 }
 
-func (h *FFDX) InitPeer(nodeName string, peer fftypes.JSONObject) {
-	id := peer.GetString("id")
-	h.nodes[id] = &dxNode{
-		Name: nodeName,
-		Peer: peer,
-	}
-}
-
 func (h *FFDX) SetHandler(remoteNamespace, nodeName string, handler dataexchange.Callbacks) {
 	key := remoteNamespace + ":" + nodeName
 	h.callbacks.handlers[key] = handler
@@ -236,11 +222,9 @@ func (h *FFDX) beforeConnect(ctx context.Context) error {
 		h.initialized = false
 		var status dxStatus
 		var body []fftypes.JSONObject
-		h.nodesMutex.Lock()
 		for _, node := range h.nodes {
 			body = append(body, node.Peer)
 		}
-		h.nodesMutex.Unlock()
 		res, err := h.client.R().SetContext(ctx).
 			SetBody(body).
 			SetResult(&status).
@@ -266,11 +250,15 @@ func (h *FFDX) checkInitialized(ctx context.Context) error {
 	return nil
 }
 
-func (h *FFDX) GetEndpointInfo(ctx context.Context, nodeName string) (peer fftypes.JSONObject, err error) {
-	if err := h.checkInitialized(ctx); err != nil {
-		return peer, err
+func (h *FFDX) GetPeerID(peer fftypes.JSONObject) string {
+	id := peer.GetString("nodeID")
+	if id == "" {
+		id = peer.GetString("id")
 	}
+	return id
+}
 
+func (h *FFDX) GetEndpointInfo(ctx context.Context, nodeName string) (peer fftypes.JSONObject, err error) {
 	res, err := h.client.R().SetContext(ctx).
 		SetResult(&peer).
 		Get("/api/v1/id")
@@ -282,31 +270,29 @@ func (h *FFDX) GetEndpointInfo(ctx context.Context, nodeName string) (peer fftyp
 		log.L(ctx).Errorf("Invalid DX info: %s", peer.String())
 		return nil, i18n.NewError(ctx, coremsgs.MsgDXInfoMissingID)
 	}
-	peer["peerID"] = id
-	peer["id"] = fmt.Sprintf("%s%s%s", id, DXIDSeparator, nodeName)
+	peer["nodeID"] = fmt.Sprintf("%s%s%s", id, DXIDSeparator, nodeName)
 	return peer, nil
 }
 
-func (h *FFDX) AddPeer(ctx context.Context, nodeName string, peer fftypes.JSONObject) (err error) {
-	if err := h.checkInitialized(ctx); err != nil {
-		return err
+func (h *FFDX) AddNode(ctx context.Context, remoteNamespace, nodeName string, peer fftypes.JSONObject) (err error) {
+	h.initMutex.Lock()
+	defer h.initMutex.Unlock()
+
+	key := remoteNamespace + ":" + h.GetPeerID(peer)
+	h.nodes[key] = &dxNode{
+		Peer: peer,
+		Name: nodeName,
 	}
 
-	id := peer.GetString("peerID")
-	if id == "" {
-		id = peer.GetString("id")
+	if h.initialized {
+		res, err := h.client.R().SetContext(ctx).
+			SetBody(peer).
+			Put(fmt.Sprintf("/api/v1/peers/%s", peer.GetString("id")))
+		if err != nil || !res.IsSuccess() {
+			return ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgDXRESTErr)
+		}
 	}
 
-	h.nodesMutex.Lock()
-	defer h.nodesMutex.Unlock()
-
-	res, err := h.client.R().SetContext(ctx).
-		SetBody(peer).
-		Put(fmt.Sprintf("/api/v1/peers/%s", id))
-	if err != nil || !res.IsSuccess() {
-		return ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgDXRESTErr)
-	}
-	h.InitPeer(nodeName, peer)
 	return nil
 }
 
@@ -340,7 +326,7 @@ func (h *FFDX) DownloadBlob(ctx context.Context, payloadRef string) (content io.
 	return res.RawBody(), nil
 }
 
-func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID, senderID string, data []byte) (err error) {
+func (h *FFDX) SendMessage(ctx context.Context, nsOpID string, peer, sender fftypes.JSONObject, data []byte) (err error) {
 	if err := h.checkInitialized(ctx); err != nil {
 		return err
 	}
@@ -349,9 +335,9 @@ func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID, senderID string,
 	res, err := h.client.R().SetContext(ctx).
 		SetBody(&sendMessage{
 			Message:   string(data),
-			Recipient: peerID,
+			Recipient: h.GetPeerID(peer),
 			RequestID: nsOpID,
-			Sender:    senderID,
+			Sender:    h.GetPeerID(sender),
 		}).
 		SetResult(&responseData).
 		Post("/api/v1/messages")
@@ -361,7 +347,7 @@ func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID, senderID string,
 	return nil
 }
 
-func (h *FFDX) TransferBlob(ctx context.Context, nsOpID, peerID, senderID, payloadRef string) (err error) {
+func (h *FFDX) TransferBlob(ctx context.Context, nsOpID string, peer, sender fftypes.JSONObject, payloadRef string) (err error) {
 	if err := h.checkInitialized(ctx); err != nil {
 		return err
 	}
@@ -370,9 +356,9 @@ func (h *FFDX) TransferBlob(ctx context.Context, nsOpID, peerID, senderID, paylo
 	res, err := h.client.R().SetContext(ctx).
 		SetBody(&transferBlob{
 			Path:      fmt.Sprintf("/%s", payloadRef),
-			Recipient: peerID,
+			Recipient: h.GetPeerID(peer),
 			RequestID: nsOpID,
-			Sender:    senderID,
+			Sender:    h.GetPeerID(sender),
 		}).
 		SetResult(&responseData).
 		Post("/api/v1/transfers")
@@ -380,30 +366,6 @@ func (h *FFDX) TransferBlob(ctx context.Context, nsOpID, peerID, senderID, paylo
 		return ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgDXRESTErr)
 	}
 	return nil
-}
-
-func (h *FFDX) CheckBlobReceived(ctx context.Context, peerID, ns string, id fftypes.UUID) (hash *fftypes.Bytes32, size int64, err error) {
-	var responseData responseWithRequestID
-	res, err := h.client.R().SetContext(ctx).
-		SetResult(&responseData).
-		Head(fmt.Sprintf("/api/v1/blobs/%s/%s/%s", peerID, ns, id.String()))
-	if err == nil && res.StatusCode() == http.StatusNotFound {
-		return nil, -1, nil
-	}
-	if err != nil || !res.IsSuccess() {
-		return nil, -1, ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgDXRESTErr)
-	}
-	hashString := res.Header().Get(dxHTTPHeaderHash)
-	if hash, err = fftypes.ParseBytes32(ctx, hashString); err != nil {
-		return nil, -1, i18n.WrapError(ctx, err, coremsgs.MsgDXBadResponse, "hash", hashString)
-	}
-	sizeString := res.Header().Get(dxHTTPHeaderSize)
-	if sizeString != "" {
-		if size, err = strconv.ParseInt(sizeString, 10, 64); err != nil {
-			return nil, -1, i18n.WrapError(ctx, err, coremsgs.MsgDXBadResponse, "size", sizeString)
-		}
-	}
-	return hash, size, nil
 }
 
 func (h *FFDX) ackLoop() {

--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -150,6 +150,7 @@ type transferBlob struct {
 	Path      string `json:"path"`
 	Recipient string `json:"recipient"`
 	RequestID string `json:"requestId"`
+	Sender    string `json:"sender"`
 }
 
 type wsAck struct {
@@ -339,7 +340,7 @@ func (h *FFDX) DownloadBlob(ctx context.Context, payloadRef string) (content io.
 	return res.RawBody(), nil
 }
 
-func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID string, senderID string, data []byte) (err error) {
+func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID, senderID string, data []byte) (err error) {
 	if err := h.checkInitialized(ctx); err != nil {
 		return err
 	}
@@ -360,7 +361,7 @@ func (h *FFDX) SendMessage(ctx context.Context, nsOpID, peerID string, senderID 
 	return nil
 }
 
-func (h *FFDX) TransferBlob(ctx context.Context, nsOpID, peerID, payloadRef string) (err error) {
+func (h *FFDX) TransferBlob(ctx context.Context, nsOpID, peerID, senderID, payloadRef string) (err error) {
 	if err := h.checkInitialized(ctx); err != nil {
 		return err
 	}
@@ -371,6 +372,7 @@ func (h *FFDX) TransferBlob(ctx context.Context, nsOpID, peerID, payloadRef stri
 			Path:      fmt.Sprintf("/%s", payloadRef),
 			Recipient: peerID,
 			RequestID: nsOpID,
+			Sender:    senderID,
 		}).
 		SetResult(&responseData).
 		Post("/api/v1/transfers")

--- a/internal/dataexchange/ffdx/ffdx_test.go
+++ b/internal/dataexchange/ffdx/ffdx_test.go
@@ -453,7 +453,7 @@ func TestTransferBlob(t *testing.T) {
 	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/v1/transfers", httpURL),
 		httpmock.NewJsonResponderOrPanic(200, fftypes.JSONObject{}))
 
-	err := h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "ns1/id1")
+	err := h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", "ns1/id1")
 	assert.NoError(t, err)
 }
 
@@ -464,7 +464,7 @@ func TestTransferBlobError(t *testing.T) {
 	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/v1/transfers", httpURL),
 		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{}))
 
-	err := h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "ns1/id1")
+	err := h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", "ns1/id1")
 	assert.Regexp(t, "FF10229", err)
 }
 
@@ -781,7 +781,7 @@ func TestDXUninitialized(t *testing.T) {
 	err = h.AddPeer(context.Background(), "node1", fftypes.JSONObject{})
 	assert.Regexp(t, "FF10342", err)
 
-	err = h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "ns1/id1")
+	err = h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", "ns1/id1")
 	assert.Regexp(t, "FF10342", err)
 
 	err = h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", []byte(`some data`))

--- a/internal/dataexchange/ffdx/ffdx_test.go
+++ b/internal/dataexchange/ffdx/ffdx_test.go
@@ -430,7 +430,7 @@ func TestSendMessage(t *testing.T) {
 	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/v1/messages", httpURL),
 		httpmock.NewJsonResponderOrPanic(200, fftypes.JSONObject{}))
 
-	err := h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", []byte(`some data`))
+	err := h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", []byte(`some data`))
 	assert.NoError(t, err)
 }
 
@@ -441,7 +441,7 @@ func TestSendMessageError(t *testing.T) {
 	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/api/v1/message", httpURL),
 		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{}))
 
-	err := h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", []byte(`some data`))
+	err := h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", []byte(`some data`))
 	assert.Regexp(t, "FF10229", err)
 }
 
@@ -778,6 +778,6 @@ func TestDXUninitialized(t *testing.T) {
 	err = h.TransferBlob(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "ns1/id1")
 	assert.Regexp(t, "FF10342", err)
 
-	err = h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", []byte(`some data`))
+	err = h.SendMessage(context.Background(), "ns1:"+fftypes.NewUUID().String(), "peer1", "sender1", []byte(`some data`))
 	assert.Regexp(t, "FF10342", err)
 }

--- a/internal/definitions/handler.go
+++ b/internal/definitions/handler.go
@@ -77,33 +77,35 @@ func (dma DefinitionMessageAction) String() string {
 }
 
 type definitionHandler struct {
-	namespace  string
-	multiparty bool
-	database   database.Plugin
-	blockchain blockchain.Plugin   // optional
-	exchange   dataexchange.Plugin // optional
-	data       data.Manager
-	identity   identity.Manager
-	assets     assets.Manager
-	contracts  contracts.Manager // optional
-	tokenNames map[string]string // mapping of token connector remote name => name
+	namespace       string
+	remoteNamespace string
+	multiparty      bool
+	database        database.Plugin
+	blockchain      blockchain.Plugin   // optional
+	exchange        dataexchange.Plugin // optional
+	data            data.Manager
+	identity        identity.Manager
+	assets          assets.Manager
+	contracts       contracts.Manager // optional
+	tokenNames      map[string]string // mapping of token connector remote name => name
 }
 
-func newDefinitionHandler(ctx context.Context, ns string, multiparty bool, di database.Plugin, bi blockchain.Plugin, dx dataexchange.Plugin, dm data.Manager, im identity.Manager, am assets.Manager, cm contracts.Manager, tokenNames map[string]string) (*definitionHandler, error) {
+func newDefinitionHandler(ctx context.Context, ns, remoteNS string, multiparty bool, di database.Plugin, bi blockchain.Plugin, dx dataexchange.Plugin, dm data.Manager, im identity.Manager, am assets.Manager, cm contracts.Manager, tokenNames map[string]string) (*definitionHandler, error) {
 	if di == nil || dm == nil || im == nil || am == nil {
 		return nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError, "DefinitionHandler")
 	}
 	return &definitionHandler{
-		namespace:  ns,
-		multiparty: multiparty,
-		database:   di,
-		blockchain: bi,
-		exchange:   dx,
-		data:       dm,
-		identity:   im,
-		assets:     am,
-		contracts:  cm,
-		tokenNames: tokenNames,
+		namespace:       ns,
+		remoteNamespace: remoteNS,
+		multiparty:      multiparty,
+		database:        di,
+		blockchain:      bi,
+		exchange:        dx,
+		data:            dm,
+		identity:        im,
+		assets:          am,
+		contracts:       cm,
+		tokenNames:      tokenNames,
 	}, nil
 }
 

--- a/internal/definitions/handler_identity_claim.go
+++ b/internal/definitions/handler_identity_claim.go
@@ -89,7 +89,7 @@ func (dh *definitionHandler) getClaimVerifier(msg *identityMsgInfo, identity *co
 	switch identity.Type {
 	case core.IdentityTypeNode:
 		verifier.VerifierRef.Type = core.VerifierTypeFFDXPeerID
-		verifier.VerifierRef.Value = identity.Profile.GetString("id")
+		verifier.VerifierRef.Value = dh.exchange.GetPeerID(identity.Profile)
 	default:
 		verifier.VerifierRef.Type = dh.blockchain.VerifierType()
 		verifier.VerifierRef.Value = msg.Key
@@ -234,7 +234,7 @@ func (dh *definitionHandler) handleIdentityClaim(ctx context.Context, state *cor
 		state.AddPreFinalize(
 			func(ctx context.Context) error {
 				// Tell the data exchange about this node. Treat these errors like database errors - and return for retry processing
-				return dh.exchange.AddPeer(ctx, identity.Name, identity.Profile)
+				return dh.exchange.AddNode(ctx, dh.remoteNamespace, identity.Name, identity.Profile)
 			})
 	}
 

--- a/internal/definitions/handler_identity_claim.go
+++ b/internal/definitions/handler_identity_claim.go
@@ -234,7 +234,7 @@ func (dh *definitionHandler) handleIdentityClaim(ctx context.Context, state *cor
 		state.AddPreFinalize(
 			func(ctx context.Context) error {
 				// Tell the data exchange about this node. Treat these errors like database errors - and return for retry processing
-				return dh.exchange.AddPeer(ctx, identity.Profile)
+				return dh.exchange.AddPeer(ctx, identity.Name, identity.Profile)
 			})
 	}
 

--- a/internal/definitions/handler_network_node_test.go
+++ b/internal/definitions/handler_network_node_test.go
@@ -128,7 +128,8 @@ func TestHandleDeprecatedNodeDefinitionOK(t *testing.T) {
 	})).Return(nil)
 
 	mdx := dh.exchange.(*dataexchangemocks.Plugin)
-	mdx.On("AddPeer", ctx, node.Name, node.DX.Endpoint).Return(nil)
+	mdx.On("GetPeerID", node.DX.Endpoint).Return("member_0")
+	mdx.On("AddNode", ctx, "ns1", node.Name, node.DX.Endpoint).Return(nil)
 
 	dh.multiparty = true
 

--- a/internal/definitions/handler_network_node_test.go
+++ b/internal/definitions/handler_network_node_test.go
@@ -128,7 +128,7 @@ func TestHandleDeprecatedNodeDefinitionOK(t *testing.T) {
 	})).Return(nil)
 
 	mdx := dh.exchange.(*dataexchangemocks.Plugin)
-	mdx.On("AddPeer", ctx, node.DX.Endpoint).Return(nil)
+	mdx.On("AddPeer", ctx, node.Name, node.DX.Endpoint).Return(nil)
 
 	dh.multiparty = true
 

--- a/internal/definitions/handler_test.go
+++ b/internal/definitions/handler_test.go
@@ -44,7 +44,7 @@ func newTestDefinitionHandler(t *testing.T) (*definitionHandler, *testDefinition
 	tokenNames := make(map[string]string)
 	tokenNames["remote1"] = "connector1"
 	mbi.On("VerifierType").Return(core.VerifierTypeEthAddress).Maybe()
-	dh, _ := newDefinitionHandler(context.Background(), "ns1", false, mdi, mbi, mdx, mdm, mim, mam, mcm, tokenNames)
+	dh, _ := newDefinitionHandler(context.Background(), "ns1", "ns1", false, mdi, mbi, mdx, mdm, mim, mam, mcm, tokenNames)
 	return dh, newTestDefinitionBatchState(t)
 }
 
@@ -70,7 +70,7 @@ func (bs *testDefinitionBatchState) assertNoFinalizers() {
 }
 
 func TestInitFail(t *testing.T) {
-	_, err := newDefinitionHandler(context.Background(), "", false, nil, nil, nil, nil, nil, nil, nil, nil)
+	_, err := newDefinitionHandler(context.Background(), "", "", false, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Regexp(t, "FF10128", err)
 }
 

--- a/internal/definitions/sender.go
+++ b/internal/definitions/sender.go
@@ -71,7 +71,7 @@ func fakeBatch(ctx context.Context, handler func(context.Context, *core.BatchSta
 	return err
 }
 
-func NewDefinitionSender(ctx context.Context, ns string, multiparty bool, di database.Plugin, bi blockchain.Plugin, dx dataexchange.Plugin, bm broadcast.Manager, im identity.Manager, dm data.Manager, am assets.Manager, cm contracts.Manager, tokenRemoteNames map[string]string) (Sender, Handler, error) {
+func NewDefinitionSender(ctx context.Context, ns, remoteNS string, multiparty bool, di database.Plugin, bi blockchain.Plugin, dx dataexchange.Plugin, bm broadcast.Manager, im identity.Manager, dm data.Manager, am assets.Manager, cm contracts.Manager, tokenRemoteNames map[string]string) (Sender, Handler, error) {
 	if di == nil || im == nil || dm == nil {
 		return nil, nil, i18n.NewError(ctx, coremsgs.MsgInitializationNilDepError, "DefinitionSender")
 	}
@@ -86,7 +86,7 @@ func NewDefinitionSender(ctx context.Context, ns string, multiparty bool, di dat
 		contracts:        cm,
 		tokenRemoteNames: tokenRemoteNames,
 	}
-	dh, err := newDefinitionHandler(ctx, ns, multiparty, di, bi, dx, dm, im, am, cm, reverseMap(tokenRemoteNames))
+	dh, err := newDefinitionHandler(ctx, ns, remoteNS, multiparty, di, bi, dx, dm, im, am, cm, reverseMap(tokenRemoteNames))
 	ds.handler = dh
 	return ds, dh, err
 }

--- a/internal/definitions/sender_test.go
+++ b/internal/definitions/sender_test.go
@@ -48,13 +48,13 @@ func newTestDefinitionSender(t *testing.T) (*definitionSender, func()) {
 	tokenRemoteNames["connector1"] = "remote1"
 
 	ctx, cancel := context.WithCancel(context.Background())
-	ds, _, err := NewDefinitionSender(ctx, "ns1", false, mdi, mbi, mdx, mbm, mim, mdm, mam, mcm, tokenRemoteNames)
+	ds, _, err := NewDefinitionSender(ctx, "ns1", "ns1", false, mdi, mbi, mdx, mbm, mim, mdm, mam, mcm, tokenRemoteNames)
 	assert.NoError(t, err)
 	return ds.(*definitionSender), cancel
 }
 
 func TestInitSenderFail(t *testing.T) {
-	_, _, err := NewDefinitionSender(context.Background(), "", false, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	_, _, err := NewDefinitionSender(context.Background(), "", "", false, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Regexp(t, "FF10128", err)
 }
 

--- a/internal/networkmap/register_node.go
+++ b/internal/networkmap/register_node.go
@@ -18,7 +18,6 @@ package networkmap
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly/internal/coremsgs"
@@ -45,18 +44,10 @@ func (nm *networkMap) RegisterNode(ctx context.Context, waitConfirm bool) (ident
 		},
 	}
 
-	dxInfo, err := nm.exchange.GetEndpointInfo(ctx)
+	nodeRequest.Profile, err = nm.exchange.GetEndpointInfo(ctx, localNodeName)
 	if err != nil {
 		return nil, err
 	}
-
-	dxID := dxInfo.GetString("id")
-	if dxID != "" {
-		namespacedDestination := fmt.Sprintf("%s-%s", dxID, nm.namespace)
-		dxInfo["id"] = namespacedDestination
-	}
-
-	nodeRequest.Profile = dxInfo
 
 	return nm.RegisterIdentity(ctx, nodeRequest, waitConfirm)
 }

--- a/internal/networkmap/register_node.go
+++ b/internal/networkmap/register_node.go
@@ -18,6 +18,7 @@ package networkmap
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly/internal/coremsgs"
@@ -48,6 +49,13 @@ func (nm *networkMap) RegisterNode(ctx context.Context, waitConfirm bool) (ident
 	if err != nil {
 		return nil, err
 	}
+
+	dxID := dxInfo.GetString("id")
+	if dxID != "" {
+		namespacedDestination := fmt.Sprintf("%s-%s", dxID, nm.namespace)
+		dxInfo["id"] = namespacedDestination
+	}
+
 	nodeRequest.Profile = dxInfo
 
 	return nm.RegisterIdentity(ctx, nodeRequest, waitConfirm)

--- a/internal/networkmap/register_node_test.go
+++ b/internal/networkmap/register_node_test.go
@@ -45,7 +45,7 @@ func TestRegisterNodeOk(t *testing.T) {
 	mim.On("ResolveIdentitySigner", nm.ctx, parentOrg).Return(signerRef, nil)
 
 	mdx := nm.exchange.(*dataexchangemocks.Plugin)
-	mdx.On("GetEndpointInfo", nm.ctx).Return(fftypes.JSONObject{
+	mdx.On("GetEndpointInfo", nm.ctx, "node1").Return(fftypes.JSONObject{
 		"id":       "peer1",
 		"endpoint": "details",
 	}, nil)
@@ -101,7 +101,7 @@ func TestRegisterNodePeerInfoFail(t *testing.T) {
 	mim.On("GetMultipartyRootOrg", nm.ctx).Return(parentOrg, nil)
 
 	mdx := nm.exchange.(*dataexchangemocks.Plugin)
-	mdx.On("GetEndpointInfo", nm.ctx).Return(fftypes.JSONObject{}, fmt.Errorf("pop"))
+	mdx.On("GetEndpointInfo", nm.ctx, "node1").Return(fftypes.JSONObject{}, fmt.Errorf("pop"))
 
 	mmp := nm.multiparty.(*multipartymocks.Manager)
 	mmp.On("LocalNode").Return(multiparty.LocalNode{Name: "node1"})

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -371,7 +371,10 @@ func (or *orchestrator) initHandlers(ctx context.Context) (err error) {
 			return err
 		}
 		for _, node := range nodes {
-			or.plugins.DataExchange.Plugin.InitPeer(node.Name, node.Profile)
+			err = or.plugins.DataExchange.Plugin.AddNode(ctx, or.namespace.RemoteName, node.Name, node.Profile)
+			if err != nil {
+				return err
+			}
 		}
 		or.plugins.DataExchange.Plugin.SetHandler(or.namespace.RemoteName, or.config.Multiparty.Node.Name, or.events)
 		or.plugins.DataExchange.Plugin.SetOperationHandler(or.namespace.LocalName, &or.bc)
@@ -463,7 +466,7 @@ func (or *orchestrator) initManagers(ctx context.Context) (err error) {
 	}
 
 	if or.defsender == nil {
-		or.defsender, or.defhandler, err = definitions.NewDefinitionSender(ctx, or.namespace.LocalName, or.config.Multiparty.Enabled, or.database(), or.blockchain(), or.dataexchange(), or.broadcast, or.identity, or.data, or.assets, or.contracts, or.config.TokenRemoteNames)
+		or.defsender, or.defhandler, err = definitions.NewDefinitionSender(ctx, or.namespace.LocalName, or.namespace.RemoteName, or.config.Multiparty.Enabled, or.database(), or.blockchain(), or.dataexchange(), or.broadcast, or.identity, or.data, or.assets, or.contracts, or.config.TokenRemoteNames)
 		if err != nil {
 			return err
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -370,12 +370,10 @@ func (or *orchestrator) initHandlers(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		nodeInfo := make([]fftypes.JSONObject, len(nodes))
-		for i, node := range nodes {
-			nodeInfo[i] = node.Profile
+		for _, node := range nodes {
+			or.plugins.DataExchange.Plugin.InitPeer(node.Name, node.Profile)
 		}
-		or.plugins.DataExchange.Plugin.SetNodes(nodeInfo)
-		or.plugins.DataExchange.Plugin.SetHandler(or.namespace.RemoteName, or.events)
+		or.plugins.DataExchange.Plugin.SetHandler(or.namespace.RemoteName, or.config.Multiparty.Node.Name, or.events)
 		or.plugins.DataExchange.Plugin.SetOperationHandler(or.namespace.LocalName, &or.bc)
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -216,7 +216,7 @@ func TestInitOK(t *testing.T) {
 	or.mdi.On("GetIdentities", mock.Anything, "ns", mock.Anything).Return([]*core.Identity{node}, nil, nil)
 	or.mdx.On("SetHandler", "ns2", "node1", mock.Anything).Return()
 	or.mdx.On("SetOperationHandler", "ns", mock.Anything).Return()
-	or.mdx.On("InitPeer", "node1", mock.Anything).Return()
+	or.mdx.On("AddNode", mock.Anything, "ns2", "node1", mock.Anything).Return(nil)
 	or.mps.On("SetHandler", "ns", mock.Anything).Return()
 	or.mti.On("SetHandler", "ns", mock.Anything).Return(nil)
 	or.mti.On("SetOperationHandler", "ns", mock.Anything).Return()
@@ -237,7 +237,7 @@ func TestInitOK(t *testing.T) {
 	assert.Equal(t, or.mmp, or.MultiParty())
 }
 
-func TestInitDataexchangeNodesFail(t *testing.T) {
+func TestInitDataexchangeLookupNodesFail(t *testing.T) {
 	or := newTestOrchestrator()
 	defer or.cleanup(t)
 	or.mdi.On("SetHandler", "ns", mock.Anything).Return()
@@ -245,6 +245,25 @@ func TestInitDataexchangeNodesFail(t *testing.T) {
 	or.mbi.On("SetOperationHandler", "ns", mock.Anything).Return()
 	or.mps.On("SetHandler", "ns", mock.Anything).Return()
 	or.mdi.On("GetIdentities", mock.Anything, "ns", mock.Anything).Return(nil, nil, fmt.Errorf("pop"))
+	ctx := context.Background()
+	err := or.initHandlers(ctx)
+	assert.EqualError(t, err, "pop")
+}
+
+func TestInitDataexchangeAddNodesFail(t *testing.T) {
+	or := newTestOrchestrator()
+	defer or.cleanup(t)
+	node := &core.Identity{
+		IdentityBase: core.IdentityBase{
+			Name: "node1",
+		},
+	}
+	or.mdi.On("SetHandler", "ns", mock.Anything).Return()
+	or.mbi.On("SetHandler", "ns", mock.Anything).Return()
+	or.mbi.On("SetOperationHandler", "ns", mock.Anything).Return()
+	or.mps.On("SetHandler", "ns", mock.Anything).Return()
+	or.mdi.On("GetIdentities", mock.Anything, "ns", mock.Anything).Return([]*core.Identity{node}, nil, nil)
+	or.mdx.On("AddNode", mock.Anything, "ns", "node1", mock.Anything).Return(fmt.Errorf("pop"))
 	ctx := context.Background()
 	err := or.initHandlers(ctx)
 	assert.EqualError(t, err, "pop")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -204,13 +204,19 @@ func TestInitOK(t *testing.T) {
 	or := newTestOrchestrator()
 	defer or.cleanup(t)
 	or.namespace.RemoteName = "ns2"
+	or.config.Multiparty.Node.Name = "node1"
+	node := &core.Identity{
+		IdentityBase: core.IdentityBase{
+			Name: "node1",
+		},
+	}
 	or.mdi.On("SetHandler", "ns", mock.Anything).Return()
 	or.mbi.On("SetHandler", "ns", mock.Anything).Return()
 	or.mbi.On("SetOperationHandler", "ns", mock.Anything).Return()
-	or.mdi.On("GetIdentities", mock.Anything, "ns", mock.Anything).Return([]*core.Identity{{}}, nil, nil)
-	or.mdx.On("SetHandler", "ns2", mock.Anything).Return()
+	or.mdi.On("GetIdentities", mock.Anything, "ns", mock.Anything).Return([]*core.Identity{node}, nil, nil)
+	or.mdx.On("SetHandler", "ns2", "node1", mock.Anything).Return()
 	or.mdx.On("SetOperationHandler", "ns", mock.Anything).Return()
-	or.mdx.On("SetNodes", mock.Anything).Return()
+	or.mdx.On("InitPeer", "node1", mock.Anything).Return()
 	or.mps.On("SetHandler", "ns", mock.Anything).Return()
 	or.mti.On("SetHandler", "ns", mock.Anything).Return(nil)
 	or.mti.On("SetOperationHandler", "ns", mock.Anything).Return()

--- a/internal/privatemessaging/operations.go
+++ b/internal/privatemessaging/operations.go
@@ -129,7 +129,8 @@ func (pm *privateMessaging) PrepareOperation(ctx context.Context, op *core.Opera
 func (pm *privateMessaging) RunOperation(ctx context.Context, op *core.PreparedOperation) (outputs fftypes.JSONObject, complete bool, err error) {
 	switch data := op.Data.(type) {
 	case transferBlobData:
-		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), data.Node.Profile.GetString("id"), data.Blob.PayloadRef)
+		recipient := data.Node.Profile.GetString("id")
+		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), recipient, data.Blob.PayloadRef)
 
 	case batchSendData:
 		node, err := pm.identity.GetLocalNode(ctx)
@@ -141,7 +142,10 @@ func (pm *privateMessaging) RunOperation(ctx context.Context, op *core.PreparedO
 		if err != nil {
 			return nil, false, i18n.WrapError(ctx, err, coremsgs.MsgSerializationFailed)
 		}
-		return nil, false, pm.exchange.SendMessage(ctx, op.NamespacedIDString(), data.Node.Profile.GetString("id"), node.Profile.GetString("id"), payload)
+
+		recipient := data.Node.Profile.GetString("id")
+		sender := node.Profile.GetString("id")
+		return nil, false, pm.exchange.SendMessage(ctx, op.NamespacedIDString(), recipient, sender, payload)
 
 	default:
 		return nil, false, i18n.NewError(ctx, coremsgs.MsgOperationDataIncorrect, op.Data)

--- a/internal/privatemessaging/operations.go
+++ b/internal/privatemessaging/operations.go
@@ -129,8 +129,14 @@ func (pm *privateMessaging) PrepareOperation(ctx context.Context, op *core.Opera
 func (pm *privateMessaging) RunOperation(ctx context.Context, op *core.PreparedOperation) (outputs fftypes.JSONObject, complete bool, err error) {
 	switch data := op.Data.(type) {
 	case transferBlobData:
+		node, err := pm.identity.GetLocalNode(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+
 		recipient := data.Node.Profile.GetString("id")
-		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), recipient, data.Blob.PayloadRef)
+		sender := node.Profile.GetString("id")
+		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), recipient, sender, data.Blob.PayloadRef)
 
 	case batchSendData:
 		node, err := pm.identity.GetLocalNode(ctx)

--- a/internal/privatemessaging/operations.go
+++ b/internal/privatemessaging/operations.go
@@ -129,17 +129,14 @@ func (pm *privateMessaging) PrepareOperation(ctx context.Context, op *core.Opera
 func (pm *privateMessaging) RunOperation(ctx context.Context, op *core.PreparedOperation) (outputs fftypes.JSONObject, complete bool, err error) {
 	switch data := op.Data.(type) {
 	case transferBlobData:
-		node, err := pm.identity.GetLocalNode(ctx)
+		localNode, err := pm.identity.GetLocalNode(ctx)
 		if err != nil {
 			return nil, false, err
 		}
-
-		recipient := data.Node.Profile.GetString("id")
-		sender := node.Profile.GetString("id")
-		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), recipient, sender, data.Blob.PayloadRef)
+		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), data.Node.Profile, localNode.Profile, data.Blob.PayloadRef)
 
 	case batchSendData:
-		node, err := pm.identity.GetLocalNode(ctx)
+		localNode, err := pm.identity.GetLocalNode(ctx)
 		if err != nil {
 			return nil, false, err
 		}
@@ -148,10 +145,7 @@ func (pm *privateMessaging) RunOperation(ctx context.Context, op *core.PreparedO
 		if err != nil {
 			return nil, false, i18n.WrapError(ctx, err, coremsgs.MsgSerializationFailed)
 		}
-
-		recipient := data.Node.Profile.GetString("id")
-		sender := node.Profile.GetString("id")
-		return nil, false, pm.exchange.SendMessage(ctx, op.NamespacedIDString(), recipient, sender, payload)
+		return nil, false, pm.exchange.SendMessage(ctx, op.NamespacedIDString(), data.Node.Profile, localNode.Profile, payload)
 
 	default:
 		return nil, false, i18n.NewError(ctx, coremsgs.MsgOperationDataIncorrect, op.Data)

--- a/internal/privatemessaging/operations.go
+++ b/internal/privatemessaging/operations.go
@@ -132,11 +132,16 @@ func (pm *privateMessaging) RunOperation(ctx context.Context, op *core.PreparedO
 		return nil, false, pm.exchange.TransferBlob(ctx, op.NamespacedIDString(), data.Node.Profile.GetString("id"), data.Blob.PayloadRef)
 
 	case batchSendData:
+		node, err := pm.identity.GetLocalNode(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+
 		payload, err := json.Marshal(data.Transport)
 		if err != nil {
 			return nil, false, i18n.WrapError(ctx, err, coremsgs.MsgSerializationFailed)
 		}
-		return nil, false, pm.exchange.SendMessage(ctx, op.NamespacedIDString(), data.Node.Profile.GetString("id"), payload)
+		return nil, false, pm.exchange.SendMessage(ctx, op.NamespacedIDString(), data.Node.Profile.GetString("id"), node.Profile.GetString("id"), payload)
 
 	default:
 		return nil, false, i18n.NewError(ctx, coremsgs.MsgOperationDataIncorrect, op.Data)

--- a/internal/privatemessaging/operations_test.go
+++ b/internal/privatemessaging/operations_test.go
@@ -96,6 +96,16 @@ func TestPrepareAndRunBatchSend(t *testing.T) {
 			},
 		},
 	}
+	localNode := &core.Identity{
+		IdentityBase: core.IdentityBase{
+			ID: fftypes.NewUUID(),
+		},
+		IdentityProfile: core.IdentityProfile{
+			Profile: fftypes.JSONObject{
+				"id": "local1",
+			},
+		},
+	}
 	group := &core.Group{
 		Hash: fftypes.NewRandB32(),
 	}
@@ -114,10 +124,11 @@ func TestPrepareAndRunBatchSend(t *testing.T) {
 	mdm := pm.data.(*datamocks.Manager)
 	mdm.On("HydrateBatch", context.Background(), bp).Return(batch, nil)
 	mim := pm.identity.(*identitymanagermocks.Manager)
+	mim.On("GetLocalNode", context.Background()).Return(localNode, nil)
 	mim.On("CachedIdentityLookupByID", context.Background(), node.ID).Return(node, nil)
 	mdi.On("GetGroupByHash", context.Background(), "ns1", group.Hash).Return(group, nil)
 	mdi.On("GetBatchByID", context.Background(), "ns1", batch.ID).Return(bp, nil)
-	mdx.On("SendMessage", context.Background(), "ns1:"+op.ID.String(), "peer1", mock.Anything).Return(nil)
+	mdx.On("SendMessage", context.Background(), "ns1:"+op.ID.String(), "peer1", "local1", mock.Anything).Return(nil)
 
 	po, err := pm.PrepareOperation(context.Background(), op)
 	assert.NoError(t, err)
@@ -540,6 +551,18 @@ func TestRunOperationBatchSendInvalidData(t *testing.T) {
 			ID: fftypes.NewUUID(),
 		},
 	}
+	localNode := &core.Identity{
+		IdentityBase: core.IdentityBase{
+			ID: fftypes.NewUUID(),
+		},
+		IdentityProfile: core.IdentityProfile{
+			Profile: fftypes.JSONObject{
+				"id": "local1",
+			},
+		},
+	}
+	mim := pm.identity.(*identitymanagermocks.Manager)
+	mim.On("GetLocalNode", context.Background()).Return(localNode, nil)
 	transport := &core.TransportWrapper{
 		Group: &core.Group{},
 		Batch: &core.Batch{

--- a/internal/privatemessaging/operations_test.go
+++ b/internal/privatemessaging/operations_test.go
@@ -71,7 +71,7 @@ func TestPrepareAndRunTransferBlob(t *testing.T) {
 	mim.On("CachedIdentityLookupByID", context.Background(), mock.Anything).Return(node, nil)
 	mdi.On("GetBlobMatchingHash", context.Background(), blob.Hash).Return(blob, nil)
 	mim.On("GetLocalNode", context.Background()).Return(localNode, nil)
-	mdx.On("TransferBlob", context.Background(), "ns1:"+op.ID.String(), "peer1", "local1", "payload").Return(nil)
+	mdx.On("TransferBlob", context.Background(), "ns1:"+op.ID.String(), node.Profile, localNode.Profile, "payload").Return(nil)
 
 	po, err := pm.PrepareOperation(context.Background(), op)
 	assert.NoError(t, err)
@@ -139,7 +139,7 @@ func TestPrepareAndRunBatchSend(t *testing.T) {
 	mim.On("CachedIdentityLookupByID", context.Background(), node.ID).Return(node, nil)
 	mdi.On("GetGroupByHash", context.Background(), "ns1", group.Hash).Return(group, nil)
 	mdi.On("GetBatchByID", context.Background(), "ns1", batch.ID).Return(bp, nil)
-	mdx.On("SendMessage", context.Background(), "ns1:"+op.ID.String(), "peer1", "local1", mock.Anything).Return(nil)
+	mdx.On("SendMessage", context.Background(), "ns1:"+op.ID.String(), node.Profile, localNode.Profile, mock.Anything).Return(nil)
 
 	po, err := pm.PrepareOperation(context.Background(), op)
 	assert.NoError(t, err)

--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,8 @@
   },
   "dataexchange-https": {
     "image": "ghcr.io/hyperledger/firefly-dataexchange-https",
-    "tag": "v1.0.0",
-    "sha": "1a19cdbdc3311930c59a4a8089db8ba843a9267cffc79c7a22331d373150e94f"
+    "tag": "v1.0.0-20220801-11",
+    "sha": "f113ccbd1ad166c3a382ec744af93b0701e1741fc97be2f4c60c3edb29767570"
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",

--- a/mocks/dataexchangemocks/plugin.go
+++ b/mocks/dataexchangemocks/plugin.go
@@ -162,13 +162,13 @@ func (_m *Plugin) Name() string {
 	return r0
 }
 
-// SendMessage provides a mock function with given fields: ctx, nsOpID, peerID, data
-func (_m *Plugin) SendMessage(ctx context.Context, nsOpID string, peerID string, data []byte) error {
-	ret := _m.Called(ctx, nsOpID, peerID, data)
+// SendMessage provides a mock function with given fields: ctx, nsOpID, peerID, senderID, data
+func (_m *Plugin) SendMessage(ctx context.Context, nsOpID string, peerID string, senderID string, data []byte) error {
+	ret := _m.Called(ctx, nsOpID, peerID, senderID, data)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, []byte) error); ok {
-		r0 = rf(ctx, nsOpID, peerID, data)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []byte) error); ok {
+		r0 = rf(ctx, nsOpID, peerID, senderID, data)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/dataexchangemocks/plugin.go
+++ b/mocks/dataexchangemocks/plugin.go
@@ -23,13 +23,13 @@ type Plugin struct {
 	mock.Mock
 }
 
-// AddPeer provides a mock function with given fields: ctx, nodeName, peer
-func (_m *Plugin) AddPeer(ctx context.Context, nodeName string, peer fftypes.JSONObject) error {
-	ret := _m.Called(ctx, nodeName, peer)
+// AddNode provides a mock function with given fields: ctx, remoteNamespace, nodeName, peer
+func (_m *Plugin) AddNode(ctx context.Context, remoteNamespace string, nodeName string, peer fftypes.JSONObject) error {
+	ret := _m.Called(ctx, remoteNamespace, nodeName, peer)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, fftypes.JSONObject) error); ok {
-		r0 = rf(ctx, nodeName, peer)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, fftypes.JSONObject) error); ok {
+		r0 = rf(ctx, remoteNamespace, nodeName, peer)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -51,36 +51,6 @@ func (_m *Plugin) Capabilities() *dataexchange.Capabilities {
 	}
 
 	return r0
-}
-
-// CheckBlobReceived provides a mock function with given fields: ctx, peerID, ns, id
-func (_m *Plugin) CheckBlobReceived(ctx context.Context, peerID string, ns string, id fftypes.UUID) (*fftypes.Bytes32, int64, error) {
-	ret := _m.Called(ctx, peerID, ns, id)
-
-	var r0 *fftypes.Bytes32
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, fftypes.UUID) *fftypes.Bytes32); ok {
-		r0 = rf(ctx, peerID, ns, id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*fftypes.Bytes32)
-		}
-	}
-
-	var r1 int64
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, fftypes.UUID) int64); ok {
-		r1 = rf(ctx, peerID, ns, id)
-	} else {
-		r1 = ret.Get(1).(int64)
-	}
-
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, string, string, fftypes.UUID) error); ok {
-		r2 = rf(ctx, peerID, ns, id)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
 }
 
 // DownloadBlob provides a mock function with given fields: ctx, payloadRef
@@ -129,6 +99,20 @@ func (_m *Plugin) GetEndpointInfo(ctx context.Context, nodeName string) (fftypes
 	return r0, r1
 }
 
+// GetPeerID provides a mock function with given fields: peer
+func (_m *Plugin) GetPeerID(peer fftypes.JSONObject) string {
+	ret := _m.Called(peer)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(fftypes.JSONObject) string); ok {
+		r0 = rf(peer)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // Init provides a mock function with given fields: ctx, _a1
 func (_m *Plugin) Init(ctx context.Context, _a1 config.Section) error {
 	ret := _m.Called(ctx, _a1)
@@ -148,11 +132,6 @@ func (_m *Plugin) InitConfig(_a0 config.Section) {
 	_m.Called(_a0)
 }
 
-// InitPeer provides a mock function with given fields: nodeName, peer
-func (_m *Plugin) InitPeer(nodeName string, peer fftypes.JSONObject) {
-	_m.Called(nodeName, peer)
-}
-
 // Name provides a mock function with given fields:
 func (_m *Plugin) Name() string {
 	ret := _m.Called()
@@ -167,13 +146,13 @@ func (_m *Plugin) Name() string {
 	return r0
 }
 
-// SendMessage provides a mock function with given fields: ctx, nsOpID, peerID, senderID, data
-func (_m *Plugin) SendMessage(ctx context.Context, nsOpID string, peerID string, senderID string, data []byte) error {
-	ret := _m.Called(ctx, nsOpID, peerID, senderID, data)
+// SendMessage provides a mock function with given fields: ctx, nsOpID, peer, sender, data
+func (_m *Plugin) SendMessage(ctx context.Context, nsOpID string, peer fftypes.JSONObject, sender fftypes.JSONObject, data []byte) error {
+	ret := _m.Called(ctx, nsOpID, peer, sender, data)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []byte) error); ok {
-		r0 = rf(ctx, nsOpID, peerID, senderID, data)
+	if rf, ok := ret.Get(0).(func(context.Context, string, fftypes.JSONObject, fftypes.JSONObject, []byte) error); ok {
+		r0 = rf(ctx, nsOpID, peer, sender, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -205,13 +184,13 @@ func (_m *Plugin) Start() error {
 	return r0
 }
 
-// TransferBlob provides a mock function with given fields: ctx, nsOpID, peerID, senderID, payloadRef
-func (_m *Plugin) TransferBlob(ctx context.Context, nsOpID string, peerID string, senderID string, payloadRef string) error {
-	ret := _m.Called(ctx, nsOpID, peerID, senderID, payloadRef)
+// TransferBlob provides a mock function with given fields: ctx, nsOpID, peer, sender, payloadRef
+func (_m *Plugin) TransferBlob(ctx context.Context, nsOpID string, peer fftypes.JSONObject, sender fftypes.JSONObject, payloadRef string) error {
+	ret := _m.Called(ctx, nsOpID, peer, sender, payloadRef)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
-		r0 = rf(ctx, nsOpID, peerID, senderID, payloadRef)
+	if rf, ok := ret.Get(0).(func(context.Context, string, fftypes.JSONObject, fftypes.JSONObject, string) error); ok {
+		r0 = rf(ctx, nsOpID, peer, sender, payloadRef)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/dataexchangemocks/plugin.go
+++ b/mocks/dataexchangemocks/plugin.go
@@ -23,13 +23,13 @@ type Plugin struct {
 	mock.Mock
 }
 
-// AddPeer provides a mock function with given fields: ctx, peer
-func (_m *Plugin) AddPeer(ctx context.Context, peer fftypes.JSONObject) error {
-	ret := _m.Called(ctx, peer)
+// AddPeer provides a mock function with given fields: ctx, nodeName, peer
+func (_m *Plugin) AddPeer(ctx context.Context, nodeName string, peer fftypes.JSONObject) error {
+	ret := _m.Called(ctx, nodeName, peer)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, fftypes.JSONObject) error); ok {
-		r0 = rf(ctx, peer)
+	if rf, ok := ret.Get(0).(func(context.Context, string, fftypes.JSONObject) error); ok {
+		r0 = rf(ctx, nodeName, peer)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -106,13 +106,13 @@ func (_m *Plugin) DownloadBlob(ctx context.Context, payloadRef string) (io.ReadC
 	return r0, r1
 }
 
-// GetEndpointInfo provides a mock function with given fields: ctx
-func (_m *Plugin) GetEndpointInfo(ctx context.Context) (fftypes.JSONObject, error) {
-	ret := _m.Called(ctx)
+// GetEndpointInfo provides a mock function with given fields: ctx, nodeName
+func (_m *Plugin) GetEndpointInfo(ctx context.Context, nodeName string) (fftypes.JSONObject, error) {
+	ret := _m.Called(ctx, nodeName)
 
 	var r0 fftypes.JSONObject
-	if rf, ok := ret.Get(0).(func(context.Context) fftypes.JSONObject); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, string) fftypes.JSONObject); ok {
+		r0 = rf(ctx, nodeName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(fftypes.JSONObject)
@@ -120,8 +120,8 @@ func (_m *Plugin) GetEndpointInfo(ctx context.Context) (fftypes.JSONObject, erro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, nodeName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -146,6 +146,11 @@ func (_m *Plugin) Init(ctx context.Context, _a1 config.Section) error {
 // InitConfig provides a mock function with given fields: _a0
 func (_m *Plugin) InitConfig(_a0 config.Section) {
 	_m.Called(_a0)
+}
+
+// InitPeer provides a mock function with given fields: nodeName, peer
+func (_m *Plugin) InitPeer(nodeName string, peer fftypes.JSONObject) {
+	_m.Called(nodeName, peer)
 }
 
 // Name provides a mock function with given fields:
@@ -176,14 +181,9 @@ func (_m *Plugin) SendMessage(ctx context.Context, nsOpID string, peerID string,
 	return r0
 }
 
-// SetHandler provides a mock function with given fields: namespace, handler
-func (_m *Plugin) SetHandler(namespace string, handler dataexchange.Callbacks) {
-	_m.Called(namespace, handler)
-}
-
-// SetNodes provides a mock function with given fields: nodes
-func (_m *Plugin) SetNodes(nodes []fftypes.JSONObject) {
-	_m.Called(nodes)
+// SetHandler provides a mock function with given fields: remoteNamespace, nodeName, handler
+func (_m *Plugin) SetHandler(remoteNamespace string, nodeName string, handler dataexchange.Callbacks) {
+	_m.Called(remoteNamespace, nodeName, handler)
 }
 
 // SetOperationHandler provides a mock function with given fields: namespace, handler

--- a/mocks/dataexchangemocks/plugin.go
+++ b/mocks/dataexchangemocks/plugin.go
@@ -205,13 +205,13 @@ func (_m *Plugin) Start() error {
 	return r0
 }
 
-// TransferBlob provides a mock function with given fields: ctx, nsOpID, peerID, payloadRef
-func (_m *Plugin) TransferBlob(ctx context.Context, nsOpID string, peerID string, payloadRef string) error {
-	ret := _m.Called(ctx, nsOpID, peerID, payloadRef)
+// TransferBlob provides a mock function with given fields: ctx, nsOpID, peerID, senderID, payloadRef
+func (_m *Plugin) TransferBlob(ctx context.Context, nsOpID string, peerID string, senderID string, payloadRef string) error {
+	ret := _m.Called(ctx, nsOpID, peerID, senderID, payloadRef)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
-		r0 = rf(ctx, nsOpID, peerID, payloadRef)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
+		r0 = rf(ctx, nsOpID, peerID, senderID, payloadRef)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/dataexchange/plugin.go
+++ b/pkg/dataexchange/plugin.go
@@ -97,10 +97,10 @@ type Plugin interface {
 
 	// SendMessage sends an in-line package of data to another network node.
 	// Should return as quickly as possible for parallelism, then report completion asynchronously via the operation ID
-	SendMessage(ctx context.Context, nsOpID, peerID string, senderID string, data []byte) (err error)
+	SendMessage(ctx context.Context, nsOpID, peerID, senderID string, data []byte) (err error)
 
 	// TransferBlob initiates a transfer of a previously stored blob to another node
-	TransferBlob(ctx context.Context, nsOpID, peerID string, payloadRef string) (err error)
+	TransferBlob(ctx context.Context, nsOpID, peerID, senderID, payloadRef string) (err error)
 }
 
 // Callbacks is the interface provided to the data exchange plugin, to allow it to pass events back to firefly.

--- a/pkg/dataexchange/plugin.go
+++ b/pkg/dataexchange/plugin.go
@@ -97,7 +97,7 @@ type Plugin interface {
 
 	// SendMessage sends an in-line package of data to another network node.
 	// Should return as quickly as possible for parallelism, then report completion asynchronously via the operation ID
-	SendMessage(ctx context.Context, nsOpID, peerID string, data []byte) (err error)
+	SendMessage(ctx context.Context, nsOpID, peerID string, senderID string, data []byte) (err error)
 
 	// TransferBlob initiates a transfer of a previously stored blob to another node
 	TransferBlob(ctx context.Context, nsOpID, peerID string, payloadRef string) (err error)

--- a/pkg/dataexchange/plugin.go
+++ b/pkg/dataexchange/plugin.go
@@ -63,9 +63,6 @@ type Plugin interface {
 	// Init initializes the plugin, with configuration
 	Init(ctx context.Context, config config.Section) error
 
-	// InitPeer initializes info on a known peer (loaded from the database)
-	InitPeer(nodeName string, peer fftypes.JSONObject)
-
 	// SetHandler registers a handler to receive callbacks
 	// Plugin will attempt (but is not guaranteed) to deliver events only for the given namespace and node
 	SetHandler(remoteNamespace, nodeName string, handler Callbacks)
@@ -83,8 +80,9 @@ type Plugin interface {
 	// GetEndpointInfo returns the information about the local endpoint
 	GetEndpointInfo(ctx context.Context, nodeName string) (peer fftypes.JSONObject, err error)
 
-	// AddPeer translates the configuration published by another peer, into a reference string that is used between DX and FireFly to refer to the peer
-	AddPeer(ctx context.Context, nodeName string, peer fftypes.JSONObject) (err error)
+	// AddNode registers details on a node in the multiparty network
+	// This may be information loaded from the database at init, or received in flight while running
+	AddNode(ctx context.Context, remoteNamespace, nodeName string, peer fftypes.JSONObject) (err error)
 
 	// UploadBlob streams a blob to storage, and returns the hash to confirm the hash calculated in Core matches the hash calculated in the plugin
 	UploadBlob(ctx context.Context, ns string, id fftypes.UUID, content io.Reader) (payloadRef string, hash *fftypes.Bytes32, size int64, err error)
@@ -92,15 +90,15 @@ type Plugin interface {
 	// DownloadBlob streams a received blob out of storage
 	DownloadBlob(ctx context.Context, payloadRef string) (content io.ReadCloser, err error)
 
-	// CheckBlobReceived confirms that a blob with the specified hash has been received from the specified peer
-	CheckBlobReceived(ctx context.Context, peerID, ns string, id fftypes.UUID) (hash *fftypes.Bytes32, size int64, err error)
-
 	// SendMessage sends an in-line package of data to another network node.
 	// Should return as quickly as possible for parallelism, then report completion asynchronously via the operation ID
-	SendMessage(ctx context.Context, nsOpID, peerID, senderID string, data []byte) (err error)
+	SendMessage(ctx context.Context, nsOpID string, peer, sender fftypes.JSONObject, data []byte) (err error)
 
 	// TransferBlob initiates a transfer of a previously stored blob to another node
-	TransferBlob(ctx context.Context, nsOpID, peerID, senderID, payloadRef string) (err error)
+	TransferBlob(ctx context.Context, nsOpID string, peer, sender fftypes.JSONObject, payloadRef string) (err error)
+
+	// GetPeerID extracts the peer ID from the peer JSON
+	GetPeerID(peer fftypes.JSONObject) string
 }
 
 // Callbacks is the interface provided to the data exchange plugin, to allow it to pass events back to firefly.

--- a/pkg/dataexchange/plugin.go
+++ b/pkg/dataexchange/plugin.go
@@ -63,12 +63,12 @@ type Plugin interface {
 	// Init initializes the plugin, with configuration
 	Init(ctx context.Context, config config.Section) error
 
-	// SetNodes initializes the known nodes from the database
-	SetNodes(nodes []fftypes.JSONObject)
+	// InitPeer initializes info on a known peer (loaded from the database)
+	InitPeer(nodeName string, peer fftypes.JSONObject)
 
 	// SetHandler registers a handler to receive callbacks
-	// Plugin will attempt (but is not guaranteed) to deliver events only for the given namespace
-	SetHandler(namespace string, handler Callbacks)
+	// Plugin will attempt (but is not guaranteed) to deliver events only for the given namespace and node
+	SetHandler(remoteNamespace, nodeName string, handler Callbacks)
 
 	// SetOperationHandler registers a handler to receive async operation status
 	// If namespace is set, plugin will attempt to deliver only events for that namespace
@@ -81,10 +81,10 @@ type Plugin interface {
 	Capabilities() *Capabilities
 
 	// GetEndpointInfo returns the information about the local endpoint
-	GetEndpointInfo(ctx context.Context) (peer fftypes.JSONObject, err error)
+	GetEndpointInfo(ctx context.Context, nodeName string) (peer fftypes.JSONObject, err error)
 
 	// AddPeer translates the configuration published by another peer, into a reference string that is used between DX and FireFly to refer to the peer
-	AddPeer(ctx context.Context, peer fftypes.JSONObject) (err error)
+	AddPeer(ctx context.Context, nodeName string, peer fftypes.JSONObject) (err error)
 
 	// UploadBlob streams a blob to storage, and returns the hash to confirm the hash calculated in Core matches the hash calculated in the plugin
 	UploadBlob(ctx context.Context, ns string, id fftypes.UUID, content io.Reader) (payloadRef string, hash *fftypes.Bytes32, size int64, err error)


### PR DESCRIPTION
~~In a chain with #915~~
Depends on https://github.com/hyperledger/firefly-dataexchange-https/pull/62

UPDATE: found a number of bugs while adding E2E tests - so #918 contains everything from this PR, some additional fixes, and an E2E test. The comments below are still relevant though.

FireFly can now support many local namespaces that map to a single remote namespace (for multi-tenancy purposes). Each of these local namespaces may have their own "node" within FireFly, but they may all be sharing a single DX plugin. This change adds a "nodeName" qualifier to many of the dataexchange plugin calls, along with a specific implementation in the FFDX plugin code, to allow many nodes to exist behind a single DX.

Implementation outline:
* For newly created nodes, the FFDX connector will append a suffix to the member ID advertised by the plugin before storing or broadcasting it. This means each node will have a unique verifier ID even if they are sharing a DX member ID and certificate. The FFDX connector and FFDX plugin have agreed on `/` as a separator.
* The FFDX connector will ignore this suffix when routing messages (paying attention only to the member ID before the separator) - but will pass the full recipient string for further routing by FireFly on the far end.
* FireFly will use the combination of the received message's remote namespace and recipient ID to route it uniquely to a single event manager.

Should remain fully backwards compatible for nodes that were already broadcast/stored in the database with a non-suffixed peer ID.