### PR TITLE
Fix Docker Release GitHub Action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ reference:
 manifest:
 		./manifestgen.sh
 docker:
-		./docker_build.sh $(DOCKER_ARGS)
+		./docker_build.sh --load $(DOCKER_ARGS)
 docker-multiarch:
 		./docker_build.sh --platform linux/amd64,linux/arm64 $(DOCKER_ARGS) 
 docs: .ALWAYS

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -46,7 +46,6 @@ docker buildx build \
     --build-arg BASE_TAG=$BASE_TAG \
     --build-arg UI_TAG=$UI_TAG \
     --build-arg UI_RELEASE=$UI_RELEASE \
-    --load \
     $@ \
     .
 docker buildx rm firefly


### PR DESCRIPTION
Apparently `docker buildx` flags `--load` and `--push` cannot be used at the same time currently. So this change switches `load` to happen when doing a normal, native architecture build. But allows for pushes when doing multiarch builds.