### PR TITLE
Properly enforce uniqueness of BatchPin blockchain events

### DIFF
--- a/db/migrations/postgres/000099_fix_blockchainevent_protocolid_index.down.sql
+++ b/db/migrations/postgres/000099_fix_blockchainevent_protocolid_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP INDEX blockchainevents_protocolid;
+DROP INDEX blockchainevents_listener_protocolid;
+CREATE UNIQUE INDEX blockchainevents_protocolid ON blockchainevents(namespace, listener_id, protocol_id);
+COMMIT;

--- a/db/migrations/postgres/000099_fix_blockchainevent_protocolid_index.up.sql
+++ b/db/migrations/postgres/000099_fix_blockchainevent_protocolid_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP INDEX blockchainevents_protocolid;
+CREATE UNIQUE INDEX blockchainevents_protocolid ON blockchainevents(namespace, protocol_id) WHERE listener_id IS NULL;
+CREATE UNIQUE INDEX blockchainevents_listener_protocolid ON blockchainevents(namespace, listener_id, protocol_id) WHERE listener_id IS NOT NULL;
+COMMIT;

--- a/db/migrations/sqlite/000099_fix_blockchainevent_protocolid_index.down.sql
+++ b/db/migrations/sqlite/000099_fix_blockchainevent_protocolid_index.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX blockchainevents_protocolid;
+DROP INDEX blockchainevents_listener_protocolid;
+CREATE UNIQUE INDEX blockchainevents_protocolid ON blockchainevents(namespace, listener_id, protocol_id);

--- a/db/migrations/sqlite/000099_fix_blockchainevent_protocolid_index.up.sql
+++ b/db/migrations/sqlite/000099_fix_blockchainevent_protocolid_index.up.sql
@@ -1,0 +1,3 @@
+DROP INDEX blockchainevents_protocolid;
+CREATE UNIQUE INDEX blockchainevents_protocolid ON blockchainevents(namespace, protocol_id) WHERE listener_id IS NULL;
+CREATE UNIQUE INDEX blockchainevents_listener_protocolid ON blockchainevents(namespace, listener_id, protocol_id) WHERE listener_id IS NOT NULL;


### PR DESCRIPTION
Because listener_id is NULL for these events, we need separate indexes for when it is NULL and not NULL.