### PR TITLE
Fix group race condition, optimize transaction cache

### DIFF
--- a/internal/privatemessaging/groupmanager_test.go
+++ b/internal/privatemessaging/groupmanager_test.go
@@ -47,6 +47,8 @@ func TestGroupInitWriteGroupFail(t *testing.T) {
 
 	mdi := pm.database.(*databasemocks.Plugin)
 	mdi.On("UpsertGroup", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(fmt.Errorf("pop"))
+	mdi.On("UpsertData", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(nil)
+	mdi.On("UpsertMessage", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(nil)
 
 	group := &core.Group{
 		GroupIdentity: core.GroupIdentity{
@@ -59,6 +61,32 @@ func TestGroupInitWriteGroupFail(t *testing.T) {
 	group.Seal()
 	err := pm.groupInit(pm.ctx, &core.SignerRef{}, group)
 	assert.Regexp(t, "pop", err)
+
+	mdi.AssertExpectations(t)
+}
+
+func TestGroupInitWriteMessageFail(t *testing.T) {
+
+	pm, cancel := newTestPrivateMessaging(t)
+	defer cancel()
+
+	mdi := pm.database.(*databasemocks.Plugin)
+	mdi.On("UpsertData", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(nil)
+	mdi.On("UpsertMessage", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(fmt.Errorf("pop"))
+
+	group := &core.Group{
+		GroupIdentity: core.GroupIdentity{
+			Namespace: "ns1",
+			Members: core.Members{
+				{Identity: "id1", Node: fftypes.NewUUID()},
+			},
+		},
+	}
+	group.Seal()
+	err := pm.groupInit(pm.ctx, &core.SignerRef{}, group)
+	assert.Regexp(t, "pop", err)
+
+	mdi.AssertExpectations(t)
 }
 
 func TestGroupInitWriteDataFail(t *testing.T) {
@@ -67,7 +95,6 @@ func TestGroupInitWriteDataFail(t *testing.T) {
 	defer cancel()
 
 	mdi := pm.database.(*databasemocks.Plugin)
-	mdi.On("UpsertGroup", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(nil)
 	mdi.On("UpsertData", mock.Anything, mock.Anything, database.UpsertOptimizationNew).Return(fmt.Errorf("pop"))
 
 	group := &core.Group{
@@ -81,6 +108,8 @@ func TestGroupInitWriteDataFail(t *testing.T) {
 	group.Seal()
 	err := pm.groupInit(pm.ctx, &core.SignerRef{}, group)
 	assert.Regexp(t, "pop", err)
+
+	mdi.AssertExpectations(t)
 }
 
 func TestResolveInitGroupMissingData(t *testing.T) {

--- a/internal/txcommon/txcommon.go
+++ b/internal/txcommon/txcommon.go
@@ -105,6 +105,7 @@ func (t *transactionHelper) SubmitNewTransaction(ctx context.Context, txType cor
 		return nil, err
 	}
 
+	t.updateTransactionsCache(tx)
 	return tx.ID, nil
 }
 
@@ -144,7 +145,6 @@ func (t *transactionHelper) PersistTransaction(ctx context.Context, id *fftypes.
 	}
 
 	t.updateTransactionsCache(tx)
-
 	return true, nil
 }
 
@@ -162,8 +162,8 @@ func (t *transactionHelper) AddBlockchainTX(ctx context.Context, tx *core.Transa
 	if err != nil {
 		return err
 	}
-	t.updateTransactionsCache(tx)
 
+	t.updateTransactionsCache(tx)
 	return nil
 }
 


### PR DESCRIPTION
Insert local group only after inserting groupinit message.
This ensures no other threads pick up on the group before the
message is sequenced.

Update transaction cache after initial insert.