### PR TITLE
Add docs on passing ABI info to token pools

### DIFF
--- a/docs/tutorials/tokens/erc1155.md
+++ b/docs/tutorials/tokens/erc1155.md
@@ -24,7 +24,7 @@ If you haven't set up the FireFly CLI already, please go back to the Getting Sta
 [← ① Install the FireFly CLI](../../gettingstarted/firefly_cli.md){: .btn .btn-purple .mb-5}
 
 ## Create a stack with an ERC-1155 connector
-The default Token Connector that the FireFly CLI sets up is for ERC-20 and ERC-721. If you would like to work with ERC-1155 tokens, you need to create a stack that is configured to use that Token Connector. To do that, run:
+The default token connector that the FireFly CLI sets up is for ERC-20 and ERC-721. If you would like to work with ERC-1155 tokens, you need to create a stack that is configured to use that token connector. To do that, run:
 ```
 ff init -t erc1155
 ```
@@ -34,13 +34,17 @@ Then run:
 ff start <your_stack_name>
 ```
 
+## About the sample token contract
+When the FireFly CLI set up your FireFly stack, it also deployed a sample ERC-1155 contract that conforms to the expectations of the token connector. When you create a token pool through FireFly's token APIs, that contract will be used by default.
+
+<div style="color: #ffffff; background: #ff7700; padding: 1em; border-radius: 5px;">⚠️ <span style="font-weight: bold;">WARNING</span>: The default token contract that was deployed by the FireFly CLI is only provided for the purpose of learning about FireFly. It is <span style="font-weight: bold;">not</span> a production grade contract. If you intend to deploy a production application using tokens on FireFly, you should research token contract best practices. For details, <a style="color: #ffffff;" href="https://github.com/hyperledger/firefly-tokens-erc1155/blob/main/samples/solidity/contracts/ERC1155MixedFungible.sol">please see the source code</a> for the contract that was deployed.</div>
+
 ## Use the Sandbox (optional)
-At this point you could open the Sandbox to http://localhost:3000/home?action=tokens.pools and perform the functions outlined in the rest of this guide. Or you can keep reading to learn how to build HTTP requests to work with tokens in FireFly.
+At this point you could open the Sandbox at [http://127.0.0.1:5109/home?action=tokens.pools](http://127.0.0.1:5109/home?action=tokens.pools) and perform the functions outlined in the rest of this guide. Or you can keep reading to learn how to build HTTP requests to work with tokens in FireFly.
 ![Tokens Sandbox](../../images/sandbox/sandbox_token_pool.png) 
 
-## Create a pool
-After you stack is up and running, the first thing you need to do is create a Token Pool. Every application will need at least one Token Pool. At a minimum, you must always
-specify a `name` and `type` (`fungible` or `nonfungible`) for the pool.
+## Create a pool (using default token contract)
+After your stack is up and running, the first thing you need to do is create a token pool. Every application will need at least one token pool. At a minimum, you must always specify a `name` and `type` (`fungible` or `nonfungible`) for the pool.
 
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/pools`
 
@@ -56,10 +60,32 @@ Other parameters:
 - You may pass through a `config` object of additional parameters, if supported by your token connector
 - You may specify a `key` understood by the connector (i.e. an Ethereum address) if you'd like to use a non-default signing identity
 
