### PR TITLE
Default token pool interfaceFormat to empty string

### DIFF
--- a/db/migrations/postgres/000104_add_tokenpool_interface.up.sql
+++ b/db/migrations/postgres/000104_add_tokenpool_interface.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 ALTER TABLE tokenpool ADD COLUMN interface UUID;
-ALTER TABLE tokenpool ADD COLUMN interface_format VARCHAR(64);
+ALTER TABLE tokenpool ADD COLUMN interface_format VARCHAR(64) DEFAULT '';
 ALTER TABLE tokenpool ADD COLUMN methods TEXT;
 COMMIT;

--- a/db/migrations/sqlite/000104_add_tokenpool_interface.up.sql
+++ b/db/migrations/sqlite/000104_add_tokenpool_interface.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE tokenpool ADD COLUMN interface UUID;
-ALTER TABLE tokenpool ADD COLUMN interface_format VARCHAR(64);
+ALTER TABLE tokenpool ADD COLUMN interface_format VARCHAR(64) DEFAULT '';
 ALTER TABLE tokenpool ADD COLUMN methods TEXT;


### PR DESCRIPTION
Loading a NULL value into a Go string is unsupported.

Default this column to `''` so that pre-existing token pools receive that value instead of a `NULL`.

Note that this is an alteration to a migration file added in https://github.com/hyperledger/firefly/pull/1123, so wouldn't be executed by any installation that has already picked up that change. Since it hasn't yet been released, this shouldn't cause any problems.