### PR TITLE
Changes to support E2E tests with confirmations, where requests might be slow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/hyperledger/firefly-common v0.1.19-0.20220811200324-b6c4c44d2d0d
+	github.com/hyperledger/firefly-common v0.1.20
 	github.com/hyperledger/firefly-signer v0.9.12
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/karlseguin/ccache v2.0.3+incompatible

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/hyperledger/firefly-common v0.1.16
+	github.com/hyperledger/firefly-common v0.1.19-0.20220811200324-b6c4c44d2d0d
 	github.com/hyperledger/firefly-signer v0.9.12
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/karlseguin/ccache v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,14 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hyperledger/firefly-common v0.1.13/go.mod h1:2NqPi5Ud9H6rSlZXkLbotxW7z4EAD89p3/8oNOpm9Gs=
 github.com/hyperledger/firefly-common v0.1.16 h1:21xidDEKrJhtGdBSRqHN4PfDi7aYxF0HOFuAa04V1AE=
 github.com/hyperledger/firefly-common v0.1.16/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811192657-e63ab6827844 h1:DDWL4Tv2vZbcKgc/1dSjgei0QnWIQnu3ikRqg7tBnkQ=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811192657-e63ab6827844/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811194331-db95d0f1bc31 h1:ijIhHR9uDwGBXOBydaQxAVyyReNmUWcTHW5R6oJYc5U=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811194331-db95d0f1bc31/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811195438-ef727fa10629 h1:id4k0rBHXzcez+1qy+E8xP4J3ZudNtuSF7dJaBhPqMI=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811195438-ef727fa10629/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811200324-b6c4c44d2d0d h1:9s1MI4RIfKgftrGQ6sI2gvQBEQElq2CQOs3uaiB44s8=
+github.com/hyperledger/firefly-common v0.1.19-0.20220811200324-b6c4c44d2d0d/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
 github.com/hyperledger/firefly-signer v0.9.12 h1:pCPiGHx1+MbTsIQuRkoQmfWxvpcvtGHVavls0NnH0po=
 github.com/hyperledger/firefly-signer v0.9.12/go.mod h1:GPQRUZOFOAjkLmg8GDjZUjEdUD0gcar+CSVhwltIwyw=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,8 @@ github.com/hyperledger/firefly-common v0.1.19-0.20220811195438-ef727fa10629 h1:i
 github.com/hyperledger/firefly-common v0.1.19-0.20220811195438-ef727fa10629/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
 github.com/hyperledger/firefly-common v0.1.19-0.20220811200324-b6c4c44d2d0d h1:9s1MI4RIfKgftrGQ6sI2gvQBEQElq2CQOs3uaiB44s8=
 github.com/hyperledger/firefly-common v0.1.19-0.20220811200324-b6c4c44d2d0d/go.mod h1:MNbaI2spBsdZYOub6Duj9xueE7Qyu9itOmJ4vE8tjYw=
