### PR TITLE
use `cm.namespace` when generating contract URL's 

### DIFF
--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -257,7 +257,7 @@ func (cm *contractManager) resolveInvokeContractRequest(ctx context.Context, req
 func (cm *contractManager) addContractURLs(httpServerURL string, api *core.ContractAPI) {
 	if api != nil {
 		// These URLs must match the actual routes in apiserver.createMuxRouter()!
-		baseURL := fmt.Sprintf("%s/namespaces/%s/apis/%s", httpServerURL, api.Namespace, api.Name)
+		baseURL := fmt.Sprintf("%s/namespaces/%s/apis/%s", httpServerURL, cm.namespace, api.Name)
 		api.URLs.OpenAPI = baseURL + "/api/swagger.json"
 		api.URLs.UI = baseURL + "/api"
 	}


### PR DESCRIPTION
~~Fixes error where namespace was not set when resolving contract API on create. This resulted in contract listener url's being broken in the `POST` response.~~

When generating contract URL's, always use the `ContractManager` namespace.

closes #1067 