### PR TITLE
Use advisory lock instead of exclusive lock on events table

### DIFF
--- a/internal/database/postgres/postgres_test.go
+++ b/internal/database/postgres/postgres_test.go
@@ -40,7 +40,8 @@ func TestPostgresProvider(t *testing.T) {
 
 	assert.Equal(t, "postgres", psql.Name())
 	assert.Equal(t, sq.Dollar, psql.Features().PlaceholderFormat)
-	assert.Equal(t, `LOCK TABLE "events" IN EXCLUSIVE MODE;`, psql.Features().ExclusiveTableLockSQL("events"))
+	assert.Equal(t, `SELECT pg_advisory_xact_lock(8387236824920056683);`, psql.Features().AcquireLock("test-lock"))
+	assert.Equal(t, `SELECT pg_advisory_xact_lock(116);`, psql.Features().AcquireLock("t"))
 
 	insert := sq.Insert("test").Columns("col1").Values("val1")
 	insert, query := psql.ApplyInsertQueryCustomizations(insert, true)

--- a/internal/database/sqlcommon/provider.go
+++ b/internal/database/sqlcommon/provider.go
@@ -28,10 +28,10 @@ const (
 )
 
 type SQLFeatures struct {
-	UseILIKE              bool
-	MultiRowInsert        bool
-	PlaceholderFormat     sq.PlaceholderFormat
-	ExclusiveTableLockSQL func(table string) string
+	UseILIKE          bool
+	MultiRowInsert    bool
+	PlaceholderFormat sq.PlaceholderFormat
+	AcquireLock       func(lockName string) string
 }
 
 func DefaultSQLProviderFeatures() SQLFeatures {

--- a/internal/database/sqlcommon/provider_mock_test.go
+++ b/internal/database/sqlcommon/provider_mock_test.go
@@ -79,8 +79,8 @@ func (mp *mockProvider) MigrationsDir() string {
 func (psql *mockProvider) Features() SQLFeatures {
 	features := DefaultSQLProviderFeatures()
 	features.UseILIKE = true
-	features.ExclusiveTableLockSQL = func(table string) string {
-		return fmt.Sprintf(`LOCK TABLE "%s" IN EXCLUSIVE MODE;`, table)
+	features.AcquireLock = func(lockName string) string {
+		return fmt.Sprintf(`<acquire lock %s>`, lockName)
 	}
 	return features
 }

--- a/internal/database/sqlcommon/sqlcommon_test.go
+++ b/internal/database/sqlcommon/sqlcommon_test.go
@@ -328,19 +328,6 @@ func TestQueryResSwallowError(t *testing.T) {
 	assert.Equal(t, int64(-1), *res.TotalCount)
 }
 
-func TestDoubleLock(t *testing.T) {
-	s, mdb := newMockProvider().init()
-	mdb.ExpectBegin()
-	mdb.ExpectExec("LOCK .*").WillReturnResult(driver.ResultNoRows)
-	ctx, tx, _, err := s.beginOrUseTx(context.Background())
-	assert.NoError(t, err)
-	err = s.lockTableExclusiveTx(ctx, "table1", tx)
-	assert.NoError(t, err)
-	err = s.lockTableExclusiveTx(ctx, "table1", tx)
-	assert.NoError(t, err)
-	assert.NoError(t, mdb.ExpectationsWereMet())
-}
-
 func TestInsertTxRowsBadConfig(t *testing.T) {
 	s, mdb := newMockProvider().init()
 	mdb.ExpectBegin()


### PR DESCRIPTION
Advisory locks are identified with a 64-bit integer, so I've put in place a
rudimentary mapping from namespace names to a (probably) unique int64.
This should ensure consistent ordering for the writes to the events table
within a particular namespace, without blocking reads or other namespaces.