### PR TITLE
Pin golangci-lint to v1.47.3 instead of latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: ${LINT}
 ${MOCKERY}:
 		$(VGO) install github.com/vektra/mockery/cmd/mockery@latest
 ${LINT}:
-		$(VGO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+		$(VGO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 ffcommon:
 		$(eval WSCLIENT_PATH := $(shell $(VGO) list -f '{{.Dir}}' github.com/hyperledger/firefly-common/pkg/wsclient))
 


### PR DESCRIPTION
Avoids surprising changes to linter rules.

Also looks like the current "latest" version of golangci-lint is Go 1.19 only, and we don't want to upgrade just yet.