### PR TITLE
v1.2.0-alpha.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,71 +56,71 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        blockchain-provider: [geth, fabric]
-        exclude: [ blockchain-provider: geth, blockchain-provider: fabric ]
+        stack-type: [ethereum, fabric]
+        exclude: [stack-type: ethereum, stack-type: fabric]
         include:
-            - blockchain-provider: geth
-              blockchain-connector: ethconnect
-              test-suite: TestEthereumMultipartyE2ESuite
-              database-type: sqlite3
-              token-provider: erc20_erc721
-              multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: sqlite3
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-            - blockchain-provider: geth
-              blockchain-connector: ethconnect
-              test-suite: TestEthereumMultipartyE2ESuite
-              database-type: postgres
-              token-provider: erc20_erc721
-              multiparty-enabled: true
-            
-            - blockchain-provider: geth
-              blockchain-connector: ethconnect
-              test-suite: TestEthereumMultipartyE2ESuite
-              database-type: sqlite3
-              token-provider: erc1155
-              multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: postgres
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-            - blockchain-provider: geth
-              blockchain-connector: ethconnect
-              test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
-              database-type: postgres
-              token-provider: erc20_erc721
-              multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: sqlite3
+            token-provider: erc1155
+            multiparty-enabled: true
 
-            - blockchain-provider: fabric
-              blockchain-connector: fabconnect
-              test-suite: TestFabricE2ESuite
-              database-type: sqlite3
-              token-provider: none
-              multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
+            database-type: postgres
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-            - blockchain-provider: geth
-              blockchain-connector: ethconnect
-              test-suite: TestEthereumGatewayE2ESuite
-              database-type: sqlite3
-              token-provider: erc20_erc721
-              multiparty-enabled: false
+          - stack-type: fabric
+            blockchain-connector: fabconnect
+            test-suite: TestFabricE2ESuite
+            database-type: sqlite3
+            token-provider: none
+            multiparty-enabled: true
 
-            - blockchain-provider: fabric
-              blockchain-connector: fabconnect
-              test-suite: TestFabricGatewayE2ESuite
-              database-type: sqlite3
-              token-provider: none
-              multiparty-enabled: false
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumGatewayE2ESuite
+            database-type: sqlite3
+            token-provider: erc20_erc721
+            multiparty-enabled: false
 
-            - blockchain-provider: geth
-              blockchain-connector: evmconnect
-              test-suite: TestEthereumMultipartyE2ESuite
-              database-type: sqlite3
-              token-provider: erc20_erc721
-              multiparty-enabled: true
+          - stack-type: fabric
+            blockchain-connector: fabconnect
+            test-suite: TestFabricGatewayE2ESuite
+            database-type: sqlite3
+            token-provider: none
+            multiparty-enabled: false
 
-            - blockchain-provider: geth
-              blockchain-connector: evmconnect
-              test-suite: TestEthereumGatewayE2ESuite
-              database-type: sqlite3
-              token-provider: erc1155
-              multiparty-enabled: false
+          - stack-type: ethereum
+            blockchain-connector: ethconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: sqlite3
+            token-provider: erc20_erc721
+            multiparty-enabled: true
+
+          - stack-type: ethereum
+            blockchain-connector: ethconnect
+            test-suite: TestEthereumGatewayE2ESuite
+            database-type: sqlite3
+            token-provider: erc1155
+            multiparty-enabled: false
 
     steps:
       - uses: actions/checkout@v2
@@ -144,7 +144,7 @@ jobs:
         env:
           BUILD_FIREFLY: false
           TEST_SUITE: ${{ matrix.test-suite }}
