### PR TITLE
Adjust defaults for all cache items that don't expose a Size

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,7 +36,7 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|size|The size of the cache|[`BytesSize`](https://pkg.go.dev/github.com/docker/go-units#BytesSize)|`<nil>`
+|limit|Max number of cache items for batches|`string`|`<nil>`
 |ttl|The time to live (TTL) for the cache|[`time.Duration`](https://pkg.go.dev/time#Duration)|`<nil>`
 
 ## batch.manager
@@ -268,7 +268,7 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|size|The size of the cache|[`BytesSize`](https://pkg.go.dev/github.com/docker/go-units#BytesSize)|`<nil>`
+|limit|Max number of cache items for blockchain events|`string`|`<nil>`
 |ttl|The time to live (TTL) for the cache|[`time.Duration`](https://pkg.go.dev/time#Duration)|`<nil>`
 
 ## broadcast.batch
@@ -284,14 +284,14 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|size|Size of blockchain cache|`string`|`<nil>`
+|limit|Max number of cache items for blockchain plugin cache|`string`|`<nil>`
 |ttl|Time to live for blockchain cache items|`string`|`<nil>`
 
 ## cache.operations
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|size|Size of operation cache|`string`|`<nil>`
+|limit|Max number of cache items for operations|`string`|`<nil>`
 |ttl|Time to live for operation cache items|`string`|`<nil>`
 
 ## cors
@@ -467,7 +467,7 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|size|The size of the cache|[`BytesSize`](https://pkg.go.dev/github.com/docker/go-units#BytesSize)|`<nil>`
+|limit|Max number of cache items for blockchain listener topics|`string`|`<nil>`
 |ttl|The time to live (TTL) for the cache|[`time.Duration`](https://pkg.go.dev/time#Duration)|`<nil>`
 
 ## event.transports
@@ -481,7 +481,7 @@ nav_order: 2
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|size|The size of the cache|[`BytesSize`](https://pkg.go.dev/github.com/docker/go-units#BytesSize)|`<nil>`
+|limit|Max number of cache items for private group addresses|`string`|`<nil>`
 |ttl|The time to live (TTL) for the cache|[`time.Duration`](https://pkg.go.dev/time#Duration)|`<nil>`
 
 ## histograms

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -161,7 +161,7 @@ func (e *Ethereum) Init(ctx context.Context, conf config.Section, metrics metric
 	}
 
 	e.cacheTTL = config.GetDuration(coreconfig.CacheBlockchainTTL)
-	e.cache = ccache.New(ccache.Configure().MaxSize(config.GetByteSize(coreconfig.CacheBlockchainSize)))
+	e.cache = ccache.New(ccache.Configure().MaxSize(config.GetInt64(coreconfig.CacheBlockchainLimit)))
 
 	e.streams = newStreamManager(e.client, e.cache, e.cacheTTL)
 	batchSize := ethconnectConf.GetUint(EthconnectConfigBatchSize)

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -223,7 +223,7 @@ func (f *Fabric) Init(ctx context.Context, conf config.Section, metrics metrics.
 	}
 
 	f.cacheTTL = config.GetDuration(coreconfig.CacheBlockchainTTL)
-	f.cache = ccache.New(ccache.Configure().MaxSize(config.GetByteSize(coreconfig.CacheBlockchainSize)))
+	f.cache = ccache.New(ccache.Configure().MaxSize(config.GetInt64(coreconfig.CacheBlockchainLimit)))
 
 	f.streams = newStreamManager(f.client, f.signer, f.cache, f.cacheTTL)
 	batchSize := f.fabconnectConf.GetUint(FabconnectConfigBatchSize)

--- a/internal/coreconfig/coreconfig.go
+++ b/internal/coreconfig/coreconfig.go
@@ -80,9 +80,9 @@ var (
 	APIRequestMaxTimeout = ffc("api.requestMaxTimeout")
 	// APIOASPanicOnMissingDescription controls whether the OpenAPI Spec generator will strongly enforce descriptions on every field or not
 	APIOASPanicOnMissingDescription = ffc("api.oas.panicOnMissingDescription")
-	// BatchCacheSize
-	BatchCacheSize = ffc("batch.cache.size")
-	// BatchCacheSize
+	// BatchCacheLimit max number of cache items for batches
+	BatchCacheLimit = ffc("batch.cache.limit")
+	// BatchCacheTTL time to live for cache of batches
 	BatchCacheTTL = ffc("batch.cache.ttl")
 	// BatchManagerReadPageSize is the size of each page of messages read from the database into memory when assembling batches
 	BatchManagerReadPageSize = ffc("batch.manager.readPageSize")
@@ -108,9 +108,9 @@ var (
 	BlobReceiverWorkerBatchTimeout = ffc("blobreceiver.worker.batchTimeout")
 	// BlobReceiverWorkerBatchMaxInserts
 	BlobReceiverWorkerBatchMaxInserts = ffc("blobreceiver.worker.batchMaxInserts")
-	// BlockchainEventCacheSize size of cache for blockchain events
-	BlockchainEventCacheSize = ffc("blockchainevent.cache.size")
-	// BlockchainEventCacheTTL time to live of cache for blockchain events
+	// BlockchainEventCacheLimit max number of cache items for blockchain events
+	BlockchainEventCacheLimit = ffc("blockchainevent.cache.limit")
+	// BlockchainEventCacheTTL time to live for cache of blockchain events
 	BlockchainEventCacheTTL = ffc("blockchainevent.cache.ttl")
 	// BroadcastBatchAgentTimeout how long to keep around a batching agent for a sending identity before disposal
 	BroadcastBatchAgentTimeout = ffc("broadcast.batch.agentTimeout")
@@ -120,14 +120,14 @@ var (
 	BroadcastBatchPayloadLimit = ffc("broadcast.batch.payloadLimit")
 	// BroadcastBatchTimeout is the timeout to wait for a batch to fill, before sending
 	BroadcastBatchTimeout = ffc("broadcast.batch.timeout")
-	// CacheBlockchainTTL size of cache for blockchain plugin cache
+	// CacheBlockchainTTL time to live of blockchain plugin cache
 	CacheBlockchainTTL = ffc("cache.blockchain.ttl")
-	// CacheBlockchainSize the max number of cache items for blockchain plugin cache
-	CacheBlockchainSize = ffc("cache.blockchain.size")
-	// CacheOperationsTTL time to live of cache for operations cache
+	// CacheBlockchainLimit max number of cache items for blockchain plugin cache
+	CacheBlockchainLimit = ffc("cache.blockchain.limit")
+	// CacheOperationsTTL time to live for cache of operations
 	CacheOperationsTTL = ffc("cache.operations.ttl")
-	// CacheOperationsSize the max number of cache items for operations cache
-	CacheOperationsSize = ffc("cache.operations.size")
+	// CacheOperationsLimit the max number of cache items for operations
+	CacheOperationsLimit = ffc("cache.operations.limit")
 	// DownloadWorkerCount is the number of download workers created to pull data from shared storage to the local DX
 	DownloadWorkerCount = ffc("download.worker.count")
 	// DownloadWorkerQueueLength is the length of the work queue in the channel to the workers - defaults to 2x the worker count
@@ -212,12 +212,12 @@ var (
 	EventDispatcherRetryMaxDelay = ffc("event.dispatcher.retry.maxDelay")
 	// EventDBEventsBufferSize the size of the buffer of change events
 	EventDBEventsBufferSize = ffc("event.dbevents.bufferSize")
-	// EventListenerTopicCacheSize cache size for blockchain listeners addresses
-	EventListenerTopicCacheSize = ffc("event.listenerTopic.cache.size")
-	// EventListenerTopicCacheTTL cache time-to-live for private group addresses
+	// EventListenerTopicCacheLimit max number of cache items for blockchain listener topics
+	EventListenerTopicCacheLimit = ffc("event.listenerTopic.cache.limit")
+	// EventListenerTopicCacheTTL time-to-live for for cache of blockchain listener topics
 	EventListenerTopicCacheTTL = ffc("event.listenerTopic.cache.ttl")
-	// GroupCacheSize cache size for private group addresses
-	GroupCacheSize = ffc("group.cache.size")
+	// GroupCacheLimit cache size for private group addresses
+	GroupCacheLimit = ffc("group.cache.limit")
 	// GroupCacheTTL cache time-to-live for private group addresses
 	GroupCacheTTL = ffc("group.cache.ttl")
 	// SPIEnabled determines whether the admin interface will be enabled or not
@@ -234,9 +234,9 @@ var (
 	IdentityManagerCacheTTL = ffc("identity.manager.cache.ttl")
 	// IdentityManagerCacheLimit the identity manager cache limit in count of items
 	IdentityManagerCacheLimit = ffc("identity.manager.cache.limit")
-	// MessageCacheSize
+	// MessageCacheSize max size for cache of messages
 	MessageCacheSize = ffc("message.cache.size")
-	// MessageCacheTTL
+	// MessageCacheTTL time-to-live for cache of messages
 	MessageCacheTTL = ffc("message.cache.ttl")
 	// MessageWriterCount
 	MessageWriterCount = ffc("message.writer.count")
@@ -288,9 +288,9 @@ var (
 	SubscriptionsRetryMaxDelay = ffc("subscription.retry.maxDelay")
 	// SubscriptionsRetryFactor the backoff factor to use for retry of database operations
 	SubscriptionsRetryFactor = ffc("subscription.retry.factor")
-	// TransactionCacheSize
+	// TransactionCacheSize max size for cache of transactions
 	TransactionCacheSize = ffc("transaction.cache.size")
-	// TransactionCacheTTL
+	// TransactionCacheTTL time-to-live for cache of transactions
 	TransactionCacheTTL = ffc("transaction.cache.ttl")
 	// AssetManagerKeyNormalization mechanism to normalize keys before using them. Valid options: "blockchain_plugin" - use blockchain plugin (default), "none" - do not attempt normalization
 	AssetManagerKeyNormalization = ffc("asset.manager.keynormalization")
@@ -298,9 +298,9 @@ var (
 	UIEnabled = ffc("ui.enabled")
 	// UIPath the path on which to serve the UI
 	UIPath = ffc("ui.path")
-	// ValidatorCacheSize
+	// ValidatorCacheSize max size for cache of validators
 	ValidatorCacheSize = ffc("validator.cache.size")
-	// ValidatorCacheTTL
+	// ValidatorCacheTTL time-to-live for cache of validators
 	ValidatorCacheTTL = ffc("validator.cache.ttl")
 )
 
@@ -313,7 +313,7 @@ func setDefaults() {
 	viper.SetDefault(string(APIMaxFilterSkip), 1000) // protects database (skip+limit pagination is not for bulk operations)
 	viper.SetDefault(string(APIRequestTimeout), "120s")
 	viper.SetDefault(string(AssetManagerKeyNormalization), "blockchain_plugin")
-	viper.SetDefault(string(BatchCacheSize), "1Mb")
+	viper.SetDefault(string(BatchCacheLimit), 100)
 	viper.SetDefault(string(BatchCacheTTL), "5m")
 	viper.SetDefault(string(BatchManagerReadPageSize), 100)
 	viper.SetDefault(string(BatchManagerReadPollTimeout), "30s")
@@ -330,12 +330,16 @@ func setDefaults() {
 	viper.SetDefault(string(BlobReceiverWorkerBatchTimeout), "50ms")
 	viper.SetDefault(string(BlobReceiverWorkerCount), 5)
 	viper.SetDefault(string(BlobReceiverWorkerBatchMaxInserts), 200)
+	viper.SetDefault(string(BlockchainEventCacheLimit), 100)
+	viper.SetDefault(string(BlockchainEventCacheTTL), "5m")
 	viper.SetDefault(string(BroadcastBatchAgentTimeout), "2m")
 	viper.SetDefault(string(BroadcastBatchSize), 200)
 	viper.SetDefault(string(BroadcastBatchPayloadLimit), "800Kb")
 	viper.SetDefault(string(BroadcastBatchTimeout), "1s")
-	viper.SetDefault(string(CacheBlockchainSize), "50Mb")
+	viper.SetDefault(string(CacheBlockchainLimit), 100)
 	viper.SetDefault(string(CacheBlockchainTTL), "5m")
+	viper.SetDefault(string(CacheOperationsLimit), 200)
+	viper.SetDefault(string(CacheOperationsTTL), "5m")
 	viper.SetDefault(string(HistogramsMaxChartRows), 100)
 	viper.SetDefault(string(DebugPort), -1)
 	viper.SetDefault(string(DownloadWorkerCount), 10)
@@ -359,9 +363,9 @@ func setDefaults() {
 	viper.SetDefault(string(EventDispatcherPollTimeout), "30s")
 	viper.SetDefault(string(EventTransportsEnabled), []string{"websockets", "webhooks"})
 	viper.SetDefault(string(EventTransportsDefault), "websockets")
-	viper.SetDefault(string(EventListenerTopicCacheSize), "100Kb")
+	viper.SetDefault(string(EventListenerTopicCacheLimit), 100)
 	viper.SetDefault(string(EventListenerTopicCacheTTL), "5m")
-	viper.SetDefault(string(GroupCacheSize), "1Mb")
+	viper.SetDefault(string(GroupCacheLimit), 50)
 	viper.SetDefault(string(GroupCacheTTL), "1h")
 	viper.SetDefault(string(SPIEnabled), false)
 	viper.SetDefault(string(SPIWebSocketReadBufferSize), "16Kb")

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -93,10 +93,15 @@ var (
 	ConfigBlockchainFabricFabconnectProxyURL     = ffc("config.blockchain.fabric.fabconnect.proxy.url", "Optional HTTP proxy server to use when connecting to Fabconnect", "URL "+i18n.StringType)
 
 	ConfigCacheBlockchainTTL  = ffc("config.cache.blockchain.ttl", "Time to live for blockchain cache items", i18n.StringType)
-	ConfigCacheBlockchainSize = ffc("config.cache.blockchain.size", "Size of blockchain cache", i18n.StringType)
+	ConfigCacheBlockchainSize = ffc("config.cache.blockchain.limit", "Max number of cache items for blockchain plugin cache", i18n.StringType)
 
 	ConfigCacheOperationsTTL  = ffc("config.cache.operations.ttl", "Time to live for operation cache items", i18n.StringType)
-	ConfigCacheOperationsSize = ffc("config.cache.operations.size", "Size of operation cache", i18n.StringType)
+	ConfigCacheOperationsSize = ffc("config.cache.operations.limit", "Max number of cache items for operations", i18n.StringType)
+
+	ConfigCacheBatchLimit           = ffc("config.batch.cache.limit", "Max number of cache items for batches", i18n.StringType)
+	ConfigCacheBlockchainEventLimit = ffc("config.blockchainevent.cache.limit", "Max number of cache items for blockchain events", i18n.StringType)
+	ConfigCacheListenerTopicLimit   = ffc("config.event.listenerTopic.cache.limit", "Max number of cache items for blockchain listener topics", i18n.StringType)
+	ConfigCacheGroupLimit           = ffc("config.group.cache.limit", "Max number of cache items for private group addresses", i18n.StringType)
 
 	ConfigPluginDatabase     = ffc("config.plugins.database", "The list of configured Database plugins", i18n.StringType)
 	ConfigPluginDatabaseName = ffc("config.plugins.database[].name", "The name of the Database plugin", i18n.StringType)

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -82,7 +82,7 @@ func newAggregator(ctx context.Context, ns string, di database.Plugin, bi blockc
 	ag.batchCache = ccache.New(
 		// We use a LRU cache with a size-aware max
 		ccache.Configure().
-			MaxSize(config.GetByteSize(coreconfig.BatchCacheSize)),
+			MaxSize(config.GetInt64(coreconfig.BatchCacheLimit)),
 	)
 	firstEvent := core.SubOptsFirstEvent(config.GetString(coreconfig.EventAggregatorFirstEvent))
 	ag.eventPoller = newEventPoller(ctx, di, en, &eventPollerConf{

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -145,7 +145,7 @@ func NewEventManager(ctx context.Context, ns core.NamespaceRef, di database.Plug
 		newEventNotifier:      newEventNotifier,
 		newPinNotifier:        newPinNotifier,
 		metrics:               mm,
-		chainListenerCache:    ccache.New(ccache.Configure().MaxSize(config.GetByteSize(coreconfig.EventListenerTopicCacheSize))),
+		chainListenerCache:    ccache.New(ccache.Configure().MaxSize(config.GetInt64(coreconfig.EventListenerTopicCacheLimit))),
 		chainListenerCacheTTL: config.GetDuration(coreconfig.EventListenerTopicCacheTTL),
 	}
 	ie, _ := eifactory.GetPlugin(ctx, system.SystemEventsTransport)

--- a/internal/operations/manager.go
+++ b/internal/operations/manager.go
@@ -83,7 +83,7 @@ func NewOperationsManager(ctx context.Context, ns string, di database.Plugin, tx
 	}
 	om.updater = newOperationUpdater(ctx, om, di, txHelper)
 	om.cache = ccache.New(
-		ccache.Configure().MaxSize(config.GetInt64(coreconfig.CacheOperationsSize)),
+		ccache.Configure().MaxSize(config.GetInt64(coreconfig.CacheOperationsLimit)),
 	)
 	return om, nil
 }

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -117,7 +117,7 @@ func NewPrivateMessaging(ctx context.Context, ns core.NamespaceRef, di database.
 	pm.groupManager.groupCache = ccache.New(
 		// We use a LRU cache with a size-aware max
 		ccache.Configure().
-			MaxSize(config.GetByteSize(coreconfig.GroupCacheSize)),
+			MaxSize(config.GetInt64(coreconfig.GroupCacheLimit)),
 	)
 
 	bo := batch.DispatcherOptions{

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -43,7 +43,7 @@ import (
 func newTestPrivateMessagingCommon(t *testing.T, metricsEnabled bool) (*privateMessaging, func()) {
 	coreconfig.Reset()
 	config.Set(coreconfig.GroupCacheTTL, "1m")
-	config.Set(coreconfig.GroupCacheSize, "1m")
+	config.Set(coreconfig.GroupCacheLimit, 10)
 
 	mdi := &databasemocks.Plugin{}
 	mim := &identitymanagermocks.Manager{}

--- a/internal/txcommon/txcommon.go
+++ b/internal/txcommon/txcommon.go
@@ -64,7 +64,7 @@ func NewTransactionHelper(ns string, di database.Plugin, dm data.Manager) Helper
 	t.blockchainEventCache = ccache.New(
 		// We use a LRU cache with a size-aware max
 		ccache.Configure().
-			MaxSize(config.GetByteSize(coreconfig.BlockchainEventCacheSize)),
+			MaxSize(config.GetInt64(coreconfig.BlockchainEventCacheLimit)),
 	)
 	return t
 }

--- a/internal/txcommon/txcommon_test.go
+++ b/internal/txcommon/txcommon_test.go
@@ -48,7 +48,7 @@ func NewTestTransactionHelper(di database.Plugin, dm data.Manager) (Helper, *cca
 	t.blockchainEventCache = ccache.New(
 		// We use a LRU cache with a size-aware max
 		ccache.Configure().
-			MaxSize(config.GetByteSize(coreconfig.BlockchainEventCacheSize)),
+			MaxSize(config.GetByteSize(coreconfig.BlockchainEventCacheLimit)),
 	)
 	return t, t.transactionCache, t.blockchainEventCache
 }


### PR DESCRIPTION
Caches may be limited on size (if the items advertise their Size) or on
number of items. Since most cached items do not expose a Size, the limit
should be set on number of items alone.

Picked numbers pretty much at random, so I'm open to feedback if they
should be higher or lower, or if any of these items should get a Size method
to do size estimation.

I've tagged with "migration_consideration" since I have renamed a few
config keys, but I don't think they're widely used.