### PR TITLE
Add status information for subscriptions & contract listeners

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3846,6 +3846,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: When set, the API will return additional status information
+        in: query
+        name: fetchstatus
+        schema:
+          example: "true"
+          type: string
       - description: Server-side request timeout (milliseconds, or set a custom suffix
           like 10s)
         in: header
@@ -13055,6 +13061,12 @@ paths:
         required: true
         schema:
           example: default
+          type: string
+      - description: When set, the API will return additional status information
+        in: query
+        name: fetchstatus
+        schema:
+          example: "true"
           type: string
       - description: Server-side request timeout (milliseconds, or set a custom suffix
           like 10s)
@@ -22400,7 +22412,7 @@ paths:
       operationId: getTokenAccountPoolsNamespace
       parameters:
       - description: The key for the token account. The exact format may vary based
-          on the token connector use.
+          on the token connector use
         in: path
         name: key
         required: true
@@ -29964,7 +29976,7 @@ paths:
       operationId: getTokenAccountPools
       parameters:
       - description: The key for the token account. The exact format may vary based
-          on the token connector use.
+          on the token connector use
         in: path
         name: key
         required: true

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3846,7 +3846,8 @@ paths:
         required: true
         schema:
           type: string
-      - description: When set, the API will return additional status information
+      - description: When set, the API will return additional status information if
+          available
         in: query
         name: fetchstatus
         schema:
@@ -13062,7 +13063,8 @@ paths:
         schema:
           example: default
           type: string
-      - description: When set, the API will return additional status information
+      - description: When set, the API will return additional status information if
+          available
         in: query
         name: fetchstatus
         schema:
@@ -22102,6 +22104,12 @@ paths:
         schema:
           example: default
           type: string
+      - description: When set, the API will return additional status information if
+          available
+        in: query
+        name: fetchstatus
+        schema:
+          type: string
       - description: Server-side request timeout (milliseconds, or set a custom suffix
           like 10s)
         in: header
@@ -29671,6 +29679,12 @@ paths:
         in: path
         name: subid
         required: true
+        schema:
+          type: string
+      - description: When set, the API will return additional status information if
+          available
+        in: query
+        name: fetchstatus
         schema:
           type: string
       - description: Server-side request timeout (milliseconds, or set a custom suffix

--- a/internal/apiserver/route_get_contract_listener_by_name_or_id.go
+++ b/internal/apiserver/route_get_contract_listener_by_name_or_id.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
@@ -32,7 +33,9 @@ var getContractListenerByNameOrID = &ffapi.Route{
 	PathParams: []*ffapi.PathParam{
 		{Name: "nameOrId", Description: coremsgs.APIParamsContractListenerNameOrID},
 	},
-	QueryParams:     nil,
+	QueryParams: []*ffapi.QueryParam{
+		{Name: "fetchstatus", Example: "true", Description: coremsgs.APIParamsFetchStatus, IsBool: true},
+	},
 	Description:     coremsgs.APIEndpointsGetContractListenerByNameOrID,
 	JSONInputValue:  nil,
 	JSONOutputValue: func() interface{} { return &core.ContractListener{} },
@@ -42,6 +45,9 @@ var getContractListenerByNameOrID = &ffapi.Route{
 			return or.Contracts() != nil
 		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
+			if strings.EqualFold(r.QP["fetchstatus"], "true") {
+				return cr.or.Contracts().GetContractListenerByNameOrIDWithStatus(cr.ctx, r.PP["nameOrId"])
+			}
 			return cr.or.Contracts().GetContractListenerByNameOrID(cr.ctx, r.PP["nameOrId"])
 		},
 	},

--- a/internal/apiserver/route_get_contract_listener_by_name_or_id_test.go
+++ b/internal/apiserver/route_get_contract_listener_by_name_or_id_test.go
@@ -43,3 +43,20 @@ func TestGetContractListenerByNameOrID(t *testing.T) {
 
 	assert.Equal(t, 200, res.Result().StatusCode)
 }
+
+func TestGetContractListenerByNameOrIDWithStatus(t *testing.T) {
+	o, r := newTestAPIServer()
+	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
+	mcm := &contractmocks.Manager{}
+	o.On("Contracts").Return(mcm)
+	id := fftypes.NewUUID()
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/contracts/listeners/"+id.String()+"?fetchstatus", nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	mcm.On("GetContractListenerByNameOrIDWithStatus", mock.Anything, id.String()).
+		Return(&core.ContractListenerWithStatus{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 200, res.Result().StatusCode)
+}

--- a/internal/apiserver/route_get_subscription_by_id.go
+++ b/internal/apiserver/route_get_subscription_by_id.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
@@ -31,15 +32,19 @@ var getSubscriptionByID = &ffapi.Route{
 	PathParams: []*ffapi.PathParam{
 		{Name: "subid", Description: coremsgs.APIParamsSubscriptionID},
 	},
-	QueryParams:     nil,
+	QueryParams: []*ffapi.QueryParam{
+		{Name: "fetchstatus", Description: coremsgs.APIParamsFetchStatus, IsBool: true},
+	},
 	Description:     coremsgs.APIEndpointsGetSubscriptionByID,
 	JSONInputValue:  nil,
 	JSONOutputValue: func() interface{} { return &core.Subscription{} },
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
-			output, err = cr.or.GetSubscriptionByID(cr.ctx, r.PP["subid"])
-			return output, err
+			if strings.EqualFold(r.QP["fetchstatus"], "true") {
+				return cr.or.GetSubscriptionByIDWithStatus(cr.ctx, r.PP["subid"])
+			}
+			return cr.or.GetSubscriptionByID(cr.ctx, r.PP["subid"])
 		},
 	},
 }

