### PR TITLE
Add "attachment" field to message header

### DIFF
--- a/docs/reference/types/message.md
+++ b/docs/reference/types/message.md
@@ -74,6 +74,7 @@ nav_order: 15
 | `cid` | The correlation ID of the message. Set this when a message is a response to another message | [`UUID`](simpletypes#uuid) |
 | `type` | The type of the message | `FFEnum`:<br/>`"definition"`<br/>`"broadcast"`<br/>`"private"`<br/>`"groupinit"`<br/>`"transfer_broadcast"`<br/>`"transfer_private"`<br/>`"approval_broadcast"`<br/>`"approval_private"` |
 | `txtype` | The type of transaction used to order/deliver this message | `FFEnum`:<br/>`"none"`<br/>`"unpinned"`<br/>`"batch_pin"`<br/>`"network_action"`<br/>`"token_pool"`<br/>`"token_transfer"`<br/>`"contract_deploy"`<br/>`"contract_invoke"`<br/>`"token_approval"`<br/>`"data_publish"` |
+| `attachment` | The type of attachment to be correlated with this message | `FFEnum`:<br/>`""`<br/>`"token_transfer"`<br/>`"token_approval"` |
 | `author` | The DID of identity of the submitter | `string` |
 | `key` | The on-chain signing key used to sign the transaction | `string` |
 | `created` | The creation time of the message | [`FFTime`](simpletypes#fftime) |

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5609,6 +5609,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -8048,6 +8056,14 @@ paths:
                       description: The message header contains all fields that are
                         used to build the message hash
                       properties:
+                        attachment:
+                          description: The type of attachment to be correlated with
+                            this message
+                          enum:
+                          - ""
+                          - token_transfer
+                          - token_approval
+                          type: string
                         author:
                           description: The DID of identity of the submitter
                           type: string
@@ -8300,6 +8316,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -8917,6 +8941,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -9054,6 +9086,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -9355,6 +9395,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -9498,6 +9546,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -9881,6 +9937,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -16164,6 +16228,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -18722,6 +18794,14 @@ paths:
                       description: The message header contains all fields that are
                         used to build the message hash
                       properties:
+                        attachment:
+                          description: The type of attachment to be correlated with
+                            this message
+                          enum:
+                          - ""
+                          - token_transfer
+                          - token_approval
+                          type: string
                         author:
                           description: The DID of identity of the submitter
                           type: string
@@ -18981,6 +19061,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -19664,6 +19752,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -19807,6 +19903,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -20121,6 +20225,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -20264,6 +20376,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string
@@ -20654,6 +20774,14 @@ paths:
                     description: The message header contains all fields that are used
                       to build the message hash
                     properties:
+                      attachment:
+                        description: The type of attachment to be correlated with
+                          this message
+                        enum:
+                        - ""
+                        - token_transfer
+                        - token_approval
+                        type: string
                       author:
                         description: The DID of identity of the submitter
                         type: string

--- a/internal/assets/token_approval.go
+++ b/internal/assets/token_approval.go
@@ -195,19 +195,22 @@ func (am *assetManager) validateApproval(ctx context.Context, approval *core.Tok
 
 func (s *approveSender) buildApprovalMessage(ctx context.Context, in *core.MessageInOut) (syncasync.Sender, error) {
 	allowedTypes := []fftypes.FFEnum{
-		core.MessageTypeApprovalBroadcast,
-		core.MessageTypeApprovalPrivate,
+		core.MessageTypeBroadcast,
+		core.MessageTypePrivate,
+		core.MessageTypeDeprecatedApprovalBroadcast,
+		core.MessageTypeDeprecatedApprovalPrivate,
 	}
+	in.Header.Attachment = core.AttachmentTypeTokenApproval
 	if in.Header.Type == "" {
-		in.Header.Type = core.MessageTypeApprovalBroadcast
+		in.Header.Type = core.MessageTypeBroadcast
 	}
 	switch in.Header.Type {
-	case core.MessageTypeApprovalBroadcast:
+	case core.MessageTypeBroadcast, core.MessageTypeDeprecatedApprovalBroadcast:
 		if s.mgr.broadcast == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}
 		return s.mgr.broadcast.NewBroadcast(in), nil
-	case core.MessageTypeApprovalPrivate:
+	case core.MessageTypePrivate, core.MessageTypeDeprecatedApprovalPrivate:
 		if s.mgr.messaging == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}

--- a/internal/assets/token_approval_test.go
+++ b/internal/assets/token_approval_test.go
@@ -593,8 +593,9 @@ func TestApprovalWithPrivateMessage(t *testing.T) {
 		Message: &core.MessageInOut{
 			Message: core.Message{
 				Header: core.MessageHeader{
-					ID:   msgID,
-					Type: core.MessageTypeApprovalPrivate,
+					ID:         msgID,
+					Type:       core.MessageTypePrivate,
+					Attachment: core.AttachmentTypeTokenApproval,
 				},
 				Hash: hash,
 			},
@@ -659,7 +660,7 @@ func TestApprovalWithPrivateMessageDisabled(t *testing.T) {
 			Message: core.Message{
 				Header: core.MessageHeader{
 					ID:   msgID,
-					Type: core.MessageTypeApprovalPrivate,
+					Type: core.MessageTypeDeprecatedApprovalPrivate,
 				},
 				Hash: hash,
 			},

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -262,19 +262,22 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) (e
 
 func (s *transferSender) buildTransferMessage(ctx context.Context, in *core.MessageInOut) (syncasync.Sender, error) {
 	allowedTypes := []fftypes.FFEnum{
-		core.MessageTypeTransferBroadcast,
-		core.MessageTypeTransferPrivate,
+		core.MessageTypeBroadcast,
+		core.MessageTypePrivate,
+		core.MessageTypeDeprecatedTransferBroadcast,
+		core.MessageTypeDeprecatedTransferPrivate,
 	}
+	in.Header.Attachment = core.AttachmentTypeTokenTransfer
 	if in.Header.Type == "" {
-		in.Header.Type = core.MessageTypeTransferBroadcast
+		in.Header.Type = core.MessageTypeBroadcast
 	}
 	switch in.Header.Type {
-	case core.MessageTypeTransferBroadcast:
+	case core.MessageTypeBroadcast, core.MessageTypeDeprecatedTransferBroadcast:
 		if s.mgr.broadcast == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}
 		return s.mgr.broadcast.NewBroadcast(in), nil
-	case core.MessageTypeTransferPrivate:
+	case core.MessageTypePrivate, core.MessageTypeDeprecatedTransferPrivate:
 		if s.mgr.messaging == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}

--- a/internal/assets/token_transfer_test.go
+++ b/internal/assets/token_transfer_test.go
@@ -905,8 +905,9 @@ func TestTransferTokensWithPrivateMessage(t *testing.T) {
 		Message: &core.MessageInOut{
 			Message: core.Message{
 				Header: core.MessageHeader{
-					ID:   msgID,
-					Type: core.MessageTypeTransferPrivate,
+					ID:         msgID,
+					Type:       core.MessageTypePrivate,
+					Attachment: core.AttachmentTypeTokenTransfer,
 				},
 				Hash: hash,
 			},
@@ -972,7 +973,7 @@ func TestTransferTokensWithPrivateMessageDisabled(t *testing.T) {
 			Message: core.Message{
 				Header: core.MessageHeader{
 					ID:   msgID,
-					Type: core.MessageTypeTransferPrivate,
+					Type: core.MessageTypeDeprecatedTransferPrivate,
 				},
 				Hash: hash,
 			},

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -109,8 +109,8 @@ func NewBroadcastManager(ctx context.Context, ns *core.Namespace, di database.Pl
 			[]core.MessageType{
 				core.MessageTypeBroadcast,
 				core.MessageTypeDefinition,
-				core.MessageTypeTransferBroadcast,
-				core.MessageTypeApprovalBroadcast,
+				core.MessageTypeDeprecatedTransferBroadcast,
+				core.MessageTypeDeprecatedApprovalBroadcast,
 			}, bm.dispatchBatch, bo)
 	}
 

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -66,8 +66,8 @@ func newTestBroadcastCommon(t *testing.T, metricsEnabled bool) (*broadcastManage
 		[]core.MessageType{
 			core.MessageTypeBroadcast,
 			core.MessageTypeDefinition,
-			core.MessageTypeTransferBroadcast,
-			core.MessageTypeApprovalBroadcast,
+			core.MessageTypeDeprecatedTransferBroadcast,
+			core.MessageTypeDeprecatedApprovalBroadcast,
 		}, mock.Anything, mock.Anything).Return()
 	mom.On("RegisterHandler", mock.Anything, mock.Anything, mock.Anything)
 

--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -41,7 +41,6 @@ func (bm *broadcastManager) NewBroadcast(in *core.MessageInOut) syncasync.Sender
 
 func (bm *broadcastManager) BroadcastMessage(ctx context.Context, in *core.MessageInOut, waitConfirm bool) (out *core.Message, err error) {
 	broadcast := bm.NewBroadcast(in)
-	in.Header.Type = core.MessageTypeBroadcast
 	if bm.metrics.IsMetricsEnabled() {
 		bm.metrics.MessageSubmitted(&in.Message)
 	}
@@ -95,6 +94,7 @@ func (s *broadcastSender) setDefaults() {
 	}
 	// We only have one transaction type for broadcast currently
 	msg.Header.TxType = core.TransactionTypeBatchPin
+	msg.Header.Attachment = core.AttachmentTypeUnset
 }
 
 func (s *broadcastSender) resolveAndSend(ctx context.Context, method sendMethod) error {

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -48,16 +48,17 @@ var ffm = func(key, translation string) i18n.MessageKey {
 
 var (
 	// MessageHeader field descriptions
-	MessageHeaderID        = ffm("MessageHeader.id", "The UUID of the message. Unique to each message")
-	MessageHeaderCID       = ffm("MessageHeader.cid", "The correlation ID of the message. Set this when a message is a response to another message")
-	MessageHeaderType      = ffm("MessageHeader.type", "The type of the message")
-	MessageHeaderTxType    = ffm("MessageHeader.txtype", "The type of transaction used to order/deliver this message")
-	MessageHeaderCreated   = ffm("MessageHeader.created", "The creation time of the message")
-	MessageHeaderNamespace = ffm("MessageHeader.namespace", "The namespace of the message within the multiparty network")
-	MessageHeaderGroup     = ffm("MessageHeader.group", "Private messages only - the identifier hash of the privacy group. Derived from the name and member list of the group")
-	MessageHeaderTopics    = ffm("MessageHeader.topics", "A message topic associates this message with an ordered stream of data. A custom topic should be assigned - using the default topic is discouraged")
-	MessageHeaderTag       = ffm("MessageHeader.tag", "The message tag indicates the purpose of the message to the applications that process it")
-	MessageHeaderDataHash  = ffm("MessageHeader.datahash", "A single hash representing all data in the message. Derived from the array of data ids+hashes attached to this message")
+	MessageHeaderID         = ffm("MessageHeader.id", "The UUID of the message. Unique to each message")
+	MessageHeaderCID        = ffm("MessageHeader.cid", "The correlation ID of the message. Set this when a message is a response to another message")
+	MessageHeaderType       = ffm("MessageHeader.type", "The type of the message")
+	MessageHeaderTxType     = ffm("MessageHeader.txtype", "The type of transaction used to order/deliver this message")
+	MessageHeaderAttachment = ffm("MessageHeader.attachment", "The type of attachment to be correlated with this message")
+	MessageHeaderCreated    = ffm("MessageHeader.created", "The creation time of the message")
+	MessageHeaderNamespace  = ffm("MessageHeader.namespace", "The namespace of the message within the multiparty network")
+	MessageHeaderGroup      = ffm("MessageHeader.group", "Private messages only - the identifier hash of the privacy group. Derived from the name and member list of the group")
+	MessageHeaderTopics     = ffm("MessageHeader.topics", "A message topic associates this message with an ordered stream of data. A custom topic should be assigned - using the default topic is discouraged")
+	MessageHeaderTag        = ffm("MessageHeader.tag", "The message tag indicates the purpose of the message to the applications that process it")
+	MessageHeaderDataHash   = ffm("MessageHeader.datahash", "A single hash representing all data in the message. Derived from the array of data ids+hashes attached to this message")
 
 	// Message field descriptions
 	MessageHeader         = ffm("Message.header", "The message header contains all fields that are used to build the message hash")

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -548,7 +548,9 @@ func (ag *aggregator) attemptMessageDispatch(ctx context.Context, msg *core.Mess
 		}
 
 		// For transfers, verify the transfer has come through
-		if msg.Header.Type == core.MessageTypeTransferBroadcast || msg.Header.Type == core.MessageTypeTransferPrivate {
+		if msg.Header.Attachment == core.AttachmentTypeTokenTransfer ||
+			msg.Header.Type == core.MessageTypeDeprecatedTransferBroadcast ||
+			msg.Header.Type == core.MessageTypeDeprecatedTransferPrivate {
 			fb := database.TokenTransferQueryFactory.NewFilter(ctx)
 			filter := fb.And(
 				fb.Eq("message", msg.Header.ID),
@@ -563,7 +565,9 @@ func (ag *aggregator) attemptMessageDispatch(ctx context.Context, msg *core.Mess
 		}
 
 		// For approvals, verify the approval has come through
-		if msg.Header.Type == core.MessageTypeApprovalBroadcast || msg.Header.Type == core.MessageTypeApprovalPrivate {
+		if msg.Header.Attachment == core.AttachmentTypeTokenApproval ||
+			msg.Header.Type == core.MessageTypeDeprecatedApprovalBroadcast ||
+			msg.Header.Type == core.MessageTypeDeprecatedApprovalPrivate {
 			fb := database.TokenApprovalQueryFactory.NewFilter(ctx)
 			filter := fb.And(
 				fb.Eq("message", msg.Header.ID),

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -1514,8 +1514,9 @@ func TestAttemptMessageDispatchMissingTransfers(t *testing.T) {
 
 	msg := &core.Message{
 		Header: core.MessageHeader{
-			ID:   fftypes.NewUUID(),
-			Type: core.MessageTypeTransferBroadcast,
+			ID:         fftypes.NewUUID(),
+			Type:       core.MessageTypeBroadcast,
+			Attachment: core.AttachmentTypeTokenTransfer,
 			SignerRef: core.SignerRef{
 				Author: org1.DID,
 				Key:    "0x12345",
@@ -1541,7 +1542,7 @@ func TestAttemptMessageDispatchGetTransfersFail(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeTransferBroadcast,
+			Type:      core.MessageTypeDeprecatedTransferBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}
@@ -1561,7 +1562,7 @@ func TestAttemptMessageDispatchTransferMismatch(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeTransferBroadcast,
+			Type:      core.MessageTypeDeprecatedTransferBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}
@@ -1593,9 +1594,10 @@ func TestAttemptMessageDispatchGetApprovalsFail(t *testing.T) {
 
 	msg := &core.Message{
 		Header: core.MessageHeader{
-			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeApprovalBroadcast,
-			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
+			ID:         fftypes.NewUUID(),
+			Type:       core.MessageTypeBroadcast,
+			Attachment: core.AttachmentTypeTokenApproval,
+			SignerRef:  core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}
 	msg.Hash = msg.Header.Hash()
@@ -1614,7 +1616,7 @@ func TestAttemptMessageDispatchApprovalMismatch(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeApprovalBroadcast,
+			Type:      core.MessageTypeDeprecatedApprovalBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -41,7 +41,6 @@ func (pm *privateMessaging) NewMessage(in *core.MessageInOut) syncasync.Sender {
 
 func (pm *privateMessaging) SendMessage(ctx context.Context, in *core.MessageInOut, waitConfirm bool) (out *core.Message, err error) {
 	message := pm.NewMessage(in)
-	in.Header.Type = core.MessageTypePrivate
 	if pm.metrics.IsMetricsEnabled() {
 		pm.metrics.MessageSubmitted(&in.Message)
 	}
@@ -112,6 +111,7 @@ func (s *messageSender) setDefaults() {
 		// the only other valid option is "batch_pin"
 		msg.Header.TxType = core.TransactionTypeBatchPin
 	}
+	msg.Header.Attachment = core.AttachmentTypeUnset
 }
 
 func (s *messageSender) resolveAndSend(ctx context.Context, method sendMethod) error {

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -141,8 +141,8 @@ func NewPrivateMessaging(ctx context.Context, ns *core.Namespace, di database.Pl
 		[]core.MessageType{
 			core.MessageTypeGroupInit,
 			core.MessageTypePrivate,
-			core.MessageTypeTransferPrivate,
-			core.MessageTypeApprovalPrivate,
+			core.MessageTypeDeprecatedTransferPrivate,
+			core.MessageTypeDeprecatedApprovalPrivate,
 		},
 		pm.dispatchPinnedBatch, bo)
 

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -70,8 +70,8 @@ func newTestPrivateMessagingCommon(t *testing.T, metricsEnabled bool) (*privateM
 		[]core.MessageType{
 			core.MessageTypeGroupInit,
 			core.MessageTypePrivate,
-			core.MessageTypeTransferPrivate,
-			core.MessageTypeApprovalPrivate,
+			core.MessageTypeDeprecatedTransferPrivate,
+			core.MessageTypeDeprecatedApprovalPrivate,
 		}, mock.Anything, mock.Anything).Return()
 
 	mba.On("RegisterDispatcher",

--- a/pkg/core/message.go
+++ b/pkg/core/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -42,14 +42,26 @@ var (
 	MessageTypePrivate = fftypes.FFEnumValue("messagetype", "private")
 	// MessageTypeGroupInit is a special private message that contains the definition of the group
 	MessageTypeGroupInit = fftypes.FFEnumValue("messagetype", "groupinit")
-	// MessageTypeTransferBroadcast is a broadcast message to accompany/annotate a token transfer
-	MessageTypeTransferBroadcast = fftypes.FFEnumValue("messagetype", "transfer_broadcast")
-	// MessageTypeTransferPrivate is a private message to accompany/annotate a token transfer
-	MessageTypeTransferPrivate = fftypes.FFEnumValue("messagetype", "transfer_private")
-	// MessageTypeApprovalBroadcast is a broadcast message to accompany/annotate a token approval
-	MessageTypeApprovalBroadcast = fftypes.FFEnumValue("messagetype", "approval_broadcast")
-	// MessageTypeApprovalPrivate is a private message to accompany/annotate a token approval
-	MessageTypeApprovalPrivate = fftypes.FFEnumValue("messagetype", "approval_private")
+	// MessageTypeDeprecatedTransferBroadcast is deprecated - use MessageTypeBroadcast with AttachmentTypeTokenTransfer
+	MessageTypeDeprecatedTransferBroadcast = fftypes.FFEnumValue("messagetype", "transfer_broadcast")
+	// MessageTypeDeprecatedTransferPrivate is deprecated - use MessageTypePrivate with AttachmentTypeTokenTransfer
+	MessageTypeDeprecatedTransferPrivate = fftypes.FFEnumValue("messagetype", "transfer_private")
+	// MessageTypeDeprecatedApprovalBroadcast is deprecated - use MessageTypeBroadcast with AttachmentTypeTokenApproval
+	MessageTypeDeprecatedApprovalBroadcast = fftypes.FFEnumValue("messagetype", "approval_broadcast")
+	// MessageTypeDeprecatedApprovalPrivate is a deprecated - use MessageTypePrivate with AttachmentTypeTokenApproval
+	MessageTypeDeprecatedApprovalPrivate = fftypes.FFEnumValue("messagetype", "approval_private")
+)
+
+// AttachmentType identifies another type of FireFly object that must be correlated with the message
+type AttachmentType = fftypes.FFEnum
+
+var (
+	// AttachmentTypeUnset indicate the message has no attachment
+	AttachmentTypeUnset = fftypes.FFEnumValue("attachmenttype", "")
+	// AttachmentTypeTokenTransfer indicates the message is accompanied by a token transfer
+	AttachmentTypeTokenTransfer = fftypes.FFEnumValue("attachmenttype", "token_transfer")
+	// AttachmentTypeTokenApproval indicates the message is accompanied by a token approval
+	AttachmentTypeTokenApproval = fftypes.FFEnumValue("attachmenttype", "token_approval")
 )
 
 // MessageState is the current transmission/confirmation state of a message
@@ -73,10 +85,11 @@ var (
 // MessageHeader contains all fields that contribute to the hash
 // The order of the serialization mut not change, once released
 type MessageHeader struct {
-	ID     *fftypes.UUID   `ffstruct:"MessageHeader" json:"id,omitempty" ffexcludeinput:"true"`
-	CID    *fftypes.UUID   `ffstruct:"MessageHeader" json:"cid,omitempty"`
-	Type   MessageType     `ffstruct:"MessageHeader" json:"type" ffenum:"messagetype"`
-	TxType TransactionType `ffstruct:"MessageHeader" json:"txtype,omitempty" ffenum:"txtype"`
+	ID         *fftypes.UUID   `ffstruct:"MessageHeader" json:"id,omitempty" ffexcludeinput:"true"`
+	CID        *fftypes.UUID   `ffstruct:"MessageHeader" json:"cid,omitempty"`
+	Type       MessageType     `ffstruct:"MessageHeader" json:"type" ffenum:"messagetype"`
+	TxType     TransactionType `ffstruct:"MessageHeader" json:"txtype,omitempty" ffenum:"txtype"`
+	Attachment AttachmentType  `ffstruct:"MessageHeader" json:"attachment,omitempty" ffenum:"attachmenttype" ffexcludeinput:"true"`
 	SignerRef
 	Created   *fftypes.FFTime       `ffstruct:"MessageHeader" json:"created,omitempty" ffexcludeinput:"true"`
 	Namespace string                `ffstruct:"MessageHeader" json:"namespace,omitempty" ffexcludeinput:"true"`


### PR DESCRIPTION
This field indicates another type of FireFly object that is to be correlated with the message. This replaces the proliferation of message "types" that were actually a duality, like "transfer_broadcast" and "transfer_private". These previous types are deprecated, but all changes are backwards compatible.

As is often the case, naming is the primary concern here. Is "attachment" the right word to use? It's fairly close to accurate IMO, although it runs the risk of being confused with the data payload of the message. Something around "correlation" crossed my mind as well, but we've used "correlator" on events and I didn't want to reuse.