### PR TITLE
Add e2e test which attempts to register an invalid identity by reusing a key

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -153,6 +153,17 @@ func WaitForMessageConfirmed(t *testing.T, c chan *core.EventDelivery, msgType c
 	}
 }
 
+func WaitForMessageRejected(t *testing.T, c chan *core.EventDelivery, msgType core.MessageType) *core.EventDelivery {
+	for {
+		ed := <-c
+		if ed.Type == core.EventTypeMessageRejected && ed.Message != nil && ed.Message.Header.Type == msgType {
+			t.Logf("Detected '%s' event for message '%s' of type '%s'", ed.Type, ed.Message.Header.ID, msgType)
+			return ed
+		}
+		t.Logf("Ignored event '%s'", ed.ID)
+	}
+}
+
 func WaitForIdentityConfirmed(t *testing.T, c chan *core.EventDelivery) *core.EventDelivery {
 	for {
 		ed := <-c

--- a/test/e2e/multiparty/common.go
+++ b/test/e2e/multiparty/common.go
@@ -178,10 +178,10 @@ func beforeE2ETest(t *testing.T) *testState {
 	}
 	ts.org1key = ts.client1.GetIdentityBlockchainKeys(t, ts.org1.ID, 200)[0]
 	ts.org2key = ts.client2.GetIdentityBlockchainKeys(t, ts.org2.ID, 200)[0]
-	t.Logf("Org1: ID=%s DID=%s Key=%s", ts.org1.DID, ts.org1.ID, ts.org1key.Value)
-	t.Logf("Org2: ID=%s DID=%s Key=%s", ts.org2.DID, ts.org2.ID, ts.org2key.Value)
+	t.Logf("Org1: ID=%s DID=%s Key=%s", ts.org1.ID, ts.org1.DID, ts.org1key.Value)
+	t.Logf("Org2: ID=%s DID=%s Key=%s", ts.org2.ID, ts.org2.DID, ts.org2key.Value)
 
-	eventNames := "message_confirmed|token_pool_confirmed|token_transfer_confirmed|blockchain_event_received|token_approval_confirmed|identity_confirmed"
+	eventNames := "message_confirmed|token_pool_confirmed|token_transfer_confirmed|blockchain_event_received|token_approval_confirmed|identity_confirmed|message_rejected"
 	queryString := fmt.Sprintf("namespace=%s&ephemeral&autoack&filter.events=%s&changeevents=.*", ts.namespace, eventNames)
 	ts.ws1 = ts.client1.WebSocket(t, queryString, authHeader1)
 	ts.ws2 = ts.client2.WebSocket(t, queryString, authHeader2)

--- a/test/e2e/multiparty/identity.go
+++ b/test/e2e/multiparty/identity.go
@@ -142,6 +142,36 @@ func (suite *IdentityTestSuite) TestCustomChildIdentityPrivate() {
 	e2e.WaitForMessageConfirmed(suite.T(), received2, core.MessageTypePrivate)
 }
 
+func (suite *IdentityTestSuite) TestInvalidIdentityAlreadyRegistered() {
+	defer suite.testState.done()
+
+	received1 := e2e.WsReader(suite.testState.ws1)
+
+	key := getUnregisteredAccount(suite, suite.testState.org1.Name)
+	require.NotEqual(suite.T(), "", key)
+	ts := time.Now().Unix()
+
+	suite.testState.client1.ClaimCustomIdentity(suite.T(),
+		key,
+		fmt.Sprintf("custom_already_registered_%d_1", ts),
+		"Description 1",
+		fftypes.JSONObject{"profile": 1},
+		suite.testState.org1.ID,
+		false)
+
+	e2e.WaitForIdentityConfirmed(suite.T(), received1)
+
+	suite.testState.client1.ClaimCustomIdentity(suite.T(),
+		key,
+		fmt.Sprintf("custom_already_registered_%d_2", ts),
+		"Description 2",
+		fftypes.JSONObject{"profile": 2},
+		suite.testState.org1.ID,
+		false)
+
+	e2e.WaitForMessageRejected(suite.T(), received1, core.MessageTypeDefinition)
+}
+
 func getUnregisteredAccount(suite *IdentityTestSuite, orgName string) string {
 	verifiers := suite.testState.client1.GetVerifiers(suite.T())
 	suite.T().Logf("checking for account with orgName: %s", orgName)

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -11,7 +11,7 @@ CLI_VERSION=$(cat $CWD/../../manifest.json | jq -r .cli.tag)
 create_accounts() {
   if [ "$TEST_SUITE" == "TestEthereumMultipartyE2ESuite" ]; then
       # Create 4 new accounts for use in testing
-      for i in {1..4}
+      for i in {1..5}
       do
           $CLI accounts create $STACK_NAME
       done


### PR DESCRIPTION
Signed-off-by: Anna Jackson <anna.jackson@kaleido.io>

Adds one of the proposed negative test cases from https://github.com/hyperledger/firefly/issues/944
> Registering invalid identities- keys that have already been used