-          BLOCKCHAIN_PROVIDER: ${{ matrix.blockchain-provider }}
+          STACK_TYPE: ${{ matrix.stack-type }}
           BLOCKCHAIN_CONNECTOR: ${{ matrix.blockchain-connector }}
           TOKENS_PROVIDER: ${{ matrix.token-provider }}
           DATABASE_TYPE: ${{ matrix.database-type }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,7 +88,6 @@ jobs:
             multiparty-enabled: true
 
           - stack-type: fabric
-            blockchain-connector: fabconnect
             test-suite: TestFabricE2ESuite
             database-type: sqlite3
             token-provider: none
@@ -102,7 +101,6 @@ jobs:
             multiparty-enabled: false
 
           - stack-type: fabric
-            blockchain-connector: fabconnect
             test-suite: TestFabricGatewayE2ESuite
             database-type: sqlite3
             token-provider: none

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,26 +12,33 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-suite: [TestEthereumMultipartyE2ESuite, TestEthereumGatewayE2ESuite, TestEthereumMultipartyTokensRemoteNameE2ESuite, TestFabricGatewayE2ESuite, TestFabricMultipartyE2ESuite]
-        blockchain-provider: [geth, besu, fabric]
+        test-suite:
+          [
+            TestEthereumMultipartyE2ESuite,
+            TestEthereumGatewayE2ESuite,
+            TestEthereumMultipartyTokensRemoteNameE2ESuite,
+            TestFabricGatewayE2ESuite,
+            TestFabricMultipartyE2ESuite,
+          ]
+        blockchain-node: [geth, besu, fabric]
         database-type: [sqlite3, postgres]
         exclude:
           - test-suite: TestEthereumGatewayE2ESuite
-            blockchain-provider: fabric
+            blockchain-node: fabric
           - test-suite: TestEthereumMultipartyE2ESuite
-            blockchain-provider: fabric
+            blockchain-node: fabric
           - test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
-            blockchain-provider: fabric
+            blockchain-node: fabric
           - test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
-            blockchain-provider: fabric
+            blockchain-node: fabric
           - test-suite: TestFabricGatewayE2ESuite
-            blockchain-provider: geth
+            blockchain-node: geth
           - test-suite: TestFabricGatewayE2ESuite
-            blockchain-provider: besu
+            blockchain-node: besu
           - test-suite: TestFabricMultipartyE2ESuite
-            blockchain-provider: geth
+            blockchain-node: geth
           - test-suite: TestFabricMultipartyE2ESuite
-            blockchain-provider: besu
+            blockchain-node: besu
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -54,8 +61,9 @@ jobs:
       - name: Run E2E tests
         env:
           TEST_SUITE: ${{ matrix.test-suite }}
-          BLOCKCHAIN_PROVIDER: ${{ matrix.blockchain-provider }}
+          STACK_TYPE: ${{ matrix.stack-type }}
           DATABASE_TYPE: ${{ matrix.database-type }}
+          BLOCKCHAIN_NODE: ${{ matrix.blockchain-node }}
           BUILD_FIREFLY: false
           RESTART: true
         run: ./test/e2e/run.sh
@@ -90,7 +98,7 @@ jobs:
       - name: Run E2E tests
         env:
           TEST_SUITE: TestEthereumV1MigrationE2ESuite
-          BLOCKCHAIN_PROVIDER: geth
+          STACK_TYPE: ethereum
           DATABASE_TYPE: postgres
           BUILD_FIREFLY: false
           RESTART: false

--- a/internal/database/sqlcommon/pin_sql.go
+++ b/internal/database/sqlcommon/pin_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/database/sqlcommon/pin_sql.go
+++ b/internal/database/sqlcommon/pin_sql.go
@@ -93,13 +93,13 @@ func (s *SQLCommon) UpsertPin(ctx context.Context, pin *core.Pin) (err error) {
 }
 
 func (s *SQLCommon) attemptPinInsert(ctx context.Context, tx *dbsql.TXWrapper, pin *core.Pin) (err error) {
-	pin.Sequence, err = s.InsertTx(ctx, pinsTable, tx,
+	requestConflictEmptyResult := true
+	pin.Sequence, err = s.InsertTxExt(ctx, pinsTable, tx,
 		s.setPinInsertValues(sq.Insert(pinsTable).Columns(pinColumns...), pin),
 		func() {
 			log.L(ctx).Debugf("Triggering creation event for pin %d", pin.Sequence)
 			s.callbacks.OrderedCollectionNSEvent(database.CollectionPins, core.ChangeEventTypeCreated, pin.Namespace, pin.Sequence)
-		},
-	)
+		}, requestConflictEmptyResult)
 	return err
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -26,8 +26,8 @@
   },
   "tokens-erc20-erc721": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc20-erc721",