--- a/internal/apiserver/route_get_subscription_by_id_test.go
+++ b/internal/apiserver/route_get_subscription_by_id_test.go
@@ -38,3 +38,19 @@ func TestGetSubscriptionByID(t *testing.T) {
 
 	assert.Equal(t, 200, res.Result().StatusCode)
 }
+
+func TestGetSubscriptionByIDWithStatus(t *testing.T) {
+	o, r := newTestAPIServer()
+	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/subscriptions/abcd12345?fetchstatus", nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	o.On("GetSubscriptionByID", mock.Anything, "abcd12345").
+		Return(&core.Subscription{}, nil)
+	o.On("GetSubscriptionByIDWithStatus", mock.Anything, "abcd12345").
+		Return(&core.SubscriptionWithStatus{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 200, res.Result().StatusCode)
+}

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -728,6 +728,19 @@ func (e *Ethereum) DeleteContractListener(ctx context.Context, subscription *cor
 	return e.streams.deleteSubscription(ctx, subscription.BackendID)
 }
 
+func (e *Ethereum) GetContractListenerStatus(ctx context.Context, subID string) (status *fftypes.JSONAny, err error) {
+	sub, err := e.streams.getSubscription(ctx, subID)
+	if err != nil {
+		return nil, err
+	}
+
+	normalized, err := json.Marshal(sub.subscriptionCheckpoint)
+	if err == nil {
+		status = fftypes.JSONAnyPtrBytes(normalized)
+	}
+	return status, nil
+}
+
 func (e *Ethereum) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {
 	return &ffi2abi.ParamValidator{}, nil
 }

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -91,6 +91,17 @@ type Location struct {
 	Address string `json:"address"`
 }
 
+type ListenerCheckpoint struct {
+	Block            int64 `json:"block"`
+	TransactionIndex int64 `json:"transactionIndex"`
+	LogIndex         int64 `json:"logIndex"`
+}
+
+type ListenerStatus struct {
+	Checkpoint ListenerCheckpoint `json:"checkpoint"`
+	Catchup    bool               `json:"catchup"`
+}
+
 type EthconnectMessageRequest struct {
 	Headers EthconnectMessageHeaders `json:"headers,omitempty"`
 	To      string                   `json:"to"`
@@ -728,17 +739,22 @@ func (e *Ethereum) DeleteContractListener(ctx context.Context, subscription *cor
 	return e.streams.deleteSubscription(ctx, subscription.BackendID)
 }
 
-func (e *Ethereum) GetContractListenerStatus(ctx context.Context, subID string) (status *fftypes.JSONAny, err error) {
+func (e *Ethereum) GetContractListenerStatus(ctx context.Context, subID string) (status interface{}, err error) {
 	sub, err := e.streams.getSubscription(ctx, subID)
 	if err != nil {
 		return nil, err
 	}
 
-	normalized, err := json.Marshal(sub.subscriptionCheckpoint)
-	if err == nil {
-		status = fftypes.JSONAnyPtrBytes(normalized)
+	checkpoint := &ListenerStatus{
+		Catchup: sub.Catchup,
+		Checkpoint: ListenerCheckpoint{
+			Block:            sub.Checkpoint.Block,
+			TransactionIndex: sub.Checkpoint.TransactionIndex,
+			LogIndex:         sub.Checkpoint.LogIndex,
+		},
 	}
-	return status, nil
+
+	return checkpoint, nil
 }
 
 func (e *Ethereum) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -3170,11 +3170,11 @@ func TestGetContractListenerStatus(t *testing.T) {
 	httpmock.ActivateNonDefault(mockedClient)
 	defer httpmock.DeactivateAndReset()
 
-	checkpoint := fftypes.JSONAnyPtr(fftypes.JSONObject{
-		"block":            0,
-		"transactionIndex": -1,
-		"logIndex":         -1,
-	}.String())
+	checkpoint := ListenerCheckpoint{
+		Block:            0,
+		TransactionIndex: -1,
+		LogIndex:         -1,
+	}
 
 	httpmock.RegisterResponder("GET", "http://localhost:12345/eventstreams",
 		httpmock.NewJsonResponderOrPanic(200, []eventStream{}))

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -3194,7 +3194,7 @@ func TestGetContractListenerStatus(t *testing.T) {
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
 	utEthconnectConf.Set(EthconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfig, e.metrics)
+	err := e.Init(e.ctx, e.cancelCtx, utConfig, e.metrics)
 	assert.NoError(t, err)
 
 	status, err := e.GetContractListenerStatus(context.Background(), "sub1")
@@ -3224,7 +3224,7 @@ func TestGetContractListenerStatusGetSubFail(t *testing.T) {
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
 	utEthconnectConf.Set(EthconnectConfigTopic, "topic1")
 
-	err := e.Init(e.ctx, utConfig, e.metrics)
+	err := e.Init(e.ctx, e.cancelCtx, utConfig, e.metrics)
 	assert.NoError(t, err)
 
 	status, err := e.GetContractListenerStatus(context.Background(), "sub1")

--- a/internal/blockchain/ethereum/eventstream.go
+++ b/internal/blockchain/ethereum/eventstream.go
@@ -63,8 +63,8 @@ type subscription struct {
 }
 
 type subscriptionCheckpoint struct {
-	Checkpoint *fftypes.JSONAny `json:"checkpoint,omitempty"`
-	Catchup    bool             `json:"catchup,omitempty"`
+	Checkpoint ListenerCheckpoint `json:"checkpoint,omitempty"`
+	Catchup    bool               `json:"catchup,omitempty"`
 }
 
 func newStreamManager(client *resty.Client, cache *ccache.Cache, cacheTTL time.Duration) *streamManager {

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -833,7 +833,7 @@ func (f *Fabric) DeleteContractListener(ctx context.Context, subscription *core.
 	return f.streams.deleteSubscription(ctx, subscription.BackendID)
 }
 
-func (f *Fabric) GetContractListenerStatus(ctx context.Context, subID string) (*fftypes.JSONAny, error) {
+func (f *Fabric) GetContractListenerStatus(ctx context.Context, subID string) (interface{}, error) {
 	// Fabconnect does not currently provide any additional status info for listener subscriptions
 	return nil, nil
 }

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -833,6 +833,11 @@ func (f *Fabric) DeleteContractListener(ctx context.Context, subscription *core.
 	return f.streams.deleteSubscription(ctx, subscription.BackendID)
 }
 
+func (f *Fabric) GetContractListenerStatus(ctx context.Context, subID string) (*fftypes.JSONAny, error) {
+	// Fabconnect does not currently provide any additional status info for listener subscriptions
+	return nil, nil
+}
+
 func (f *Fabric) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {
 	// Fabconnect does not require any additional validation beyond "JSON Schema correctness" at this time
 	return nil, nil

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -2519,3 +2519,14 @@ func TestSubmitNetworkActionVersionError(t *testing.T) {
 	err := e.SubmitNetworkAction(context.Background(), "", signer, core.NetworkActionTerminate, location)
 	assert.Regexp(t, "FF10284", err)
 }
+
+func TestGetContractListenerStatus(t *testing.T) {
+	e, cancel := newTestFabric()
+	defer cancel()
+	httpmock.ActivateNonDefault(e.client.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	status, err := e.GetContractListenerStatus(context.Background(), "id")
+	assert.Nil(t, status)
+	assert.NoError(t, err)
+}

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -580,7 +580,9 @@ func (cm *contractManager) GetContractListenerByNameOrIDWithStatus(ctx context.C
 	}
 	status, err := cm.blockchain.GetContractListenerStatus(ctx, listener.BackendID)
 	if err != nil {
-		return nil, err
+		status = core.ListenerStatusError{
+			StatusError: err.Error(),
+		}
 	}
 	enrichedListener = &core.ContractListenerWithStatus{
 		ContractListener: *listener,

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -54,6 +54,7 @@ type Manager interface {
 	AddContractListener(ctx context.Context, listener *core.ContractListenerInput) (output *core.ContractListener, err error)
 	AddContractAPIListener(ctx context.Context, apiName, eventPath string, listener *core.ContractListener) (output *core.ContractListener, err error)
 	GetContractListenerByNameOrID(ctx context.Context, nameOrID string) (*core.ContractListener, error)
+	GetContractListenerByNameOrIDWithStatus(ctx context.Context, nameOrID string) (*core.ContractListenerWithStatus, error)
 	GetContractListeners(ctx context.Context, filter database.AndFilter) ([]*core.ContractListener, *database.FilterResult, error)
 	GetContractAPIListeners(ctx context.Context, apiName, eventPath string, filter database.AndFilter) ([]*core.ContractListener, *database.FilterResult, error)
 	DeleteContractListenerByNameOrID(ctx context.Context, nameOrID string) error
@@ -570,6 +571,22 @@ func (cm *contractManager) GetContractListenerByNameOrID(ctx context.Context, na
 		return nil, i18n.NewError(ctx, coremsgs.Msg404NotFound)
 	}
 	return listener, nil
+}
+
+func (cm *contractManager) GetContractListenerByNameOrIDWithStatus(ctx context.Context, nameOrID string) (enrichedListener *core.ContractListenerWithStatus, err error) {
+	listener, err := cm.GetContractListenerByNameOrID(ctx, nameOrID)
+	if err != nil {
+		return nil, err
+	}
+	status, err := cm.blockchain.GetContractListenerStatus(ctx, listener.BackendID)
+	if err != nil {
+		return nil, err
+	}
+	enrichedListener = &core.ContractListenerWithStatus{
+		ContractListener: *listener,
+		Status:           status,
+	}
+	return enrichedListener, nil
 }
 
 func (cm *contractManager) GetContractListeners(ctx context.Context, filter database.AndFilter) ([]*core.ContractListener, *database.FilterResult, error) {

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -1614,8 +1614,14 @@ func TestGetContractListenerByNameOrIDWithStatusPluginFail(t *testing.T) {
 	mdi.On("GetContractListenerByID", context.Background(), "ns1", id).Return(&core.ContractListener{BackendID: backendID}, nil)
 	mbi.On("GetContractListenerStatus", context.Background(), backendID).Return(nil, fmt.Errorf("pop"))
 
-	_, err := cm.GetContractListenerByNameOrIDWithStatus(context.Background(), id.String())
-	assert.EqualError(t, err, "pop")
+	listener, err := cm.GetContractListenerByNameOrIDWithStatus(context.Background(), id.String())
+
+	testError := core.ListenerStatusError{
+		StatusError: "pop",
+	}
+
+	assert.Equal(t, listener.Status, testError)
+	assert.NoError(t, err)
 }
 
 func TestGetContractListenerByNameOrIDFail(t *testing.T) {

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -1579,6 +1579,45 @@ func TestGetContractListenerByNameOrID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGetContractListenerByNameOrIDWithStatus(t *testing.T) {
+	cm := newTestContractManager()
+	mdi := cm.database.(*databasemocks.Plugin)
+	mbi := cm.blockchain.(*blockchainmocks.Plugin)
+
+	id := fftypes.NewUUID()
+	backendID := "testID"
+	mdi.On("GetContractListenerByID", context.Background(), "ns1", id).Return(&core.ContractListener{BackendID: backendID}, nil)
+	mbi.On("GetContractListenerStatus", context.Background(), backendID).Return(fftypes.JSONAnyPtr(fftypes.JSONObject{}.String()), nil)
+
+	_, err := cm.GetContractListenerByNameOrIDWithStatus(context.Background(), id.String())
+	assert.NoError(t, err)
+}
+
+func TestGetContractListenerByNameOrIDWithStatusListenerFail(t *testing.T) {
+	cm := newTestContractManager()
+	mdi := cm.database.(*databasemocks.Plugin)
+
+	id := fftypes.NewUUID()
+	mdi.On("GetContractListenerByID", context.Background(), "ns1", id).Return(nil, fmt.Errorf("pop"))
+
+	_, err := cm.GetContractListenerByNameOrIDWithStatus(context.Background(), id.String())
+	assert.EqualError(t, err, "pop")
+}
+
+func TestGetContractListenerByNameOrIDWithStatusPluginFail(t *testing.T) {
+	cm := newTestContractManager()
+	mdi := cm.database.(*databasemocks.Plugin)
+	mbi := cm.blockchain.(*blockchainmocks.Plugin)
+
+	id := fftypes.NewUUID()
+	backendID := "testID"
+	mdi.On("GetContractListenerByID", context.Background(), "ns1", id).Return(&core.ContractListener{BackendID: backendID}, nil)
+	mbi.On("GetContractListenerStatus", context.Background(), backendID).Return(nil, fmt.Errorf("pop"))
+
+	_, err := cm.GetContractListenerByNameOrIDWithStatus(context.Background(), id.String())
+	assert.EqualError(t, err, "pop")
+}
+
 func TestGetContractListenerByNameOrIDFail(t *testing.T) {
 	cm := newTestContractManager()
 	mdi := cm.database.(*databasemocks.Plugin)

--- a/internal/coremsgs/en_api_translations.go
+++ b/internal/coremsgs/en_api_translations.go
@@ -50,7 +50,7 @@ var (
 	APIParamsDID                            = ffm("api.params.DID", "The identity DID")
 	APIParamsNodeNameOrID                   = ffm("api.params.nodeNameOrID", "The name or ID of the node")
 	APIParamsOrgNameOrID                    = ffm("api.params.orgNameOrID", "The name or ID of the org")
-	APIParamsTokenAccountKey                = ffm("api.params.tokenAccountKey", "The key for the token account. The exact format may vary based on the token connector use.")
+	APIParamsTokenAccountKey                = ffm("api.params.tokenAccountKey", "The key for the token account. The exact format may vary based on the token connector use")
 	APIParamsTokenPoolNameOrID              = ffm("api.params.tokenPoolNameOrID", "The token pool name or ID")
 	APIParamsTokenTransferFromOrTo          = ffm("api.params.tokenTransferFromOrTo", "The sending or receiving token account for a token transfer")
 	APIParamsTokenTransferID                = ffm("api.params.tokenTransferID", "The token transfer ID")
@@ -63,6 +63,7 @@ var (
 	APIParamsMetadata                       = ffm("api.params.metadata", "Metadata associated with this data item")
 	APIParamsAutometa                       = ffm("api.params.autometa", "When set, FireFly will automatically generate JSON metadata with the upload details")
 	APIParamsContractAPIID                  = ffm("api.params.contractAPIID", "The ID of the contract API")
+	APIParamsFetchStatus                    = ffm("api.params.fetchStatus", "When set, the API will return additional status information")
 
 	APIEndpointsAdminGetNamespaceByName = ffm("api.endpoints.adminGetNamespaceByName", "Gets a namespace by name")
 	APIEndpointsAdminGetNamespaces      = ffm("api.endpoints.adminGetNamespaces", "List namespaces")

--- a/internal/coremsgs/en_api_translations.go
+++ b/internal/coremsgs/en_api_translations.go
@@ -63,7 +63,7 @@ var (
 	APIParamsMetadata                       = ffm("api.params.metadata", "Metadata associated with this data item")
 	APIParamsAutometa                       = ffm("api.params.autometa", "When set, FireFly will automatically generate JSON metadata with the upload details")
 	APIParamsContractAPIID                  = ffm("api.params.contractAPIID", "The ID of the contract API")
-	APIParamsFetchStatus                    = ffm("api.params.fetchStatus", "When set, the API will return additional status information")
+	APIParamsFetchStatus                    = ffm("api.params.fetchStatus", "When set, the API will return additional status information if available")
 
 	APIEndpointsAdminGetNamespaceByName = ffm("api.endpoints.adminGetNamespaceByName", "Gets a namespace by name")
 	APIEndpointsAdminGetNamespaces      = ffm("api.endpoints.adminGetNamespaces", "List namespaces")

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -262,4 +262,5 @@ var (
 	MsgInvalidConnectorName               = ffe("FF10420", "Could not find name %s for %s connector")
 	MsgCannotInitLegacyNS                 = ffe("FF10421", "could not initialize legacy '%s' namespace - found conflicting V1 multi-party config in %s and %s")
 	MsgInvalidGroupMember                 = ffe("FF10422", "invalid group member - node '%s' is not owned by '%s' or any of its ancestors")
+	MsgContractListenerStatusInvalid      = ffe("FF10423", "Failed to validate contract listener status: %v", 400)
 )

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -74,6 +74,7 @@ type Orchestrator interface {
 	// Subscription management
 	GetSubscriptions(ctx context.Context, filter database.AndFilter) ([]*core.Subscription, *database.FilterResult, error)
 	GetSubscriptionByID(ctx context.Context, id string) (*core.Subscription, error)
+	GetSubscriptionByIDWithStatus(ctx context.Context, id string) (*core.SubscriptionWithStatus, error)
 	CreateSubscription(ctx context.Context, subDef *core.Subscription) (*core.Subscription, error)
 	CreateUpdateSubscription(ctx context.Context, subDef *core.Subscription) (*core.Subscription, error)
 	DeleteSubscription(ctx context.Context, id string) error

--- a/internal/orchestrator/subscriptions.go
+++ b/internal/orchestrator/subscriptions.go
@@ -76,3 +76,30 @@ func (or *orchestrator) GetSubscriptionByID(ctx context.Context, id string) (*co
 	}
 	return or.database().GetSubscriptionByID(ctx, or.namespace.Name, u)
 }
+
+func (or *orchestrator) GetSubscriptionByIDWithStatus(ctx context.Context, id string) (*core.SubscriptionWithStatus, error) {
+	sub, err := or.GetSubscriptionByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, nil
+	}
+
+	offset, err := or.database().GetOffset(ctx, core.OffsetTypeSubscription, sub.ID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	subWithStatus := &core.SubscriptionWithStatus{
+		Subscription: *sub,
+	}
+
+	if offset != nil {
+		subWithStatus.Status = core.SubscriptionStatus{
+			CurrentOffset: offset.Current,
+		}
+	}
+
+	return subWithStatus, nil
+}

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -154,6 +154,29 @@ func (_m *Plugin) GetAndConvertDeprecatedContractConfig(ctx context.Context) (*f
 	return r0, r1, r2
 }
 
+// GetContractListenerStatus provides a mock function with given fields: ctx, subID
+func (_m *Plugin) GetContractListenerStatus(ctx context.Context, subID string) (*fftypes.JSONAny, error) {
+	ret := _m.Called(ctx, subID)
+
+	var r0 *fftypes.JSONAny
+	if rf, ok := ret.Get(0).(func(context.Context, string) *fftypes.JSONAny); ok {
+		r0 = rf(ctx, subID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.JSONAny)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, subID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetFFIParamValidator provides a mock function with given fields: ctx
 func (_m *Plugin) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {
 	ret := _m.Called(ctx)

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -155,15 +155,15 @@ func (_m *Plugin) GetAndConvertDeprecatedContractConfig(ctx context.Context) (*f
 }
 
 // GetContractListenerStatus provides a mock function with given fields: ctx, subID
-func (_m *Plugin) GetContractListenerStatus(ctx context.Context, subID string) (*fftypes.JSONAny, error) {
+func (_m *Plugin) GetContractListenerStatus(ctx context.Context, subID string) (interface{}, error) {
 	ret := _m.Called(ctx, subID)
 
-	var r0 *fftypes.JSONAny
-	if rf, ok := ret.Get(0).(func(context.Context, string) *fftypes.JSONAny); ok {
+	var r0 interface{}
+	if rf, ok := ret.Get(0).(func(context.Context, string) interface{}); ok {
 		r0 = rf(ctx, subID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*fftypes.JSONAny)
+			r0 = ret.Get(0).(interface{})
 		}
 	}
 

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -235,6 +235,29 @@ func (_m *Manager) GetContractListenerByNameOrID(ctx context.Context, nameOrID s
 	return r0, r1
 }
 
+// GetContractListenerByNameOrIDWithStatus provides a mock function with given fields: ctx, nameOrID
+func (_m *Manager) GetContractListenerByNameOrIDWithStatus(ctx context.Context, nameOrID string) (*core.ContractListenerWithStatus, error) {
+	ret := _m.Called(ctx, nameOrID)
+
+	var r0 *core.ContractListenerWithStatus
+	if rf, ok := ret.Get(0).(func(context.Context, string) *core.ContractListenerWithStatus); ok {
+		r0 = rf(ctx, nameOrID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.ContractListenerWithStatus)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, nameOrID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetContractListeners provides a mock function with given fields: ctx, filter
 func (_m *Manager) GetContractListeners(ctx context.Context, filter database.AndFilter) ([]*core.ContractListener, *database.FilterResult, error) {
 	ret := _m.Called(ctx, filter)

--- a/mocks/orchestratormocks/orchestrator.go
+++ b/mocks/orchestratormocks/orchestrator.go
@@ -971,6 +971,29 @@ func (_m *Orchestrator) GetSubscriptionByID(ctx context.Context, id string) (*co
 	return r0, r1
 }
 
+// GetSubscriptionByIDWithStatus provides a mock function with given fields: ctx, id
+func (_m *Orchestrator) GetSubscriptionByIDWithStatus(ctx context.Context, id string) (*core.SubscriptionWithStatus, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *core.SubscriptionWithStatus
+	if rf, ok := ret.Get(0).(func(context.Context, string) *core.SubscriptionWithStatus); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.SubscriptionWithStatus)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSubscriptions provides a mock function with given fields: ctx, filter
 func (_m *Orchestrator) GetSubscriptions(ctx context.Context, filter database.AndFilter) ([]*core.Subscription, *database.FilterResult, error) {
 	ret := _m.Called(ctx, filter)

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -75,7 +75,7 @@ type Plugin interface {
 	// DeleteContractListener deletes a previously-created subscription
 	DeleteContractListener(ctx context.Context, subscription *core.ContractListener) error
 
-	GetContractListenerStatus(ctx context.Context, subID string) (*fftypes.JSONAny, error)
+	GetContractListenerStatus(ctx context.Context, subID string) (interface{}, error)
 
 	// GetFFIParamValidator returns a blockchain-plugin-specific validator for FFIParams and their JSON Schema
 	GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error)

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -75,6 +75,8 @@ type Plugin interface {
 	// DeleteContractListener deletes a previously-created subscription
 	DeleteContractListener(ctx context.Context, subscription *core.ContractListener) error
 
+	GetContractListenerStatus(ctx context.Context, subID string) (*fftypes.JSONAny, error)
+
 	// GetFFIParamValidator returns a blockchain-plugin-specific validator for FFIParams and their JSON Schema
 	GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error)
 

--- a/pkg/core/contract_listener.go
+++ b/pkg/core/contract_listener.go
@@ -39,6 +39,10 @@ type ContractListener struct {
 	Options   *ContractListenerOptions `ffstruct:"ContractListener" json:"options,omitempty"`
 }
 
+type ContractListenerWithStatus struct {
+	ContractListener
+	Status *fftypes.JSONAny `ffstruct:"ContractListenerWithStatus" json:"status,omitempty" ffexcludeinput:"true"`
+}
 type ContractListenerOptions struct {
 	FirstEvent string `ffstruct:"ContractListenerOptions" json:"firstEvent,omitempty"`
 }

--- a/pkg/core/contract_listener.go
+++ b/pkg/core/contract_listener.go
@@ -41,10 +41,14 @@ type ContractListener struct {
 
 type ContractListenerWithStatus struct {
 	ContractListener
-	Status *fftypes.JSONAny `ffstruct:"ContractListenerWithStatus" json:"status,omitempty" ffexcludeinput:"true"`
+	Status interface{} `ffstruct:"ContractListenerWithStatus" json:"status,omitempty" ffexcludeinput:"true"`
 }
 type ContractListenerOptions struct {
 	FirstEvent string `ffstruct:"ContractListenerOptions" json:"firstEvent,omitempty"`
+}
+
+type ListenerStatusError struct {
+	StatusError string `ffstruct:"ListenerStatusError" json:"error,omitempty"`
 }
 
 type ContractListenerInput struct {

--- a/pkg/core/subscription.go
+++ b/pkg/core/subscription.go
@@ -122,6 +122,15 @@ type Subscription struct {
 	Updated   *fftypes.FFTime     `ffstruct:"Subscription" json:"updated" ffexcludeinput:"true"`
 }
 
+type SubscriptionWithStatus struct {
+	Subscription
+	Status SubscriptionStatus `ffstruct:"SubscriptionWithStatus" json:"status,omitempty" ffexcludeinput:"true"`
+}
+
+type SubscriptionStatus struct {
+	CurrentOffset int64 `ffstruct:"SubscriptionStatus" json:"currentOffset,omitempty" ffexcludeinout:"true"`
+}
+
 func (so *SubscriptionOptions) UnmarshalJSON(b []byte) error {
 	so.additionalOptions = fftypes.JSONObject{}
 	err := json.Unmarshal(b, &so.additionalOptions)


### PR DESCRIPTION
 If the `fetchstatus` query param is supplied when querying `subscriptions` or `listeners` by ID, firefly will return additional status information, if it is available.

### Contract listeners:
FF environments connected to evm connectors will return listener checkpoint formation under the `status` key.

Example query: `http://localhost:5000/api/v1/namespaces/default/contracts/listeners/92e3bc0c-3c3f-455b-81d3-4124a0270b1d?fetchstatus`

Response:
```
{
    "id": "92e3bc0c-3c3f-455b-81d3-4124a0270b1d",
    "interface": {
        "id": "30775d45-61af-4f76-9d35-69b5d8ffbf42"
    },
    "namespace": "default",
    "name": "0182f410-a686-79ed-23a5-ac8c62acbf51",
    "backendId": "0182f410-a686-79ed-23a5-ac8c62acbf51",
    "location": {
        "address": "0x62d365e68fc55845ba904acef688feba7a598c9c"
    },
    "created": "2022-08-31T13:21:48.1687995Z",
    "event": {
        "name": "Changed",
        "description": "",
        "params": [
            {
                "name": "from",
                "schema": {
                    "type": "string",
                    "details": {
                        "type": "address",
                        "internalType": "address",
                        "indexed": true
                    }
                }
            },
            {
                "name": "value",
                "schema": {
                    "type": "integer",
                    "details": {
                        "type": "uint256",
                        "internalType": "uint256"
                    }
                }
            }
        ]
    },
    "signature": "Changed(address,uint256)",
    "topic": "bsc",
    "options": {
        "firstEvent": "oldest"
    },
    "status": {
        "checkpoint": {
            "block": 0,
            "transactionIndex": -1,
            "logIndex": -1
        }
    }
}
```

### Subscriptions
Subscriptions will provide offset information if available

Example Query: `http://localhost:5000/api/v1/namespaces/default/subscriptions/32cddc74-cc1a-4493-b376-45781e2d8d35?fetchstatus`

Response:
```
{
    "id": "32cddc74-cc1a-4493-b376-45781e2d8d35",
    "namespace": "default",
    "name": "simple-storage",
    "transport": "websockets",
    "filter": {
        "message": {},
        "transaction": {},
        "blockchainevent": {}
    },
    "options": {
        "firstEvent": "-1",
        "withData": false
    },
    "created": "2022-08-31T17:13:04.295134Z",
    "updated": null,
    "status": {
        "currentOffset": 31
    }
}
```