### PR TITLE
Fix panic on webhooks without messages

### DIFF
--- a/internal/events/webhooks/webhooks_test.go
+++ b/internal/events/webhooks/webhooks_test.go
@@ -715,6 +715,8 @@ func TestWebhookFailFastAsk(t *testing.T) {
 func TestDeliveryRequestNilMessage(t *testing.T) {
 	wh, cancel := newTestWebHooks(t)
 	defer cancel()
+	mcb := wh.callbacks["ns1"].(*eventsmocks.Callbacks)
+	mcb.On("DeliveryResponse", mock.Anything, mock.Anything).Return("", &core.EventDelivery{})
 
 	yes := true
 	sub := &core.Subscription{
@@ -741,6 +743,7 @@ func TestDeliveryRequestNilMessage(t *testing.T) {
 
 	err := wh.DeliveryRequest(mock.Anything, sub, event, nil)
 	assert.NoError(t, err)
+	mcb.AssertExpectations(t)
 }
 
 func TestDeliveryRequestReplyToReply(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/hyperledger/firefly/issues/1155

This PR changes the behavior of webhook callbacks in several ways:

- If `reply` is specified on the subscription it no longer panics if there is no Message on the event (such as is the case with custom contract events)
- If `withData` is specified subscription, but no Message is on the event, the event payload itself will still be sent

This means that subscriptions can be setup with either the `reply` and `withData` fields set (or both) and still use the same subscription for custom contract events as well.