### PR TITLE
Performance improvements for batch lookups

### DIFF
--- a/cmd/firefly.go
+++ b/cmd/firefly.go
@@ -58,6 +58,7 @@ var showConfigCommand = &cobra.Command{
 	Short:   "List out the configuration options",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Initialize config of all plugins
+		resetConfig()
 		getRootManager()
 		_ = config.ReadConfig(configSuffix, cfgFile)
 
@@ -79,6 +80,11 @@ func init() {
 	rootCmd.AddCommand(showConfigCommand)
 }
 
+func resetConfig() {
+	coreconfig.Reset()
+	apiserver.InitConfig()
+}
+
 func getRootManager() namespace.Manager {
 	if _utManager != nil {
 		return _utManager
@@ -94,8 +100,7 @@ func Execute() error {
 func run() error {
 
 	// Read the configuration
-	coreconfig.Reset()
-	apiserver.InitConfig()
+	resetConfig()
 	err := config.ReadConfig(configSuffix, cfgFile)
 
 	// Setup logging after reading config (even if failed), to output header correctly
@@ -132,8 +137,7 @@ func run() error {
 			log.L(ctx).Infof("Restarting due to configuration change")
 			mgr.WaitStop()
 			// Re-read the configuration
-			coreconfig.Reset()
-			apiserver.InitConfig()
+			resetConfig()
 			if err := config.ReadConfig(configSuffix, cfgFile); err != nil {
 				cancelCtx()
 				return err

--- a/db/migrations/postgres/000096_add_namespace_to_message_indexes.up.sql
+++ b/db/migrations/postgres/000096_add_namespace_to_message_indexes.up.sql
@@ -44,6 +44,7 @@ DROP TABLE messages_data_old;
 UPDATE messages_data SET namespace = msg.namespace
   FROM (SELECT namespace, id FROM messages) AS msg
   WHERE messages_data.message_id = msg.id;
+ALTER TABLE messages_data ALTER COLUMN namespace SET NOT NULL;
 
 CREATE INDEX messages_data_message ON messages_data(namespace, message_id);
 CREATE INDEX messages_data_data ON messages_data(namespace, data_id);

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -171,12 +171,12 @@ func TestUpsertE2EWithDB(t *testing.T) {
 	assert.Equal(t, msg.Header.ID, &msgIDs[0].ID)
 	assert.Equal(t, msg.Sequence, msgIDs[0].Sequence)
 
-	batchIDs, err := s.GetBatchIDsForMessages(ctx, []*fftypes.UUID{msg.Header.ID})
+	batchIDs, err := s.GetBatchIDsForMessages(ctx, "ns12345", []*fftypes.UUID{msg.Header.ID})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(batchIDs))
 	assert.Equal(t, *msgUpdated.BatchID, *batchIDs[0])
 
-	batchIDs, err = s.GetBatchIDsForDataAttachments(ctx, []*fftypes.UUID{dataID2})
+	batchIDs, err = s.GetBatchIDsForDataAttachments(ctx, "ns12345", []*fftypes.UUID{dataID2})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(batchIDs))
 	assert.Equal(t, *msgUpdated.BatchID, *batchIDs[0])
@@ -668,7 +668,7 @@ func TestGetBatchIDsForMessagesSelectFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	msgID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
-	_, err := s.GetBatchIDsForMessages(context.Background(), []*fftypes.UUID{msgID})
+	_, err := s.GetBatchIDsForMessages(context.Background(), "ns1", []*fftypes.UUID{msgID})
 	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -677,7 +677,7 @@ func TestGetBatchIDsForMessagesScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	msgID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"batch_id"}).AddRow("not a UUID"))
-	_, err := s.GetBatchIDsForMessages(context.Background(), []*fftypes.UUID{msgID})
+	_, err := s.GetBatchIDsForMessages(context.Background(), "ns1", []*fftypes.UUID{msgID})
 	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/events/aggregator_rewind.go
+++ b/internal/events/aggregator_rewind.go
@@ -253,7 +253,7 @@ func (rw *rewinder) getRewindsForMessages(ctx context.Context, msgRewinds []*fft
 
 	if len(cacheMisses) > 0 {
 		log.L(ctx).Debugf("Cache misses for message rewinds: %v", cacheMisses)
-		msgBatchIDs, err := rw.database.GetBatchIDsForMessages(ctx, cacheMisses)
+		msgBatchIDs, err := rw.database.GetBatchIDsForMessages(ctx, rw.aggregator.namespace, cacheMisses)
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func (rw *rewinder) getRewindsForBlobs(ctx context.Context, newHashes []driver.V
 		for i, d := range data {
 			dataIDs[i] = d.ID
 		}
-		msgBatchIDs, err := rw.database.GetBatchIDsForDataAttachments(ctx, dataIDs)
+		msgBatchIDs, err := rw.database.GetBatchIDsForDataAttachments(ctx, rw.aggregator.namespace, dataIDs)
 		if err != nil {
 			return err
 		}

--- a/internal/events/aggregator_rewind_test.go
+++ b/internal/events/aggregator_rewind_test.go
@@ -46,14 +46,14 @@ func TestRewinderE2E(t *testing.T) {
 	mockRunAsGroupPassthrough(mdi)
 	mdi.On("GetDataRefs", mock.Anything, "ns1", mock.Anything).
 		Return(core.DataRefs{{ID: dataID}}, nil, nil)
-	mdi.On("GetBatchIDsForDataAttachments", mock.Anything, []*fftypes.UUID{dataID}).
+	mdi.On("GetBatchIDsForDataAttachments", mock.Anything, "ns1", []*fftypes.UUID{dataID}).
 		Return([]*fftypes.UUID{batchID2}, nil)
 	mdm.On("PeekMessageCache", mock.Anything, mock.Anything, data.CRORequireBatchID).Return(nil, nil)
-	mdi.On("GetBatchIDsForMessages", mock.Anything, mock.Anything).
+	mdi.On("GetBatchIDsForMessages", mock.Anything, "ns1", mock.Anything).
 		Return([]*fftypes.UUID{batchID3}, nil).Once()
 	mdi.On("GetMessageIDs", mock.Anything, "ns1", mock.Anything).
 		Return([]*core.IDAndSequence{{ID: *fftypes.NewUUID()}}, nil).Once()
-	mdi.On("GetBatchIDsForMessages", mock.Anything, mock.Anything).
+	mdi.On("GetBatchIDsForMessages", mock.Anything, "ns1", mock.Anything).
 		Return([]*fftypes.UUID{batchID4}, nil).Once()
 
 	ag.rewinder.start()
@@ -96,7 +96,7 @@ func TestProcessStagedRewindsErrorMessages(t *testing.T) {
 
 	mockRunAsGroupPassthrough(mdi)
 	mdm.On("PeekMessageCache", mock.Anything, mock.Anything, data.CRORequireBatchID).Return(nil, nil)
-	mdi.On("GetBatchIDsForMessages", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
+	mdi.On("GetBatchIDsForMessages", mock.Anything, "ns1", mock.Anything).Return(nil, fmt.Errorf("pop"))
 
 	ag.rewinder.stagedRewinds = []*rewind{
 		{rewindType: rewindMessage},
@@ -143,7 +143,7 @@ func TestProcessStagedRewindsErrorBlobBatchIDs(t *testing.T) {
 	mockRunAsGroupPassthrough(mdi)
 	mdi.On("GetDataRefs", mock.Anything, "ns1", mock.Anything).
 		Return(core.DataRefs{{ID: dataID}}, nil, nil)
-	mdi.On("GetBatchIDsForDataAttachments", mock.Anything, []*fftypes.UUID{dataID}).
+	mdi.On("GetBatchIDsForDataAttachments", mock.Anything, "ns1", []*fftypes.UUID{dataID}).
 		Return(nil, fmt.Errorf("pop"))
 
 	ag.rewinder.stagedRewinds = []*rewind{

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -130,13 +130,13 @@ func (_m *Plugin) GetBatchByID(ctx context.Context, namespace string, id *fftype
 	return r0, r1
 }
 
-// GetBatchIDsForDataAttachments provides a mock function with given fields: ctx, dataIDs
-func (_m *Plugin) GetBatchIDsForDataAttachments(ctx context.Context, dataIDs []*fftypes.UUID) ([]*fftypes.UUID, error) {
-	ret := _m.Called(ctx, dataIDs)
+// GetBatchIDsForDataAttachments provides a mock function with given fields: ctx, namespace, dataIDs
+func (_m *Plugin) GetBatchIDsForDataAttachments(ctx context.Context, namespace string, dataIDs []*fftypes.UUID) ([]*fftypes.UUID, error) {
+	ret := _m.Called(ctx, namespace, dataIDs)
 
 	var r0 []*fftypes.UUID
-	if rf, ok := ret.Get(0).(func(context.Context, []*fftypes.UUID) []*fftypes.UUID); ok {
-		r0 = rf(ctx, dataIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*fftypes.UUID) []*fftypes.UUID); ok {
+		r0 = rf(ctx, namespace, dataIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*fftypes.UUID)
@@ -144,8 +144,8 @@ func (_m *Plugin) GetBatchIDsForDataAttachments(ctx context.Context, dataIDs []*
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, []*fftypes.UUID) error); ok {
-		r1 = rf(ctx, dataIDs)
+	if rf, ok := ret.Get(1).(func(context.Context, string, []*fftypes.UUID) error); ok {
+		r1 = rf(ctx, namespace, dataIDs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -153,13 +153,13 @@ func (_m *Plugin) GetBatchIDsForDataAttachments(ctx context.Context, dataIDs []*
 	return r0, r1
 }
 
-// GetBatchIDsForMessages provides a mock function with given fields: ctx, msgIDs
-func (_m *Plugin) GetBatchIDsForMessages(ctx context.Context, msgIDs []*fftypes.UUID) ([]*fftypes.UUID, error) {
-	ret := _m.Called(ctx, msgIDs)
+// GetBatchIDsForMessages provides a mock function with given fields: ctx, namespace, msgIDs
+func (_m *Plugin) GetBatchIDsForMessages(ctx context.Context, namespace string, msgIDs []*fftypes.UUID) ([]*fftypes.UUID, error) {
+	ret := _m.Called(ctx, namespace, msgIDs)
 
 	var r0 []*fftypes.UUID
-	if rf, ok := ret.Get(0).(func(context.Context, []*fftypes.UUID) []*fftypes.UUID); ok {
-		r0 = rf(ctx, msgIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*fftypes.UUID) []*fftypes.UUID); ok {
+		r0 = rf(ctx, namespace, msgIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*fftypes.UUID)
@@ -167,8 +167,8 @@ func (_m *Plugin) GetBatchIDsForMessages(ctx context.Context, msgIDs []*fftypes.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, []*fftypes.UUID) error); ok {
-		r1 = rf(ctx, msgIDs)
+	if rf, ok := ret.Get(1).(func(context.Context, string, []*fftypes.UUID) error); ok {
+		r1 = rf(ctx, namespace, msgIDs)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -106,10 +106,10 @@ type iMessageCollection interface {
 	GetMessagesForData(ctx context.Context, namespace string, dataID *fftypes.UUID, filter Filter) (message []*core.Message, res *FilterResult, err error)
 
 	// GetBatchIDsForMessages - an optimized query to retrieve any non-null batch IDs for a list of message IDs
-	GetBatchIDsForMessages(ctx context.Context, msgIDs []*fftypes.UUID) (batchIDs []*fftypes.UUID, err error)
+	GetBatchIDsForMessages(ctx context.Context, namespace string, msgIDs []*fftypes.UUID) (batchIDs []*fftypes.UUID, err error)
 
 	// GetBatchIDsForDataAttachments - an optimized query to retrieve any non-null batch IDs for a list of data IDs that might be attached to messages in batches
-	GetBatchIDsForDataAttachments(ctx context.Context, dataIDs []*fftypes.UUID) (batchIDs []*fftypes.UUID, err error)
+	GetBatchIDsForDataAttachments(ctx context.Context, namespace string, dataIDs []*fftypes.UUID) (batchIDs []*fftypes.UUID, err error)
 }
 
 type iDataCollection interface {


### PR DESCRIPTION
Ensure batch ID queries match the current indexes (to avoid sequential scan), and improve the caching in aggregator when processing a group of pins.