-    "tag": "v1.2.0-20230112-75",
-    "sha": "fd393a9f72160d1d1c8fb09987d4ab32a5139aaaa859d6377de45f7b487e4e28"
+    "tag": "v1.2.0-20230119-76",
+    "sha": "f65438c9da16f39389dbf0c36eda103670cc8559a58d72fd6b0fe6299623628e"
   },
   "signer": {
     "image": "ghcr.io/hyperledger/firefly-signer",

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,8 @@
   },
   "evmconnect": {
     "image": "ghcr.io/hyperledger/firefly-evmconnect",
-    "tag": "v1.1.11",
-    "sha": "a6fa5e764da7103e628fab1ca6cbc7fbcf9b9f47f5ea016981b7947e77d3e74e"
+    "tag": "v1.1.10-20221220-30",
+    "sha": "3366c4061573145b3e941768b11c3a27f18c7aa0e8540a13ffa56526193a4248"
   },
   "fabconnect": {
     "image": "ghcr.io/hyperledger/firefly-fabconnect",
@@ -16,23 +16,23 @@
   },
   "dataexchange-https": {
     "image": "ghcr.io/hyperledger/firefly-dataexchange-https",
-    "tag": "v1.1.0",
-    "sha": "9b191cf693a5b4a3b0bff48aac36fa76cf040d94033607a240cbd83e4fd2942c"
+    "tag": "v1.2.0",
+    "sha": "4ac765f7a07b9d17ab5648b3c789875791db364659c975a23626ec5921f11ce4"
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "v1.2.0",
-    "sha": "9a7135b4d3352992832629ff644cf1a6526fef9de716711dbf00a7bf842184a6"
+    "tag": "null-20230113-54",
+    "sha": "413963caa75ac2d08c345c125ff1c3216e7d3373f89f690b4623cb6313324cfe"
   },
   "tokens-erc20-erc721": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc20-erc721",
-    "tag": "v1.2.0",
-    "sha": "88fbaee7d7b24682bea8fe0c00d9baa50c9a3bcc86aaed828a1f5e8ac205985a"
+    "tag": "v1.2.0-20230112-75",
+    "sha": "fd393a9f72160d1d1c8fb09987d4ab32a5139aaaa859d6377de45f7b487e4e28"
   },
   "signer": {
     "image": "ghcr.io/hyperledger/firefly-signer",
-    "tag": "v1.1.5",
-    "sha": "4ee8549d12339f6d4224a277faf143da1749a51a5994e074224c95e3cce64670"
+    "tag": "v1.1.4-20230105-28",
+    "sha": "a4a26b9ce921e908e827d63219fca02e1d56da3a64e14dc396279a4818ae1083"
   },
   "build": {
     "firefly-builder": {

--- a/manifest.json
+++ b/manifest.json
@@ -21,8 +21,8 @@
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "v1.2.0-20230119-55",
-    "sha": "0c8b0154fd4bbe9af24302c4c5665cbf7f0ef1ed5d58c7d684f0d50ad0e7034a"
+    "tag": "v1.2.0-20230119-56",
+    "sha": "e025a9e07e0066a8b9dd568a28ae629c6fee3e498337a823699c4d459442d4ad"
   },
   "tokens-erc20-erc721": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc20-erc721",

--- a/manifest.json
+++ b/manifest.json
@@ -21,8 +21,8 @@
   },
   "tokens-erc1155": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc1155",
-    "tag": "null-20230113-54",
-    "sha": "413963caa75ac2d08c345c125ff1c3216e7d3373f89f690b4623cb6313324cfe"
+    "tag": "v1.2.0-20230119-55",
+    "sha": "0c8b0154fd4bbe9af24302c4c5665cbf7f0ef1ed5d58c7d684f0d50ad0e7034a"
   },
   "tokens-erc20-erc721": {
     "image": "ghcr.io/hyperledger/firefly-tokens-erc20-erc721",

--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,8 @@
   },
   "fabconnect": {
     "image": "ghcr.io/hyperledger/firefly-fabconnect",
-    "tag": "v.0.9.16",
-    "sha": "4f4798ee34eee0b67886f1baa37f4d50a33e2932c94312f189fe5f015f6564a4"
+    "tag": "null-20230119-30",
+    "sha": "d46b3408ff1a1c4730633c217fa41f78097f76caf5ca884ede8932cbafa83476"
   },
   "dataexchange-https": {
     "image": "ghcr.io/hyperledger/firefly-dataexchange-https",
@@ -50,10 +50,10 @@
     }
   },
   "ui": {
-    "tag": "v1.1.5",
-    "release": "v1.1.5"
+    "tag": "v1.2.0-alpha.1",
+    "release": "v1.2.0-alpha.1"
   },
   "cli": {
-    "tag": "v1.1.2"
+    "tag": "v1.2.0-alpha.1"
   }
 }