+## Create a pool (from a deployed token contract)
+If you wish to use a contract that is already on the chain, it is recommended that you first upload the ABI for your specific contract by [creating a FireFly contract interface](../custom_contracts/ethereum.md). This step is optional if you're certain that your ERC-1155 ABI conforms to the default expectations of the token connector, but is generally recommended.
+
+See the [README](https://github.com/hyperledger/firefly-tokens-erc1155/blob/main/README.md) of the token connector for details on what contract variants can currently be understood.
+
+You can pass a `config` object with an `address` when you make the request to create the token pool, and if you created a contract interface, you can include the `interface` ID as well.
+
+`POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/pools`
+
+```json
+{
+  "name": "testpool",
+  "type": "fungible",
+  "interface": {
+    "id": "b9e5e1ce-97bb-4a35-a25c-52c7c3f523d8"
+  },
+  "config": {
+    "address": "0xb1C845D32966c79E23f733742Ed7fCe4B41901FC"
+  }
+}
+```
+
 ## Mint tokens
 
-Once you have a token pool, you can mint tokens within it. With the default `firefly-tokens-erc1155` connector,
-only the creator of a pool is allowed to mint - but each connector may define its own permission model.
+Once you have a token pool, you can mint tokens within it. With the default sample contract,
+only the creator of a pool is allowed to mint - but each contract may define its own permission model.
 
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/mint`
 
@@ -77,7 +103,7 @@ Other parameters:
 ## Transfer tokens
 
 You may transfer tokens within a pool by specifying an amount and a destination understood by the connector (i.e. an Ethereum address).
-With the default `firefly-tokens-erc1155` connector, only the owner of a token may transfer it away - but each connector may define its
+With the default sample contract, only the owner of a token or another approved account may transfer it away - but each contract may define its
 own permission model.
 
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/transfers`
@@ -147,7 +173,7 @@ the recipients of the message will be able to view the actual message data.
 
 ## Burn tokens
 
-You may burn tokens by simply specifying an amount. With the default `firefly-tokens-erc1155` connector, only the owner of a token may
+You may burn tokens by simply specifying an amount. With the default sample contract, only the owner of a token or another approved account may
 burn it - but each connector may define its own permission model.
 
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/burn`

--- a/docs/tutorials/tokens/erc721.md
+++ b/docs/tutorials/tokens/erc721.md
@@ -22,21 +22,19 @@ If you haven't started a FireFly stack already, please go to the Getting Started
 
 [← ② Start your environment](../../gettingstarted/setup_env.md){: .btn .btn-purple .mb-5}
 
-## Use the built in sample token factory
-
+## About the sample token contracts
 If you are using the default ERC-20 / ERC-721 token connector, when the FireFly CLI set up your FireFly stack, it also deployed a token factory contract. When you create a token pool through FireFly's token APIs, the token factory contract will automatically deploy an ERC-20 or ERC-721 contract, based on the pool `type` in the API request.
 
-<div style="color: #ffffff; background: #ff7700; padding: 1em; border-radius: 5px;">⚠️ <span style="font-weight: bold;">WARNING</span>: The default token contract that was deployed by the FireFly CLI is only provided for the purpose of learning about FireFly. It is <span style="font-weight: bold;">not</span> a production grade contract. If you intend to deploy a production application using tokens FireFly you should research token contract best practices. For details, <a style="color: #ffffff;" href="https://github.com/hyperledger/firefly-tokens-erc20-erc721/blob/main/samples/solidity/contracts/TokenFactory.sol">please see the source code</a> for the contract that was deployed.</div>
+<div style="color: #ffffff; background: #ff7700; padding: 1em; border-radius: 5px;">⚠️ <span style="font-weight: bold;">WARNING</span>: The default token contract that was deployed by the FireFly CLI is only provided for the purpose of learning about FireFly. It is <span style="font-weight: bold;">not</span> a production grade contract. If you intend to deploy a production application using tokens on FireFly, you should research token contract best practices. For details, <a style="color: #ffffff;" href="https://github.com/hyperledger/firefly-tokens-erc20-erc721/blob/main/samples/solidity/contracts/TokenFactory.sol">please see the source code</a> for the contract that was deployed.</div>
 
 ## Use the Sandbox (optional)
 At this point you could open the Sandbox at [http://127.0.0.1:5109/home?action=tokens.pools](http://127.0.0.1:5109/home?action=tokens.pools) and perform the functions outlined in the rest of this guide. Or you can keep reading to learn how to build HTTP requests to work with tokens in FireFly.
 ![Tokens Sandbox](../../images/sandbox/sandbox_token_pool.png) 
 
-## Create a pool
-After you stack is up and running, the first thing you need to do is create a Token Pool. Every application will need at least one Token Pool. At a minimum, you must always
-specify a `name` and `type` for the pool.
+## Create a pool (using default token factory)
+After your stack is up and running, the first thing you need to do is create a token pool. Every application will need at least one token pool. At a minimum, you must always specify a `name` and `type` for the pool.
 
-If you're using the default ERC-20 / ERC-721 token connector and its sample token factory, it will automatically deploy a new token contract, based on the `type` in the request to create the token pool.
+If you're using the default ERC-20 / ERC-721 token connector and its sample token factory, it will automatically deploy a new ERC-721 contract instance.
 
 #### Request
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/pools`
@@ -71,7 +69,7 @@ Other parameters:
 
 ### Get the address of the deployed contract
 
-To lookup the address of the new contract, you can lookup the Token Pool by its ID on the API. Creating the token pool will also emit an event which will contain the address. To query the token pool you can make a `GET` request to the pool's ID:
+To lookup the address of the new contract, you can lookup the token pool by its ID on the API. Creating the token pool will also emit an event which will contain the address. To query the token pool you can make a `GET` request to the pool's ID:
 
 #### Request
 `GET` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/pools/5811e8d5-52d0-44b1-8b75-73f5ff88f598`
@@ -101,26 +99,38 @@ To lookup the address of the new contract, you can lookup the Token Pool by its 
 }
 ```
 
-### Create a pool for an existing contract
-If you wish to use a contract that is already on the chain, you can pass the address in a `config` object with an `address` when you make the request to create the Token Pool.
+## Create a pool (from a deployed token contract)
+If you wish to index and use a contract that is already on the chain, it is recommended that you first upload the ABI for your specific contract by [creating a FireFly contract interface](../custom_contracts/ethereum.md). This step is optional if you're certain that your ERC-721 ABI conforms to the default expectations of the token connector, but is generally recommended.
 
+See the [README](https://github.com/hyperledger/firefly-tokens-erc20-erc721/blob/main/README.md) of the token connector for details on what contract variants can currently be understood.
+
+You can pass a `config` object with an `address` and `blockNumber` when you make the request to create the token pool, and if you created a contract interface, you can include the `interface` ID as well.
+
+#### Request
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/pools`
 
 ```json
 {
   "name": "testpool",
   "type": "fungible",
+  "interface": {
+    "id": "b9e5e1ce-97bb-4a35-a25c-52c7c3f523d8"
+  },
   "config": {
-    "address": "0xb1C845D32966c79E23f733742Ed7fCe4B41901FC"
+    "address": "0xb1C845D32966c79E23f733742Ed7fCe4B41901FC",
+    "blockNumber": "0"
   }
 }
 ```
 
 ## Mint a token
 
-Once you have a token pool, you can mint tokens within it. With a token contract deployed by the default token factory, only the creator of a pool is allowed to mint, but a different contract may define its own permission model. With the default ERC-20 / ERC-721 token connector, the `tokenIndex` field must be set when minting an NFT. This is the unique index within the pool for the specific token that you are minting.
+Once you have a token pool, you can mint tokens within it. When using the sample contract deployed by the CLI, the following are true:
+* only the creator of a pool is allowed to mint within that pool
+* the `tokenIndex` must be set to a unique value
+* the `amount` must be `1`
 
-> **NOTE:** When minting NFTs the `amount` must be `1`. If you wish to mint more NFTs, simply call the endpoint multiple times.
+A different ERC-721 contract may define its own requirements.
 
 #### Request
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/mint`
@@ -156,7 +166,7 @@ Other parameters:
 
 ## Transfer a token
 
-You may transfer tokens within a pool by specifying an amount and a destination understood by the connector (i.e. an Ethereum address). With a token contract deployed by the default token factory, only the owner of the tokens or another approved account may transfer their tokens, but a different contract may define its own permission model.
+You may transfer tokens within a pool by specifying an amount and a destination understood by the connector (i.e. an Ethereum address). With the default sample contract, only the owner of the tokens or another approved account may transfer their tokens, but a different contract may define its own permission model.
 
 When transferring an NFT, you must also specify the `tokenIndex` that you wish to transfer. The `tokenIndex` is simply the ID of the specific NFT within the pool that you wish to transfer.
 
@@ -248,8 +258,7 @@ Note that all parties in the network will be able to see the transfer (including
 the recipients of the message will be able to view the actual message data.
 
 ## Burn tokens
-You may burn a token by specifying the token's `tokenIndex`. With a token contract deployed by the default token factory, only the owner of a token may
-burn it, but a different contract may define its own permission model.
+You may burn a token by specifying the token's `tokenIndex`. With the default sample contract, only the owner of a token or another approved account may burn it, but a different contract may define its own permission model.
 
 `POST` `http://127.0.0.1:5000/api/v1/namespaces/default/tokens/burn`
 


### PR DESCRIPTION
Part of [FIR-16](https://github.com/hyperledger/firefly-fir/pull/16).

This links out to the READMEs of both token connectors for "more details", so these PRs are relevant to be merged alongside this one:
https://github.com/hyperledger/firefly-tokens-erc20-erc721/pull/108
https://github.com/hyperledger/firefly-tokens-erc1155/pull/107