### PR TITLE
fix integration matrix `exclude`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,12 +16,22 @@ jobs:
         blockchain-provider: [geth, besu, fabric]
         database-type: [sqlite3, postgres]
         exclude:
-          - blockchain-provider: geth
-            test-suite: [TestFabricGatewayE2ESuite, TestFabricMultipartyE2ESuite]
-          - blockchain-provider: besu
-            test-suite: [TestFabricGatewayE2ESuite, TestFabricMultipartyE2ESuite]
-          - blockchain-provider: fabric
-            test-suite: [TestEthereumMultipartyE2ESuite, TestEthereumGatewayE2ESuite, TestEthereumMultipartyTokensRemoteNameE2ESuite]
+          - test-suite: TestEthereumGatewayE2ESuite
+            blockchain-provider: fabric
+          - test-suite: TestEthereumMultipartyE2ESuite
+            blockchain-provider: fabric
+          - test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
+            blockchain-provider: fabric
+          - test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
+            blockchain-provider: fabric
+          - test-suite: TestFabricGatewayE2ESuite
+            blockchain-provider: geth
+          - test-suite: TestFabricGatewayE2ESuite
+            blockchain-provider: besu
+          - test-suite: TestFabricMultipartyE2ESuite
+            blockchain-provider: geth
+          - test-suite: TestFabricMultipartyE2ESuite
+            blockchain-provider: besu
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`exclude` was not correctly handling arrays, so it has been updated to explicitly define all excluded combinations

list of jobs that will be executed now (courtesy of [act](https://github.com/nektos/act)):


-  `[blockchain-provider:besu database-type:postgres test-suite:TestEthereumMultipartyE2ESuite]`
- `[blockchain-provider:geth database-type:sqlite3 test-suite:TestEthereumMultipartyE2ESuite]`
- `[blockchain-provider:geth database-type:postgres test-suite:TestEthereumMultipartyE2ESuite]`
- `[blockchain-provider:geth database-type:sqlite3 test-suite:TestEthereumGatewayE2ESuite]`
- `[blockchain-provider:geth database-type:postgres test-suite:TestEthereumGatewayE2ESuite]`
- `[blockchain-provider:besu database-type:sqlite3 test-suite:TestEthereumGatewayE2ESuite]`
- `[blockchain-provider:besu database-type:postgres test-suite:TestEthereumGatewayE2ESuite]`
- `[bockchain-provider:geth database-type:sqlite3 test-suite:TestEthereumMultipartyTokensRemoteNameE2ESuite]`
- `[blockchain-provider:geth database-type:postgres test-suite:TestEthereumMultipartyTokensRemoteNameE2ESuite]`
- `[blockchain-provider:besu database-type:sqlite3 test-suite:TestEthereumMultipartyTokensRemoteNameE2ESuite]`
- `[blockchain-provider:besu database-type:postgres test-suite:TestEthereumMultipartyTokensRemoteNameE2ESuite]`
- `[blockchain-provider:fabric database-type:sqlite3 test-suite:TestFabricGatewayE2ESuite]`
- `[blockchain-provider:fabric database-type:postgres test-suite:TestFabricGatewayE2ESuite]`
- `[blockchain-provider:fabric database-type:sqlite3 test-suite:TestFabricMultipartyE2ESuite]`
- `[blockchain-provider:fabric database-type:postgres test-suite:TestFabricMultipartyE2ESuite]`

closes #968 