--- a/test/e2e/multiparty/tokens.go
+++ b/test/e2e/multiparty/tokens.go
@@ -266,16 +266,16 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 
 	transfer := &core.TokenTransferInput{
 		TokenTransfer: core.TokenTransfer{
-			TokenIndex: "0",
+			TokenIndex: "1",
 			Amount:     *fftypes.NewFFBigInt(1),
 		},
 		Pool: poolName,
 	}
 	transferOut := suite.testState.client1.MintTokens(suite.T(), transfer, true)
 	assert.Equal(suite.T(), core.TokenTransferTypeMint, transferOut.Type)
-	assert.Equal(suite.T(), "0", transferOut.TokenIndex)
+	assert.Equal(suite.T(), "1", transferOut.TokenIndex)
 	assert.Equal(suite.T(), int64(1), transferOut.Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "0", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "1", map[string]int64{
 		suite.testState.org1key.Value: 1,
 	})
 
@@ -284,15 +284,15 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	transfers := suite.testState.client2.GetTokenTransfers(suite.T(), poolID)
 	assert.Equal(suite.T(), 1, len(transfers))
 	assert.Equal(suite.T(), core.TokenTransferTypeMint, transfers[0].Type)
-	assert.Equal(suite.T(), "0", transfers[0].TokenIndex)
+	assert.Equal(suite.T(), "1", transfers[0].TokenIndex)
 	assert.Equal(suite.T(), int64(1), transfers[0].Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "0", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "1", map[string]int64{
 		suite.testState.org1key.Value: 1,
 	})
 
 	transfer = &core.TokenTransferInput{
 		TokenTransfer: core.TokenTransfer{
-			TokenIndex: "0",
+			TokenIndex: "1",
 			To:         suite.testState.org2key.Value,
 			Amount:     *fftypes.NewFFBigInt(1),
 			From:       suite.testState.org1key.Value,
@@ -309,12 +309,12 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	}
 	transferOut = suite.testState.client1.TransferTokens(suite.T(), transfer, true)
 	assert.Equal(suite.T(), core.TokenTransferTypeTransfer, transferOut.Type)
-	assert.Equal(suite.T(), "0", transferOut.TokenIndex)
+	assert.Equal(suite.T(), "1", transferOut.TokenIndex)
 	assert.Equal(suite.T(), int64(1), transferOut.Amount.Int().Int64())
 	data := suite.testState.client1.GetDataForMessage(suite.T(), suite.testState.startTime, transferOut.Message)
 	assert.Equal(suite.T(), 1, len(data))
 	assert.Equal(suite.T(), `"ownership change"`, data[0].Value.String())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "0", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "1", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 1,
 	})
@@ -324,25 +324,25 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	transfers = suite.testState.client2.GetTokenTransfers(suite.T(), poolID)
 	assert.Equal(suite.T(), 2, len(transfers))
 	assert.Equal(suite.T(), core.TokenTransferTypeTransfer, transfers[0].Type)
-	assert.Equal(suite.T(), "0", transfers[0].TokenIndex)
+	assert.Equal(suite.T(), "1", transfers[0].TokenIndex)
 	assert.Equal(suite.T(), int64(1), transfers[0].Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "0", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "1", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 1,
 	})
 
 	transfer = &core.TokenTransferInput{
 		TokenTransfer: core.TokenTransfer{
-			TokenIndex: "0",
+			TokenIndex: "1",
 			Amount:     *fftypes.NewFFBigInt(1),
 		},
 		Pool: poolName,
 	}
 	transferOut = suite.testState.client2.BurnTokens(suite.T(), transfer, true)
 	assert.Equal(suite.T(), core.TokenTransferTypeBurn, transferOut.Type)
