### PR TITLE
Consistently fall back to ff_system for legacy identity lookups

### DIFF
--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -457,6 +457,11 @@ func (im *identityManager) cachedIdentityLookupByVerifierRef(ctx context.Context
 	if err != nil {
 		return nil, err
 	} else if verifier == nil {
+		if namespace != core.LegacySystemNamespace && im.multiparty != nil && im.multiparty.GetNetworkVersion() == 1 {
+			// For V1 networks, fall back to LegacySystemNamespace for looking up identities
+			// This assumes that the system namespace shares a database with this manager's namespace!
+			return im.cachedIdentityLookupByVerifierRef(ctx, core.LegacySystemNamespace, verifierRef)
+		}
 		return nil, err
 	}
 	identity, err := im.database.GetIdentityByID(ctx, namespace, verifier.Identity)

--- a/internal/orchestrator/status.go
+++ b/internal/orchestrator/status.go
@@ -18,7 +18,6 @@ package orchestrator
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly/pkg/core"
@@ -113,7 +112,7 @@ func (or *orchestrator) GetStatus(ctx context.Context) (status *core.NamespaceSt
 				status.Org.Verifiers[i] = &v.VerifierRef
 			}
 
-			node, _, err := or.identity.CachedIdentityLookupNilOK(ctx, fmt.Sprintf("%s%s", core.FireFlyNodeDIDPrefix, status.Node.Name))
+			node, err := or.identity.GetLocalNode(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/orchestrator/status_test.go
+++ b/internal/orchestrator/status_test.go
@@ -93,13 +93,13 @@ func TestGetStatusRegistered(t *testing.T) {
 			DID:       "did:firefly:org/org1",
 		},
 	}, nil)
-	or.mim.On("CachedIdentityLookupNilOK", or.ctx, "did:firefly:node/node1").Return(&core.Identity{
+	or.mim.On("GetLocalNode", or.ctx).Return(&core.Identity{
 		IdentityBase: core.IdentityBase{
 			ID:     nodeID,
 			Name:   "node1",
 			Parent: orgID,
 		},
-	}, false, nil)
+	}, nil)
 	or.mdi.On("GetVerifiers", or.ctx, "ns", mock.Anything).Return([]*core.Verifier{
 		{Hash: fftypes.NewRandB32(), VerifierRef: core.VerifierRef{
 			Type:  core.VerifierTypeEthAddress,
@@ -181,13 +181,13 @@ func TestGetStatusWrongNodeOwner(t *testing.T) {
 			DID:       "did:firefly:org/org1",
 		},
 	}, nil)
-	or.mim.On("CachedIdentityLookupNilOK", or.ctx, "did:firefly:node/node1").Return(&core.Identity{
+	or.mim.On("GetLocalNode", or.ctx).Return(&core.Identity{
 		IdentityBase: core.IdentityBase{
 			ID:     nodeID,
 			Name:   "node1",
 			Parent: fftypes.NewUUID(),
 		},
-	}, false, nil)
+	}, nil)
 	or.mdi.On("GetVerifiers", or.ctx, "ns", mock.Anything).Return([]*core.Verifier{
 		{Hash: fftypes.NewRandB32(), VerifierRef: core.VerifierRef{
 			Type:  core.VerifierTypeEthAddress,
@@ -260,7 +260,7 @@ func TestGetStatusOrgOnlyRegistered(t *testing.T) {
 			DID:       "did:firefly:org/org1",
 		},
 	}, nil)
-	or.mim.On("CachedIdentityLookupNilOK", or.ctx, "did:firefly:node/node1").Return(nil, false, nil)
+	or.mim.On("GetLocalNode", or.ctx).Return(nil, nil)
 	or.mdi.On("GetVerifiers", or.ctx, "ns", mock.Anything).Return([]*core.Verifier{
 		{Hash: fftypes.NewRandB32(), VerifierRef: core.VerifierRef{
 			Type:  core.VerifierTypeEthAddress,
@@ -312,7 +312,7 @@ func TestGetStatusNodeError(t *testing.T) {
 			DID:       "did:firefly:org/org1",
 		},
 	}, nil)
-	or.mim.On("CachedIdentityLookupNilOK", or.ctx, "did:firefly:node/node1").Return(nil, false, fmt.Errorf("pop"))
+	or.mim.On("GetLocalNode", or.ctx).Return(nil, fmt.Errorf("pop"))
 	or.mdi.On("GetVerifiers", or.ctx, "ns", mock.Anything).Return([]*core.Verifier{
 		{Hash: fftypes.NewRandB32(), VerifierRef: core.VerifierRef{
 			Type:  core.VerifierTypeEthAddress,

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -73,7 +73,7 @@ type privateMessaging struct {
 	maxBatchPayloadLength int64
 	metrics               metrics.Manager
 	operations            operations.Manager
-	orgFirstNodes         map[fftypes.UUID]*core.Identity
+	orgFirstNodes         map[string]*core.Identity
 }
 
 type blobTransferTracker struct {
@@ -111,7 +111,7 @@ func NewPrivateMessaging(ctx context.Context, ns *core.Namespace, di database.Pl
 		maxBatchPayloadLength: config.GetByteSize(coreconfig.PrivateMessagingBatchPayloadLimit),
 		metrics:               mm,
 		operations:            om,
-		orgFirstNodes:         make(map[fftypes.UUID]*core.Identity),
+		orgFirstNodes:         make(map[string]*core.Identity),
 	}
 
 	groupCache, err := cacheManager.GetCache(

--- a/internal/privatemessaging/recipients.go
+++ b/internal/privatemessaging/recipients.go
@@ -59,19 +59,20 @@ func (pm *privateMessaging) resolveRecipientList(ctx context.Context, in *core.M
 }
 
 func (pm *privateMessaging) getFirstNodeForOrg(ctx context.Context, identity *core.Identity) (*core.Identity, error) {
-	node := pm.orgFirstNodes[*identity.ID]
+	key := fmt.Sprintf("ns=%s,did=%s", identity.Namespace, identity.DID)
+	node := pm.orgFirstNodes[key]
 	if node == nil && identity.Type == core.IdentityTypeOrg {
 		fb := database.IdentityQueryFactory.NewFilterLimit(ctx, 1)
 		filter := fb.And(
 			fb.Eq("parent", identity.ID),
 			fb.Eq("type", core.IdentityTypeNode),
 		)
-		nodes, _, err := pm.database.GetIdentities(ctx, pm.namespace.Name, filter)
+		nodes, _, err := pm.database.GetIdentities(ctx, identity.Namespace, filter)
 		if err != nil || len(nodes) == 0 {
 			return nil, err
 		}
 		node = nodes[0]
-		pm.orgFirstNodes[*identity.ID] = node
+		pm.orgFirstNodes[key] = node
 	}
 	return node, nil
 }


### PR DESCRIPTION
Reverts #1035 
Fixes #1032
Fixes #1045 