### PR TITLE
Check variable before using its value

### DIFF
--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -349,11 +349,12 @@ func (ft *FFTokens) handleTokenPoolCreate(ctx context.Context, data fftypes.JSON
 		}
 	}
 
-	txType := poolData.TXType
-	if txType == "" {
+	if poolData != nil {
+	    txType := poolData.TXType
+	    if txType == "" {
 		txType = core.TransactionTypeTokenPool
+	    }
 	}
-
 	pool := &tokens.TokenPool{
 		Type:        fftypes.FFEnum(tokenType),
 		PoolLocator: poolLocator,


### PR DESCRIPTION
Add a check to see if poolData is nil before attempting to access its fields. 

Resolves #1121 

Signed-off-by: Ayushya Chitransh <ayushyachitransh@gmail.com>