-	assert.Equal(suite.T(), "0", transferOut.TokenIndex)
+	assert.Equal(suite.T(), "1", transferOut.TokenIndex)
 	assert.Equal(suite.T(), int64(1), transferOut.Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "0", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "1", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 0,
 	})
@@ -352,9 +352,9 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	transfers = suite.testState.client1.GetTokenTransfers(suite.T(), poolID)
 	assert.Equal(suite.T(), 3, len(transfers))
 	assert.Equal(suite.T(), core.TokenTransferTypeBurn, transfers[0].Type)
-	assert.Equal(suite.T(), "0", transfers[0].TokenIndex)
+	assert.Equal(suite.T(), "1", transfers[0].TokenIndex)
 	assert.Equal(suite.T(), int64(1), transfers[0].Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "0", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "1", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 0,
 	})

--- a/test/e2e/multiparty/tokens.go
+++ b/test/e2e/multiparty/tokens.go
@@ -266,16 +266,16 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 
 	transfer := &core.TokenTransferInput{
 		TokenTransfer: core.TokenTransfer{
-			TokenIndex: "1",
+			TokenIndex: "0",
 			Amount:     *fftypes.NewFFBigInt(1),
 		},
 		Pool: poolName,
 	}
 	transferOut := suite.testState.client1.MintTokens(suite.T(), transfer, true)
 	assert.Equal(suite.T(), core.TokenTransferTypeMint, transferOut.Type)
-	assert.Equal(suite.T(), "1", transferOut.TokenIndex)
+	assert.Equal(suite.T(), "0", transferOut.TokenIndex)
 	assert.Equal(suite.T(), int64(1), transferOut.Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "1", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "0", map[string]int64{
 		suite.testState.org1key.Value: 1,
 	})
 
@@ -284,15 +284,15 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	transfers := suite.testState.client2.GetTokenTransfers(suite.T(), poolID)
 	assert.Equal(suite.T(), 1, len(transfers))
 	assert.Equal(suite.T(), core.TokenTransferTypeMint, transfers[0].Type)
-	assert.Equal(suite.T(), "1", transfers[0].TokenIndex)
+	assert.Equal(suite.T(), "0", transfers[0].TokenIndex)
 	assert.Equal(suite.T(), int64(1), transfers[0].Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "1", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "0", map[string]int64{
 		suite.testState.org1key.Value: 1,
 	})
 
 	transfer = &core.TokenTransferInput{
 		TokenTransfer: core.TokenTransfer{
-			TokenIndex: "1",
+			TokenIndex: "0",
 			To:         suite.testState.org2key.Value,
 			Amount:     *fftypes.NewFFBigInt(1),
 			From:       suite.testState.org1key.Value,
@@ -309,12 +309,12 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	}
 	transferOut = suite.testState.client1.TransferTokens(suite.T(), transfer, true)
 	assert.Equal(suite.T(), core.TokenTransferTypeTransfer, transferOut.Type)
-	assert.Equal(suite.T(), "1", transferOut.TokenIndex)
+	assert.Equal(suite.T(), "0", transferOut.TokenIndex)
 	assert.Equal(suite.T(), int64(1), transferOut.Amount.Int().Int64())
 	data := suite.testState.client1.GetDataForMessage(suite.T(), suite.testState.startTime, transferOut.Message)
 	assert.Equal(suite.T(), 1, len(data))
 	assert.Equal(suite.T(), `"ownership change"`, data[0].Value.String())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "1", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "0", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 1,
 	})
@@ -324,25 +324,25 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	transfers = suite.testState.client2.GetTokenTransfers(suite.T(), poolID)
 	assert.Equal(suite.T(), 2, len(transfers))
 	assert.Equal(suite.T(), core.TokenTransferTypeTransfer, transfers[0].Type)
-	assert.Equal(suite.T(), "1", transfers[0].TokenIndex)
+	assert.Equal(suite.T(), "0", transfers[0].TokenIndex)
 	assert.Equal(suite.T(), int64(1), transfers[0].Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "1", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "0", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 1,
 	})
 
 	transfer = &core.TokenTransferInput{
 		TokenTransfer: core.TokenTransfer{
-			TokenIndex: "1",
+			TokenIndex: "0",
 			Amount:     *fftypes.NewFFBigInt(1),
 		},
 		Pool: poolName,
 	}
 	transferOut = suite.testState.client2.BurnTokens(suite.T(), transfer, true)
 	assert.Equal(suite.T(), core.TokenTransferTypeBurn, transferOut.Type)
