### PR TITLE
Delete duplicate blockchainevents when migrating

### DIFF
--- a/db/migrations/postgres/000099_fix_blockchainevent_protocolid_index.up.sql
+++ b/db/migrations/postgres/000099_fix_blockchainevent_protocolid_index.up.sql
@@ -1,5 +1,7 @@
 BEGIN;
 DROP INDEX blockchainevents_protocolid;
+DELETE FROM blockchainevents WHERE listener_id IS NULL AND seq NOT IN (
+  SELECT MIN(seq) FROM blockchainevents WHERE listener_id IS NULL GROUP BY namespace, protocol_id);
 CREATE UNIQUE INDEX blockchainevents_protocolid ON blockchainevents(namespace, protocol_id) WHERE listener_id IS NULL;
 CREATE UNIQUE INDEX blockchainevents_listener_protocolid ON blockchainevents(namespace, listener_id, protocol_id) WHERE listener_id IS NOT NULL;
 COMMIT;

--- a/db/migrations/sqlite/000099_fix_blockchainevent_protocolid_index.up.sql
+++ b/db/migrations/sqlite/000099_fix_blockchainevent_protocolid_index.up.sql
@@ -1,3 +1,5 @@
 DROP INDEX blockchainevents_protocolid;
+DELETE FROM blockchainevents WHERE listener_id IS NULL AND seq NOT IN (
+  SELECT MIN(seq) FROM blockchainevents WHERE listener_id IS NULL GROUP BY namespace, protocol_id);
 CREATE UNIQUE INDEX blockchainevents_protocolid ON blockchainevents(namespace, protocol_id) WHERE listener_id IS NULL;
 CREATE UNIQUE INDEX blockchainevents_listener_protocolid ON blockchainevents(namespace, listener_id, protocol_id) WHERE listener_id IS NOT NULL;


### PR DESCRIPTION
Should fix any environments that got into a bad state between 0e559460a4ee2c68a66c23a5ca108bc98e7dfded (1.1.0-rc.1) and d75f2d4a0cd689df174d57d8e40d4c623c129e0d (1.1.0-rc.4).