### PR TITLE
Fix acknowledgement for webhooks in non-reply, non-fastack cases

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -531,6 +531,47 @@ nav_order: 2
 |default|The default event transport for new subscriptions|`string`|`<nil>`
 |enabled|Which event interface plugins are enabled|`boolean`|`<nil>`
 
+## events.webhooks
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|connectionTimeout|The maximum amount of time that a connection is allowed to remain with no data transmitted|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
+|expectContinueTimeout|See [ExpectContinueTimeout in the Go docs](https://pkg.go.dev/net/http#Transport)|[`time.Duration`](https://pkg.go.dev/time#Duration)|`1s`
+|headers|Adds custom headers to HTTP requests|`map[string]string`|`<nil>`
+|idleTimeout|The max duration to hold a HTTP keepalive connection between calls|[`time.Duration`](https://pkg.go.dev/time#Duration)|`475ms`
+|maxIdleConns|The max number of idle connections to hold pooled|`int`|`100`
+|requestTimeout|The maximum amount of time that a request is allowed to remain open|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
+|tlsHandshakeTimeout|The maximum amount of time to wait for a successful TLS handshake|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
+
+## events.webhooks.auth
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|password|Password|`string`|`<nil>`
+|username|Username|`string`|`<nil>`
+
+## events.webhooks.proxy
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|url|Optional HTTP proxy server to connect through|`string`|`<nil>`
+
+## events.webhooks.retry
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|count|The maximum number of times to retry|`int`|`5`
+|enabled|Enables retries|`boolean`|`false`
+|initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
+|maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
+
+## events.websockets
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|readBufferSize|WebSocket read buffer size|[`BytesSize`](https://pkg.go.dev/github.com/docker/go-units#BytesSize)|`16Kb`
+|writeBufferSize|WebSocket write buffer size|[`BytesSize`](https://pkg.go.dev/github.com/docker/go-units#BytesSize)|`16Kb`
+
 ## histograms
 
 |Key|Description|Type|Default Value|

--- a/docs/reference/types/_includes/subscription_description.md
+++ b/docs/reference/types/_includes/subscription_description.md
@@ -170,7 +170,7 @@ allowing you to customize your HTTP requests as follows:
 - Wait for a invocation of the back-end service, before acknowledging
   - To retry requests to your Webhook on a non-`2xx` HTTP status code
     or other error, then you should enable and configure
-    [events.webhooks.retry](../../config.md#eventswebhooksretry)
+    [events.webhooks.retry](../../config.html#eventswebhooksretry)
   - The event is acknowledged once the request (with any retries), is
     completed - regardless of whether the outcome was a success or failure.
 - Use `fastack` to acknowledge against FireFly immediately and make multiple

--- a/docs/reference/types/_includes/subscription_description.md
+++ b/docs/reference/types/_includes/subscription_description.md
@@ -167,8 +167,12 @@ allowing you to customize your HTTP requests as follows:
 
 - Set the HTTP request details:
   - Method, URL, query, headers and input body
-- Wait for a successful `2xx` HTTP code from the back-end service, before
-  acknowledging (default).
+- Wait for a invocation of the back-end service, before acknowledging
+  - To retry requests to your Webhook on a non-`2xx` HTTP status code
+    or other error, then you should enable and configure
+    [events.webhooks.retry](../../config.md#eventswebhooksretry)
+  - The event is acknowledged once the request (with any retries), is
+    completed - regardless of whether the outcome was a success or failure.
 - Use `fastack` to acknowledge against FireFly immediately and make multiple
   parallel calls to the HTTP API in a fire-and-forget fashion.
 - Set the HTTP request details dynamically from `message_confirmed` events:

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -351,4 +351,9 @@ var (
 	ConfigPluginsAuth     = ffc("config.plugins.auth", "Authorization plugin configuration", i18n.MapStringStringType)
 	ConfigPluginsAuthName = ffc("config.plugins.auth[].name", "The name of the auth plugin to use", i18n.StringType)
 	ConfigPluginsAuthType = ffc("config.plugins.auth[].type", "The type of the auth plugin to use", i18n.StringType)
+
+	ConfigPluginsEventSystemReadAhead           = ffc("config.events.system.readAhead", "", i18n.IgnoredType)
+	ConfigPluginsEventWebhooksURL               = ffc("config.events.webhooks.url", "", i18n.IgnoredType)
+	ConfigPluginsEventWebSocketsReadBufferSize  = ffc("config.events.websockets.readBufferSize", "WebSocket read buffer size", i18n.ByteSizeType)
+	ConfigPluginsEventWebSocketsWriteBufferSize = ffc("config.events.websockets.writeBufferSize", "WebSocket write buffer size", i18n.ByteSizeType)
 )

--- a/internal/events/eifactory/factory.go
+++ b/internal/events/eifactory/factory.go
@@ -19,6 +19,7 @@ package eifactory
 import (
 	"context"
 
+	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/internal/events/system"
@@ -38,6 +39,12 @@ var pluginsByName = make(map[string]events.Plugin)
 func init() {
 	for _, p := range plugins {
 		pluginsByName[p.Name()] = p
+	}
+}
+
+func InitConfig(config config.Section) {
+	for name, plugin := range pluginsByName {
+		plugin.InitConfig(config.SubSection(name))
 	}
 }
 

--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -229,7 +229,7 @@ func (wh *WebHooks) attemptRequest(sub *core.Subscription, event *core.EventDeli
 	log.L(wh.ctx).Debugf("Webhook-> %s %s event %s on subscription %s", req.method, req.url, event.ID, sub.ID)
 	resp, err := req.r.Execute(req.method, req.url)
 	if err != nil {
-		log.L(wh.ctx).Errorf("Webhook<-! %s %s event %s on subscription %s failed: %s", req.method, req.url, event.ID, sub.ID, err)
+		log.L(wh.ctx).Errorf("Webhook<- %s %s event %s on subscription %s failed: %s", req.method, req.url, event.ID, sub.ID, err)
 		return nil, nil, err
 	}
 	defer func() { _ = resp.RawBody().Close() }()

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -190,6 +190,9 @@ func NewNamespaceManager(withDefaults bool) Manager {
 	tifactory.InitConfig(tokensConfig)
 	authfactory.InitConfigArray(authConfig)
 
+	// Events still live at the root of the config
+	eifactory.InitConfig(config.RootSection("events"))
+
 	return nm
 }
 


### PR DESCRIPTION
Raised from #1025 

- Adds better logging
- Ensures we do a `DeliveryResponse` in the case of a non-`reply`, non-`fastack` webhook subscription
- Disabled `fastack` when `reply` is configured, as the reply would not be sent otherwise
- (Re)instate the lost `events` section in the config docs
- Correct the docs to reflect that if you want to retry on non-`2xx` error codes, you need to set `events.webhooks.retry`