-	assert.Equal(suite.T(), "1", transferOut.TokenIndex)
+	assert.Equal(suite.T(), "0", transferOut.TokenIndex)
 	assert.Equal(suite.T(), int64(1), transferOut.Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "1", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client2, poolID, "0", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 0,
 	})
@@ -352,9 +352,9 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	transfers = suite.testState.client1.GetTokenTransfers(suite.T(), poolID)
 	assert.Equal(suite.T(), 3, len(transfers))
 	assert.Equal(suite.T(), core.TokenTransferTypeBurn, transfers[0].Type)
-	assert.Equal(suite.T(), "1", transfers[0].TokenIndex)
+	assert.Equal(suite.T(), "0", transfers[0].TokenIndex)
 	assert.Equal(suite.T(), int64(1), transfers[0].Amount.Int().Int64())
-	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "1", map[string]int64{
+	e2e.ValidateAccountBalances(suite.T(), suite.testState.client1, poolID, "0", map[string]int64{
 		suite.testState.org1key.Value: 0,
 		suite.testState.org2key.Value: 0,
 	})

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -48,7 +48,7 @@ BUILD_FIREFLY=${BUILD_FIREFLY:-true}
 MULTIPARTY_ENABLED=${MULTIPARTY_ENABLED:-true}
 
 DATABASE_TYPE=${DATABASE_TYPE:-sqlite3}
-BLOCKCHAIN_PROVIDER=${BLOCKCHAIN_PROVIDER:-geth}
+STACK_TYPE=${STACK_TYPE:-ethereum}
 TOKENS_PROVIDER=${TOKENS_PROVIDER:-erc20_erc721}
 
 BLOCKCHAIN_CONNECTOR_FLAG=""
@@ -56,8 +56,13 @@ if [ -n "${BLOCKCHAIN_CONNECTOR}" ]; then
   BLOCKCHAIN_CONNECTOR_FLAG="--blockchain-connector ${BLOCKCHAIN_CONNECTOR}"
 fi
 
+BLOCKCHAIN_NODE_FLAG=""
+if [ -n "${BLOCKCHAIN_NODE}" ]; then
+  BLOCKCHAIN_CONNECTOR_FLAG="--blockchain-node ${BLOCKCHAIN_NODE}"
+fi
+
 if [ -z "${TEST_SUITE}" ]; then
-  if [ "${BLOCKCHAIN_PROVIDER}" == "fabric" ]; then
+  if [ "${STACK_TYPE}" == "fabric" ]; then
     if [ "${MULTIPARTY_ENABLED}" == "true" ]; then
       TEST_SUITE=TestFabricMultipartyE2ESuite
     else
@@ -86,7 +91,7 @@ fi
 
 if [ "$CREATE_STACK" == "true" ]; then
   $CLI remove -f $STACK_NAME
-  $CLI init --prometheus-enabled --database $DATABASE_TYPE $STACK_NAME 2 --blockchain-provider $BLOCKCHAIN_PROVIDER $BLOCKCHAIN_CONNECTOR_FLAG --token-providers $TOKENS_PROVIDER --manifest ../../manifest.json $EXTRA_INIT_ARGS --sandbox-enabled=false --multiparty=$MULTIPARTY_ENABLED
+  $CLI init $STACK_TYPE --prometheus-enabled --database $DATABASE_TYPE $STACK_NAME 2 $BLOCKCHAIN_CONNECTOR_FLAG $BLOCKCHAIN_NODE_FLAG --token-providers $TOKENS_PROVIDER --manifest ../../manifest.json $EXTRA_INIT_ARGS --sandbox-enabled=false --multiparty=$MULTIPARTY_ENABLED
   checkOk $?
 
   $CLI pull $STACK_NAME -r 3


### PR DESCRIPTION
This PR updates the `manifest.json` with the latest version of each dependency service, the latest CLI, the latest UI, and sets `evmconnect` to be the new default for E2E tests. Ethconnect is still tested, but it now takes a back seat compared to evmconnect.