### PR TITLE
Fix typo in erc1155.md

### DIFF
--- a/docs/tutorials/tokens/erc1155.md
+++ b/docs/tutorials/tokens/erc1155.md
@@ -26,7 +26,7 @@ If you haven't set up the FireFly CLI already, please go back to the Getting Sta
 ## Create a stack with an ERC-1155 connector
 The default Token Connector that the FireFly CLI sets up is for ERC-20 and ERC-721. If you would like to work with ERC-1155 tokens, you need to create a stack that is configured to use that Token Connector. To do that, run:
 ```
-ff init -t erc-1155
+ff init -t erc1155
 ```
 
 Then run:


### PR DESCRIPTION
Fix typo in the erc155 tutorial init command. `ff init -t erc-1155` to `ff init -t erc1155`

Signed-off-by: Ander Dorado <71599694+ander-db@users.noreply.github.com>