### PR TITLE
Add /api/version route returning same info as CLI, with APIVersion

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -36,6 +36,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const apiVersion = "1.1" // Test will validate this does not mismatch the first two digits of a release semver
+
 const configSuffix = "core"
 
 var sigs = make(chan os.Signal, 1)
@@ -83,7 +85,10 @@ func getRootManager() namespace.Manager {
 	if _utManager != nil {
 		return _utManager
 	}
-	return namespace.NewNamespaceManager(true)
+	return namespace.NewNamespaceManager(&namespace.InitOptions{
+		WithDefaults: true,
+		Version:      getVersion(),
+	})
 }
 
 // Execute is called by the main method of the package

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,7 +60,7 @@ func TestVersionCmdShorthand(t *testing.T) {
 }
 
 func TestSetBuildInfoWithBI(t *testing.T) {
-	info := &Info{}
+	info := &core.Version{}
 	setBuildInfo(info, &debug.BuildInfo{Main: debug.Module{Version: "12345"}}, true)
 	assert.Equal(t, "12345", info.Version)
 }

--- a/docs/config_docs_test.go
+++ b/docs/config_docs_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestConfigDocsUpToDate(t *testing.T) {
 	// Initialize config of all plugins
-	namespace.NewNamespaceManager(false)
+	namespace.NewNamespaceManager(&namespace.InitOptions{WithDefaults: false})
 	apiserver.InitConfig()
 	generatedConfig, err := config.GenerateConfigMarkdown(context.Background(), config.GetKnownKeys())
 	assert.NoError(t, err)

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -371,6 +371,27 @@ func TestContractAPISwaggerUI(t *testing.T) {
 	assert.Regexp(t, "html", string(b))
 }
 
+func TestAPIVersion(t *testing.T) {
+	verInfo := core.Version{Version: "v1.2.3"}
+
+	mgr, _, as := newTestServer()
+	r := as.createMuxRouter(context.Background(), mgr)
+	s := httptest.NewServer(r)
+	defer s.Close()
+	mgr.On("Version").Return(verInfo)
+
+	req := httptest.NewRequest("GET", "/api/version", nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	r.ServeHTTP(res, req)
+
+	var retVerInfo core.Version
+	err := json.NewDecoder(res.Body).Decode(&retVerInfo)
+	assert.NoError(t, err)
+	assert.Equal(t, verInfo, retVerInfo)
+}
+
 func TestJSONBadNamespace(t *testing.T) {
 	mgr, _, as := newTestServer()
 	r := as.createMuxRouter(context.Background(), mgr)

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -261,4 +261,5 @@ var (
 	MsgDuplicatePluginRemoteName          = ffe("FF10419", "Invalid %s plugin remote name: %s - remote names must be unique")
 	MsgInvalidConnectorName               = ffe("FF10420", "Could not find name %s for %s connector")
 	MsgCannotInitLegacyNS                 = ffe("FF10421", "could not initialize legacy '%s' namespace - found conflicting V1 multi-party config in %s and %s")
+	MsgInvalidBuildVersion                = ffe("FF10422", "Invalid build: API version '%s' mismatched with build version '%s'")
 )

--- a/internal/namespace/manager_test.go
+++ b/internal/namespace/manager_test.go
@@ -130,7 +130,7 @@ func newTestNamespaceManager(resetConfig bool) *testNamespaceManager {
 }
 
 func TestNewNamespaceManager(t *testing.T) {
-	nm := NewNamespaceManager(true)
+	nm := NewNamespaceManager(&InitOptions{WithDefaults: true})
 	assert.NotNil(t, nm)
 }
 

--- a/mocks/namespacemocks/manager.go
+++ b/mocks/namespacemocks/manager.go
@@ -159,6 +159,20 @@ func (_m *Manager) Start() error {
 	return r0
 }
 
+// Version provides a mock function with given fields:
+func (_m *Manager) Version() core.Version {
+	ret := _m.Called()
+
+	var r0 core.Version
+	if rf, ok := ret.Get(0).(func() core.Version); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(core.Version)
+	}
+
+	return r0
+}
+
 // WaitStop provides a mock function with given fields:
 func (_m *Manager) WaitStop() {
 	_m.Called()

--- a/pkg/core/version.go
+++ b/pkg/core/version.go
@@ -1,0 +1,25 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+type Version struct {
+	Version    string `json:"Version,omitempty" yaml:"Version,omitempty"`
+	Commit     string `json:"Commit,omitempty" yaml:"Commit,omitempty"`
+	Date       string `json:"Date,omitempty" yaml:"Date,omitempty"`
+	License    string `json:"License,omitempty" yaml:"License,omitempty"`
+	APIVersion string `json:"APIVersion,omitempty" yaml:"APIVersion"`
+}


### PR DESCRIPTION
This PR proposes a simple way for clients (such as the Sandbox) to know what API version is hosted by the runtime server.
- Adds an `APIVersion` that comes for source code, to the existing version structure returned by the CLI
- The first two digits of the fully qualified semver - the "Minor" version, such as `1.1`
- Enforces that in builds where the `Version` is set, that must line up with the APIVersion
   - This is to avoid us forgetting to update it int he future
- Disables the check for `(devel)` builds