### PR TITLE
Fix bugs when running with an old config file

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -17,6 +17,12 @@ nav_order: 2
 ---
 
 
+## admin
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|enabled|Deprecated - use spi.enabled instead|`boolean`|`<nil>`
+
 ## api
 
 |Key|Description|Type|Default Value|

--- a/ffconfig/migrate/migrations.go
+++ b/ffconfig/migrate/migrations.go
@@ -28,7 +28,6 @@ import (
 var migrations = map[string]func(root *ConfigItem){
 	"1.0.0": func(root *ConfigItem) {
 		root.Get("org").Get("identity").RenameTo("key")
-		root.Get("publicstorage").RenameTo("sharedstorage")
 		root.Get("tokens").Each().Get("connector").RenameTo("plugin").ReplaceValue("https", "fftokens")
 		root.Get("dataexchange").Get("type").ReplaceValue("https", "ffdx")
 		root.Get("dataexchange").Get("https").RenameTo("ffdx")
@@ -36,6 +35,10 @@ var migrations = map[string]func(root *ConfigItem){
 
 	"1.0.3": func(root *ConfigItem) {
 		root.Get("dataexchange").Get("type").SetIfEmpty("ffdx")
+	},
+
+	"1.0.4": func(root *ConfigItem) {
+		root.Get("publicstorage").RenameTo("sharedstorage")
 	},
 
 	"1.1.0": func(root *ConfigItem) {

--- a/ffconfig/migrate/migrations_test.go
+++ b/ffconfig/migrate/migrations_test.go
@@ -34,7 +34,7 @@ publicstorage:
 	assert.Equal(t, `database:
   type: sqlite3
 dataexchange: {}
-sharedstorage:
+publicstorage:
   type: ipfs
 `, string(result))
 }
@@ -43,16 +43,12 @@ func TestMigratev1_0_0(t *testing.T) {
 	config := []byte(`database:
   type: sqlite3
 dataexchange: {}
-publicstorage:
-  type: ipfs
 `)
 	result, err := Run(config, "", "v1.0.0")
 	assert.NoError(t, err)
 	assert.Equal(t, `database:
   type: sqlite3
 dataexchange: {}
-sharedstorage:
-  type: ipfs
 `, string(result))
 }
 
@@ -60,8 +56,6 @@ func TestMigrate1_0_3(t *testing.T) {
 	config := []byte(`database:
   type: sqlite3
 dataexchange: {}
-publicstorage:
-  type: ipfs
 `)
 	result, err := Run(config, "", "1.0.3")
 	assert.NoError(t, err)
@@ -69,8 +63,6 @@ publicstorage:
   type: sqlite3
 dataexchange:
   type: ffdx
-sharedstorage:
-  type: ipfs
 `, string(result))
 }
 
@@ -88,6 +80,24 @@ publicstorage:
 dataexchange:
   type: ffdx
 publicstorage:
+  type: ipfs
+`, string(result))
+}
+
+func TestMigrate1_0_4(t *testing.T) {
+	config := []byte(`database:
+  type: sqlite3
+dataexchange: {}
+publicstorage:
+  type: ipfs
+`)
+	result, err := Run(config, "", "1.0.4")
+	assert.NoError(t, err)
+	assert.Equal(t, `database:
+  type: sqlite3
+dataexchange:
+  type: ffdx
+sharedstorage:
   type: ipfs
 `, string(result))
 }

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/httpserver"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
+	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly/internal/coreconfig"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/internal/events/eifactory"
@@ -109,6 +110,8 @@ func (as *apiServer) Serve(ctx context.Context, mgr namespace.Manager) (err erro
 			return err
 		}
 		go spiHTTPServer.ServeHTTP(ctx)
+	} else if config.GetBool(coreconfig.LegacyAdminEnabled) {
+		log.L(ctx).Warnf("Your config includes an 'admin' section, which should be renamed to 'spi' - SPI server will not be enabled until this is corrected")
 	}
 
 	if as.metricsEnabled {

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -97,6 +97,24 @@ func TestStartStopServer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestStartLegacyAdminConfig(t *testing.T) {
+	coreconfig.Reset()
+	metrics.Clear()
+	InitConfig()
+	apiConfig.Set(httpserver.HTTPConfPort, 0)
+	spiConfig.Set(httpserver.HTTPConfPort, 0)
+	config.Set(coreconfig.UIPath, "test")
+	config.Set(coreconfig.LegacyAdminEnabled, true)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // server will immediately shut down
+	as := NewAPIServer()
+	mgr := &namespacemocks.Manager{}
+	mae := &spieventsmocks.Manager{}
+	mgr.On("SPIEvents").Return(mae)
+	err := as.Serve(ctx, mgr)
+	assert.NoError(t, err)
+}
+
 func TestStartAPIFail(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -788,7 +788,15 @@ func (e *Ethereum) GetNetworkVersion(ctx context.Context, location *fftypes.JSON
 		return cached.Value().(int), nil
 	}
 
-	res, err := e.queryContractMethod(ctx, ethLocation.Address, networkVersionMethodABI, []interface{}{}, nil)
+	version, err = e.queryNetworkVersion(ctx, ethLocation.Address)
+	if err == nil {
+		e.cache.Set(cacheKey, version, e.cacheTTL)
+	}
+	return version, err
+}
+
+func (e *Ethereum) queryNetworkVersion(ctx context.Context, address string) (version int, err error) {
+	res, err := e.queryContractMethod(ctx, address, networkVersionMethodABI, []interface{}{}, nil)
 	if err != nil || !res.IsSuccess() {
 		// "Call failed" is interpreted as "method does not exist, default to version 1"
 		if strings.Contains(err.Error(), "FFEC100148") {
@@ -804,9 +812,6 @@ func (e *Ethereum) GetNetworkVersion(ctx context.Context, location *fftypes.JSON
 	switch result := output.Output.(type) {
 	case string:
 		version, err = strconv.Atoi(result)
-		if err == nil {
-			e.cache.Set(cacheKey, version, e.cacheTTL)
-		}
 	default:
 		err = i18n.NewError(ctx, coremsgs.MsgBadNetworkVersion, output.Output)
 	}

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -855,7 +855,15 @@ func (f *Fabric) GetNetworkVersion(ctx context.Context, location *fftypes.JSONAn
 		return cached.Value().(int), nil
 	}
 
-	res, err := f.queryContractMethod(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode, networkVersionMethodName, f.signer, "", []*PrefixItem{}, map[string]interface{}{}, nil)
+	version, err = f.queryNetworkVersion(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode)
+	if err == nil {
+		f.cache.Set(cacheKey, version, f.cacheTTL)
+	}
+	return version, err
+}
+
+func (f *Fabric) queryNetworkVersion(ctx context.Context, channel, chaincode string) (version int, err error) {
+	res, err := f.queryContractMethod(ctx, channel, chaincode, networkVersionMethodName, f.signer, "", []*PrefixItem{}, map[string]interface{}{}, nil)
 	if err != nil || !res.IsSuccess() {
 		// "Function not found" is interpreted as "default to version 1"
 		notFoundError := fmt.Sprintf("Function %s not found", networkVersionMethodName)
@@ -872,9 +880,6 @@ func (f *Fabric) GetNetworkVersion(ctx context.Context, location *fftypes.JSONAn
 	switch result := output.Result.(type) {
 	case float64:
 		version = int(result)
-		if err == nil {
-			f.cache.Set(cacheKey, version, f.cacheTTL)
-		}
 	default:
 		err = i18n.NewError(ctx, coremsgs.MsgBadNetworkVersion, output.Result)
 	}

--- a/internal/coreconfig/coreconfig.go
+++ b/internal/coreconfig/coreconfig.go
@@ -220,6 +220,8 @@ var (
 	GroupCacheLimit = ffc("group.cache.limit")
 	// GroupCacheTTL cache time-to-live for private group addresses
 	GroupCacheTTL = ffc("group.cache.ttl")
+	// LegacyAdminEnabled is the deprecated key that pre-dates spi.enabled
+	LegacyAdminEnabled = ffc("admin.enabled")
 	// SPIEnabled determines whether the admin interface will be enabled or not
 	SPIEnabled = ffc("spi.enabled")
 	// SPIWebSocketEventQueueLength is the maximum number of events that will queue up on the server side of each WebSocket connection before events start being dropped

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -31,6 +31,7 @@ var (
 	ConfigGlobalMigrationsDirectory = ffc("config.global.migrations.directory", "The directory containing the numerically ordered migration DDL files to apply to the database", i18n.StringType)
 	ConfigGlobalShutdownTimeout     = ffc("config.global.shutdownTimeout", "The maximum amount of time to wait for any open HTTP requests to finish before shutting down the HTTP server", i18n.TimeDurationType)
 
+	ConfigLegacyAdmin     = ffc("config.admin.enabled", "Deprecated - use spi.enabled instead", i18n.BooleanType)
 	ConfigSPIAddress      = ffc("config.spi.address", "The IP address on which the admin HTTP API should listen", "IP Address "+i18n.StringType)
 	ConfigSPIEnabled      = ffc("config.spi.enabled", "Enables the admin HTTP API", i18n.BooleanType)
 	ConfigSPIPort         = ffc("config.spi.port", "The port on which the admin HTTP API should listen", i18n.IntType)

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -489,6 +489,7 @@ func (nm *namespaceManager) getTokensPlugins(ctx context.Context) (plugins map[s
 			if err = fftypes.ValidateFFNameField(ctx, name, "name"); err != nil {
 				return nil, err
 			}
+			nm.tokenRemoteNames[name] = name
 
 			plugin, err := tifactory.GetPlugin(ctx, pluginType)
 			if err != nil {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -49,7 +49,18 @@ func WriteConfig(t *testing.T, configFile string, data map[string]interface{}) {
 }
 
 func AddNamespace(data map[string]interface{}, ns map[string]interface{}) {
+	if _, ok := data["namespaces"]; !ok {
+		data["namespaces"] = make(map[interface{}]interface{})
+	}
 	namespaces := data["namespaces"].(map[interface{}]interface{})
+	if _, ok := namespaces["default"]; !ok {
+		namespaces["default"] = "default"
+	}
+	if _, ok := namespaces["predefined"]; !ok {
+		namespaces["predefined"] = []interface{}{
+			map[string]interface{}{"name": namespaces["default"]},
+		}
+	}
 	predefined := namespaces["predefined"].([]interface{})
 	namespaces["predefined"] = append(predefined, ns)
 }


### PR DESCRIPTION
FireFly should continue to work when run against a config file from 1.0.x.

Since this references 1.0.4, it should go in after https://github.com/hyperledger/firefly/pull/982 is merged and released as 1.0.4.