+github.com/hyperledger/firefly-common v0.1.20 h1:0dShkjlIShyBxkXRmu3vLmpEK6xrqmfc8GhF6k0Vgbg=
+github.com/hyperledger/firefly-common v0.1.20/go.mod h1:gMlv4Iy5JjnzXmSEdb+tWVDIc/2GhL9MRcgNX+VmI4M=
 github.com/hyperledger/firefly-signer v0.9.12 h1:pCPiGHx1+MbTsIQuRkoQmfWxvpcvtGHVavls0NnH0po=
 github.com/hyperledger/firefly-signer v0.9.12/go.mod h1:GPQRUZOFOAjkLmg8GDjZUjEdUD0gcar+CSVhwltIwyw=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -93,14 +93,18 @@ func (as *apiServer) Serve(ctx context.Context, mgr namespace.Manager) (err erro
 	spiErrChan := make(chan error)
 	metricsErrChan := make(chan error)
 
-	apiHTTPServer, err := httpserver.NewHTTPServer(ctx, "api", as.createMuxRouter(ctx, mgr), httpErrChan, apiConfig, corsConfig)
+	apiHTTPServer, err := httpserver.NewHTTPServer(ctx, "api", as.createMuxRouter(ctx, mgr), httpErrChan, apiConfig, corsConfig, &httpserver.ServerOptions{
+		MaximumRequestTimeout: as.apiMaxTimeout,
+	})
 	if err != nil {
 		return err
 	}
 	go apiHTTPServer.ServeHTTP(ctx)
 
 	if config.GetBool(coreconfig.SPIEnabled) {
-		spiHTTPServer, err := httpserver.NewHTTPServer(ctx, "spi", as.createAdminMuxRouter(mgr), spiErrChan, spiConfig, corsConfig)
+		spiHTTPServer, err := httpserver.NewHTTPServer(ctx, "spi", as.createAdminMuxRouter(mgr), spiErrChan, spiConfig, corsConfig, &httpserver.ServerOptions{
+			MaximumRequestTimeout: as.apiMaxTimeout,
+		})
 		if err != nil {
 			return err
 		}
@@ -108,7 +112,9 @@ func (as *apiServer) Serve(ctx context.Context, mgr namespace.Manager) (err erro
 	}
 
 	if as.metricsEnabled {
-		metricsHTTPServer, err := httpserver.NewHTTPServer(ctx, "metrics", as.createMetricsMuxRouter(), metricsErrChan, metricsConfig, corsConfig)
+		metricsHTTPServer, err := httpserver.NewHTTPServer(ctx, "metrics", as.createMetricsMuxRouter(), metricsErrChan, metricsConfig, corsConfig, &httpserver.ServerOptions{
+			MaximumRequestTimeout: as.apiMaxTimeout,
+		})
 		if err != nil {
 			return err
 		}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -223,7 +223,7 @@ func checkObject(t *testing.T, expected interface{}, actual interface{}) bool {
 }
 
 func VerifyAllOperationsSucceeded(t *testing.T, clients []*client.FireFlyClient, startTime time.Time) {
-	tries := 3
+	tries := 30
 	delay := 2 * time.Second
 
 	var pending string
@@ -232,13 +232,14 @@ func VerifyAllOperationsSucceeded(t *testing.T, clients []*client.FireFlyClient,
 		for _, client := range clients {
 			for _, op := range client.GetOperations(t, startTime) {
 				if op.Status != core.OpStatusSucceeded {
-					pending += fmt.Sprintf("Operation '%s' (%s) on '%s' is not successful\n", op.ID, op.Type, client.Client.BaseURL)
+					pending += fmt.Sprintf("Operation '%s' (%s) on '%s' status=%s\n", op.ID, op.Type, client.Client.BaseURL, op.Status)
 				}
 			}
 		}
 		if pending == "" {
 			return
 		}
+		t.Logf("Waiting on operations:\n%s", pending)
 		time.Sleep(delay)
 	}
 

--- a/test/e2e/runners/ethereum_multiparty_test.go
+++ b/test/e2e/runners/ethereum_multiparty_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func TestEthereumMultipartyE2ESuite(t *testing.T) {
-	suite.Run(t, new(multiparty.OnChainOffChainTestSuite))
-	suite.Run(t, new(multiparty.IdentityTestSuite))
+	// suite.Run(t, new(multiparty.OnChainOffChainTestSuite))
+	// suite.Run(t, new(multiparty.IdentityTestSuite))
 	suite.Run(t, new(multiparty.TokensTestSuite))
-	suite.Run(t, new(multiparty.EthereumContractTestSuite))
-	suite.Run(t, new(multiparty.ContractMigrationTestSuite))
-	suite.Run(t, new(multiparty.NamespaceAliasSuite))
+	// suite.Run(t, new(multiparty.EthereumContractTestSuite))
+	// suite.Run(t, new(multiparty.ContractMigrationTestSuite))
+	// suite.Run(t, new(multiparty.NamespaceAliasSuite))
 }

--- a/test/e2e/runners/ethereum_multiparty_test.go
+++ b/test/e2e/runners/ethereum_multiparty_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func TestEthereumMultipartyE2ESuite(t *testing.T) {
-	// suite.Run(t, new(multiparty.OnChainOffChainTestSuite))
-	// suite.Run(t, new(multiparty.IdentityTestSuite))
+	suite.Run(t, new(multiparty.OnChainOffChainTestSuite))
+	suite.Run(t, new(multiparty.IdentityTestSuite))
 	suite.Run(t, new(multiparty.TokensTestSuite))
-	// suite.Run(t, new(multiparty.EthereumContractTestSuite))
-	// suite.Run(t, new(multiparty.ContractMigrationTestSuite))
-	// suite.Run(t, new(multiparty.NamespaceAliasSuite))
+	suite.Run(t, new(multiparty.EthereumContractTestSuite))
+	suite.Run(t, new(multiparty.ContractMigrationTestSuite))
+	suite.Run(t, new(multiparty.NamespaceAliasSuite))
 }


### PR DESCRIPTION
Biggest change is to the HTTP Server to allow requests longer than 15s to complete without the client getting an EOF.

See https://github.com/hyperledger/firefly-common/pull/31