### PR TITLE
Prevent panic on ff_system namespace for synchronous token pool creation in V1.0 migrated env

### DIFF
--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -50,6 +50,7 @@ func addPoolDetailsFromPlugin(ffPool *core.TokenPool, pluginPool *tokens.TokenPo
 }
 
 func (em *eventManager) confirmPool(ctx context.Context, pool *core.TokenPool, ev *blockchain.Event) error {
+	log.L(em.ctx).Debugf("Confirming pool ID=%s Locator='%s'", pool.ID, pool.Locator)
 	var blockchainID string
 	if ev != nil {
 		// Some pools will not include a blockchain event for creation (such as when indexing a pre-existing pool)
@@ -88,11 +89,13 @@ func (em *eventManager) findTXOperation(ctx context.Context, tx *fftypes.UUID, o
 	} else if len(operations) > 0 {
 		return operations[0], nil
 	}
+	log.L(ctx).Debugf("No pool found for tx=%s status=%s", tx, core.OpTypeTokenCreatePool)
 	return nil, nil
 }
 
 func (em *eventManager) shouldConfirm(ctx context.Context, pool *tokens.TokenPool) (existingPool *core.TokenPool, err error) {
 	if existingPool, err = em.database.GetTokenPoolByLocator(ctx, em.namespace.Name, pool.Connector, pool.PoolLocator); err != nil || existingPool == nil {
+		log.L(ctx).Debugf("Pool not found with ns=%s connector=%s locator=%s (err=%v)", em.namespace.Name, pool.Connector, pool.PoolLocator, err)
 		return existingPool, err
 	}
 	if err = addPoolDetailsFromPlugin(existingPool, pool); err != nil {
@@ -100,6 +103,7 @@ func (em *eventManager) shouldConfirm(ctx context.Context, pool *tokens.TokenPoo
 		return nil, nil
 	}
 
+	log.L(ctx).Debugf("shouldConfirm checking pool: state=%s name=%s connector=%s locator=%s", existingPool.State, em.namespace.Name, pool.Connector, pool.PoolLocator)
 	if existingPool.State == core.TokenPoolStateUnknown {
 		// Unknown pool state - should only happen on first run after database migration
 		// Activate the pool, then immediately confirm
@@ -150,6 +154,7 @@ func (em *eventManager) TokenPoolCreated(ti tokens.Plugin, pool *tokens.TokenPoo
 			}
 			if existingPool != nil {
 				if existingPool.State == core.TokenPoolStateConfirmed {
+					log.L(em.ctx).Debugf("Token pool ID=%s Locator='%s' already confirmed", existingPool.ID, pool.PoolLocator)
 					return nil // already confirmed
 				}
 				msgIDforRewind = existingPool.Message
@@ -169,7 +174,11 @@ func (em *eventManager) TokenPoolCreated(ti tokens.Plugin, pool *tokens.TokenPoo
 			}
 
 			// Otherwise this event can be ignored
-			log.L(ctx).Debugf("Ignoring token pool transaction '%s' - pool %s is not active", pool.Event.ProtocolID, pool.PoolLocator)
+			var protoID string
+			if pool.Event != nil {
+				protoID = pool.Event.ProtocolID
+			}
+			log.L(ctx).Debugf("Handler ignoring token pool created notification. Pool is not active for namespace event='%s' locator='%s'", protoID, pool.PoolLocator)
 			return nil
 		})
 		return err != nil, err


### PR DESCRIPTION
The following panic was occurring when using an ERC-20 connector, in an environment that had been migrated from V1.0, so had the `ff_system` namespace event listener running.

The panic failed the request to create the token pool with a `500`, but the token pool was created successfully.

The problem is specific to a `200 OK` return (rather than `202 Accepted`) return from the token connector on `/api/v1/createpool`, because there is no `blockchain` field (translated to `pool.Event` during processing) in the data from the connector on that path.

So this line would panic, dereferencing the `pool.Event.ProtocolID`:
https://github.com/hyperledger/firefly/blob/c5cc7ede18e6127277ebce4715baffb69d2ca513/internal/events/token_pool_created.go#L172

I've tidied up various logging along the way.

I also tidied up the path that was extracting `tokenData` in-line in the `handleTokenPoolCreate` calls, as in the `200 OK` in-line case the caller knows it. So this gets rid of an ugly log error like this, which was cruft:

```
[2022-09-01T19:03:12.399Z]  INFO TokenPool event data could not be parsed - continuing anyway (unexpected end of JSON input): {"decimals":18,"info":{"address":"0xc4c534921ccc96eb0342dffa9f0a0df21a3caf70","name":"f","schema":"ERC20WithData"},"poolLocator":"address=0xc4c534921ccc96eb0342dffa9f0a0df21a3caf70\u0026schema=ERC20WithData\u0026type=fungible","standard":"ERC20","symbol":"f","type":"fungible"} ns=default pid=123 role=aggregator
```

Original panic stack:

```
2022/09/01 19:03:04 http: panic serving 127.0.0.1:57740: runtime error: invalid memory address or nil pointer dereference
goroutine 749 [running]:
net/http.(*conn).serve.func1(0xc0007c1900)
	/usr/local/go/src/net/http/server.go:1804 +0x153
panic(0xf50420, 0x16c6b10)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/hyperledger/firefly/internal/events.(*eventManager).TokenPoolCreated.func1.1(0x11c5e98, 0xc0001104e0, 0xc000149860, 0x11c5e98)
	/firefly/internal/events/token_pool_created.go:172 +0x26f
github.com/hyperledger/firefly/internal/database/sqlcommon.(*SQLCommon).RunAsGroup(0xc0000ec820, 0x11c5e98, 0xc0001104e0, 0xc000088f30, 0x0, 0x0)
	/firefly/internal/database/sqlcommon/sqlcommon.go:159 +0x128
github.com/hyperledger/firefly/internal/events.(*eventManager).TokenPoolCreated.func1(0x1, 0xe, 0x0, 0xc000941e00)
	/firefly/internal/events/token_pool_created.go:145 +0xbc
github.com/hyperledger/firefly-common/pkg/retry.(*Retry).Do(0xc0000e8088, 0x11c5e98, 0xc000149860, 0x1082e05, 0x1e, 0xc000638df8, 0x0, 0x0)
	/go/pkg/mod/github.com/hyperledger/firefly-common@v1.1.1/pkg/retry/retry.go:56 +0xad
github.com/hyperledger/firefly/internal/events.(*eventManager).TokenPoolCreated(0xc0000e8000, 0x11d1580, 0xc00025df10, 0xc0007aac80, 0x0, 0x0)
	/firefly/internal/events/token_pool_created.go:144 +0xfa
github.com/hyperledger/firefly/internal/tokens/fftokens.(*callbacks).TokenPoolCreated(0xc00025df30, 0x11c5e98, 0xc00008ee10, 0xc0007aac80, 0xc000032d80, 0x0)
	/firefly/internal/tokens/fftokens/fftokens.go:71 +0xcd
github.com/hyperledger/firefly/internal/tokens/fftokens.(*FFTokens).handleTokenPoolCreate(0xc00025df10, 0x11c5e98, 0xc00008ee10, 0xc000032c90, 0xc000012260, 0x0)
	/firefly/internal/tokens/fftokens/fftokens.go:354 +0x50e
github.com/hyperledger/firefly/internal/tokens/fftokens.(*FFTokens).CreateTokenPool(0xc00025df10, 0x11c5e98, 0xc00008ee10, 0xc000318240, 0x2c, 0xc0003c8b60, 0x24, 0xc000318240, 0x2c)
	/firefly/internal/tokens/fftokens/fftokens.go:600 +0x745
github.com/hyperledger/firefly/internal/assets.(*assetManager).RunOperation(0xc0005ee420, 0x11c5e98, 0xc00008ee10, 0xc000181c20, 0xc000639270, 0x1, 0x1, 0xc00040ec40)
	/firefly/internal/assets/operations.go:109 +0x47b
github.com/hyperledger/firefly/internal/operations.(*operationsManager).RunOperation(0xc0000ed310, 0x11c5e98, 0xc00008ee10, 0xc000181c20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/firefly/internal/operations/manager.go:120 +0x334
github.com/hyperledger/firefly/internal/assets.(*assetManager).createTokenPoolInternal(0xc0005ee420, 0x11c5e98, 0xc00008ee10, 0xc0003c8b60, 0x0, 0x0, 0xc0004520c0, 0x2a)
	/firefly/internal/assets/token_pool.go:96 +0x362
github.com/hyperledger/firefly/internal/assets.(*assetManager).CreateTokenPool(0xc0005ee420, 0x11c5e98, 0xc00008ee10, 0xc0003c8b60, 0x1778e00, 0x50, 0xfe5f80, 0x1)
	/firefly/internal/assets/token_pool.go:56 +0x308
github.com/hyperledger/firefly/internal/apiserver.glob..func248(0xc0000ed5e0, 0xc0000ed630, 0xc00008ee10, 0xc00008f290, 0x0, 0x0)
	/firefly/internal/apiserver/route_post_token_pool.go:44 +0x111
github.com/hyperledger/firefly/internal/apiserver.(*apiServer).routeHandler.func1(0xc0000ed5e0, 0xc0000ed5e0, 0xc00013e240, 0xc00008f1a0, 0xc00008f200)
	/firefly/internal/apiserver/server.go:294 +0x3bd
github.com/hyperledger/firefly-common/pkg/ffapi.(*HandlerFactory).RouteHandler.func1(0x11c22d0, 0xc000a67200, 0xc0000b7800, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/hyperledger/firefly-common@v1.1.1/pkg/ffapi/handler.go:162 +0x6a6
github.com/hyperledger/firefly-common/pkg/ffapi.(*HandlerFactory).APIWrapper.func1(0x11c22d0, 0xc000a67200, 0xc0000b7700)
	/go/pkg/mod/github.com/hyperledger/firefly-common@v1.1.1/pkg/ffapi/handler.go:262 +0x377
net/http.HandlerFunc.ServeHTTP(0xc000257c80, 0x11c22d0, 0xc000a67200, 0xc0000b7700)
	/usr/local/go/src/net/http/server.go:2049 +0x44
gitlab.com/hfuss/mux-prometheus/pkg/middleware.(*Instrumentation).Middleware.func1(0x11c2690, 0xc0003c8a80, 0xc0000b7700)
	/go/pkg/mod/gitlab.com/hfuss/mux-prometheus@v0.0.4/pkg/middleware/middleware.go:69 +0xec
net/http.HandlerFunc.ServeHTTP(0xc000a671e0, 0x11c2690, 0xc0003c8a80, 0xc0000b7700)
	/usr/local/go/src/net/http/server.go:2049 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000ee900, 0x11c2690, 0xc0003c8a80, 0xc0000b7500)
	/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
github.com/rs/cors.(*Cors).Handler.func1(0x11c2690, 0xc0003c8a80, 0xc0000b7500)
	/go/pkg/mod/github.com/rs/cors@v1.8.2/cors.go:231 +0x1bb
net/http.HandlerFunc.ServeHTTP(0xc00069b960, 0x11c2690, 0xc0003c8a80, 0xc0000b7500)
	/usr/local/go/src/net/http/server.go:2049 +0x44
net/http.serverHandler.ServeHTTP(0xc0008fb340, 0x11c2690, 0xc0003c8a80, 0xc0000b7500)
	/usr/local/go/src/net/http/server.go:2867 +0xa3
net/http.(*conn).serve(0xc0007c1900, 0x11c5e98, 0xc00012c2c0)
	/usr/local/go/src/net/http/server.go:1932 +0x8cd
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2993 +0x39b
```