### PR TITLE
Add "transactions" field to messages

### DIFF
--- a/db/migrations/postgres/000106_add_message_transactions.down.sql
+++ b/db/migrations/postgres/000106_add_message_transactions.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE messages DROP COLUMN tx_batch;
+ALTER TABLE messages DROP COLUMN tx_related;
+COMMIT;

--- a/db/migrations/postgres/000106_add_message_transactions.up.sql
+++ b/db/migrations/postgres/000106_add_message_transactions.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE messages ADD COLUMN tx_batch UUID;
+ALTER TABLE messages ADD COLUMN tx_related UUID;
+COMMIT;

--- a/db/migrations/sqlite/000106_add_message_transactions.down.sql
+++ b/db/migrations/sqlite/000106_add_message_transactions.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE messages DROP COLUMN tx_batch;
+ALTER TABLE messages DROP COLUMN tx_related;

--- a/db/migrations/sqlite/000106_add_message_transactions.up.sql
+++ b/db/migrations/sqlite/000106_add_message_transactions.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE messages ADD COLUMN tx_batch UUID;
+ALTER TABLE messages ADD COLUMN tx_related UUID;

--- a/docs/reference/types/message.md
+++ b/docs/reference/types/message.md
@@ -48,7 +48,8 @@ nav_order: 15
             "id": "fdf9f118-eb81-4086-a63d-b06715b3bb4e",
             "hash": "34cf848d896c83cdf433ea7bd9490c71800b316a96aac3c3a78a42a4c455d67d"
         }
-    ]
+    ],
+    "transactions": {}
 }
 ```
 
@@ -64,6 +65,7 @@ nav_order: 15
 | `confirmed` | The timestamp of when the message was confirmed/rejected | [`FFTime`](simpletypes#fftime) |
 | `data` | The list of data elements attached to the message | [`DataRef[]`](#dataref) |
 | `pins` | For private messages, a unique pin hash:nonce is assigned for each topic | `string[]` |
+| `transactions` | Identifiers for all transactions with which this message is associated | [`MessageTransactions`](#messagetransactions) |
 | `idempotencyKey` | An optional unique identifier for a message. Cannot be duplicated within a namespace, thus allowing idempotent submission of messages to the API. Local only - not transferred when the message is sent to other members of the network | `IdempotencyKey` |
 
 ## MessageHeader
@@ -89,5 +91,13 @@ nav_order: 15
 |------------|-------------|------|
 | `id` | The UUID of the referenced data resource | [`UUID`](simpletypes#uuid) |
 | `hash` | The hash of the referenced data | `Bytes32` |
+
+
+## MessageTransactions
+
+| Field Name | Description | Type |
+|------------|-------------|------|
+| `batch` | The transaction ID representing delivery of the message batch | [`UUID`](simpletypes#uuid) |
+| `related` | The transaction ID of another transaction related to this one, which must complete before the message is confirmed | [`UUID`](simpletypes#uuid) |
 
 

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5272,6 +5272,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -5529,6 +5539,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -5713,6 +5733,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -5816,6 +5851,16 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: topics
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -7966,6 +8011,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -8152,6 +8207,22 @@ paths:
                       - confirmed
                       - rejected
                       type: string
+                    transactions:
+                      description: Identifiers for all transactions with which this
+                        message is associated
+                      properties:
+                        batch:
+                          description: The transaction ID representing delivery of
+                            the message batch
+                          format: uuid
+                          type: string
+                        related:
+                          description: The transaction ID of another transaction related
+                            to this one, which must complete before the message is
+                            confirmed
+                          format: uuid
+                          type: string
+                      type: object
                   type: object
                 type: array
           description: Success
@@ -8404,6 +8475,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -9015,6 +9101,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -9152,6 +9253,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -9459,6 +9575,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -9602,6 +9733,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -9985,6 +10131,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -15813,6 +15974,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -16084,6 +16255,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -16268,6 +16449,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -16378,6 +16574,16 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: topics
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -18640,6 +18846,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txbatch
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txrelated
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -18826,6 +19042,22 @@ paths:
                       - confirmed
                       - rejected
                       type: string
+                    transactions:
+                      description: Identifiers for all transactions with which this
+                        message is associated
+                      properties:
+                        batch:
+                          description: The transaction ID representing delivery of
+                            the message batch
+                          format: uuid
+                          type: string
+                        related:
+                          description: The transaction ID of another transaction related
+                            to this one, which must complete before the message is
+                            confirmed
+                          format: uuid
+                          type: string
+                      type: object
                   type: object
                 type: array
           description: Success
@@ -19085,6 +19317,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -19768,6 +20015,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -19911,6 +20173,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -20225,6 +20502,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -20368,6 +20660,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -20758,6 +21065,21 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  transactions:
+                    description: Identifiers for all transactions with which this
+                      message is associated
+                    properties:
+                      batch:
+                        description: The transaction ID representing delivery of the
+                          message batch
+                        format: uuid
+                        type: string
+                      related:
+                        description: The transaction ID of another transaction related
+                          to this one, which must complete before the message is confirmed
+                        format: uuid
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:

--- a/internal/assets/token_approval.go
+++ b/internal/assets/token_approval.go
@@ -143,6 +143,10 @@ func (s *approveSender) sendInternal(ctx context.Context, method sendMethod) (er
 		s.approval.TX.ID = txid
 		s.approval.TX.Type = core.TransactionTypeTokenApproval
 
+		if s.approval.Message != nil {
+			s.approval.Message.Transactions.Related = txid
+		}
+
 		op = core.NewOperation(
 			plugin,
 			s.mgr.namespace,

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -232,6 +232,10 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) (e
 		s.transfer.TX.ID = txid
 		s.transfer.TX.Type = core.TransactionTypeTokenTransfer
 
+		if s.transfer.Message != nil {
+			s.transfer.Message.Transactions.Related = txid
+		}
+
 		op = core.NewOperation(
 			plugin,
 			s.mgr.namespace,

--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -614,6 +614,7 @@ func (bp *batchProcessor) markPayloadDispatched(state *DispatchState) error {
 			for i, msg := range state.Messages {
 				msgIDs[i] = msg.Header.ID
 				msg.BatchID = state.Persisted.ID
+				msg.Transactions.Batch = state.Persisted.TX.ID
 				if bp.conf.txType == core.TransactionTypeBatchPin {
 					msg.State = core.MessageStateSent
 				} else {
@@ -634,14 +635,16 @@ func (bp *batchProcessor) markPayloadDispatched(state *DispatchState) error {
 			if bp.conf.txType == core.TransactionTypeBatchPin {
 				// Sent state waiting for confirm
 				allMsgsUpdate = database.MessageQueryFactory.NewUpdate(ctx).
-					Set("batch", state.Persisted.ID).   // Mark the batch they are in
-					Set("state", core.MessageStateSent) // Set them sent, so they won't be picked up and re-sent after restart/rewind
+					Set("batch", state.Persisted.ID).    // Mark the batch they are in
+					Set("state", core.MessageStateSent). // Set them sent, so they won't be picked up and re-sent after restart/rewind
+					Set("txbatch", state.Persisted.TX.ID)
 			} else {
 				// Immediate confirmation if no batch pinning
 				allMsgsUpdate = database.MessageQueryFactory.NewUpdate(ctx).
 					Set("batch", state.Persisted.ID).
 					Set("state", core.MessageStateConfirmed).
-					Set("confirmed", confirmTime)
+					Set("confirmed", confirmTime).
+					Set("txbatch", state.Persisted.TX.ID)
 			}
 
 			if err = bp.database.UpdateMessages(ctx, bp.bm.namespace, filter, allMsgsUpdate); err != nil {

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -68,7 +68,12 @@ var (
 	MessageConfirmed      = ffm("Message.confirmed", "The timestamp of when the message was confirmed/rejected")
 	MessageData           = ffm("Message.data", "The list of data elements attached to the message")
 	MessagePins           = ffm("Message.pins", "For private messages, a unique pin hash:nonce is assigned for each topic")
+	MessageTransactions   = ffm("Message.transactions", "Identifiers for all transactions with which this message is associated")
 	MessageIdempotencyKey = ffm("Message.idempotencyKey", "An optional unique identifier for a message. Cannot be duplicated within a namespace, thus allowing idempotent submission of messages to the API. Local only - not transferred when the message is sent to other members of the network")
+
+	// MessageTransactions field descriptions
+	MessageTXBatch   = ffm("MessageTransactions.batch", "The transaction ID representing delivery of the message batch")
+	MessageTXRelated = ffm("MessageTransactions.related", "The transaction ID of another transaction related to this one, which must complete before the message is confirmed")
 
 	// MessageInOut field descriptions
 	MessageInOutData  = ffm("MessageInOut.data", "For input allows you to specify data in-line in the message, that will be turned into data attachments. For output when fetchdata is used on API calls, includes the in-line data payloads of all data attachments")

--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -48,6 +48,8 @@ var (
 		"datahash",
 		"hash",
 		"pins",
+		"tx_batch",
+		"tx_related",
 		"state",
 		"confirmed",
 		"tx_type",
@@ -57,6 +59,8 @@ var (
 	msgFilterFieldMap = map[string]string{
 		"type":           "mtype",
 		"txtype":         "tx_type",
+		"txbatch":        "tx_batch",
+		"txrelated":      "tx_related",
 		"batch":          "batch_id",
 		"group":          "group_hash",
 		"idempotencykey": "idempotency_key",
@@ -80,6 +84,8 @@ func (s *SQLCommon) attemptMessageUpdate(ctx context.Context, tx *dbsql.TXWrappe
 			Set("datahash", message.Header.DataHash).
 			Set("hash", message.Hash).
 			Set("pins", message.Pins).
+			Set("tx_batch", message.Transactions.Batch).
+			Set("tx_related", message.Transactions.Related).
 			Set("state", message.State).
 			Set("confirmed", message.Confirmed).
 			Set("tx_type", message.Header.TxType).
@@ -112,6 +118,8 @@ func (s *SQLCommon) setMessageInsertValues(query sq.InsertBuilder, message *core
 		message.Header.DataHash,
 		message.Hash,
 		message.Pins,
+		message.Transactions.Batch,
+		message.Transactions.Related,
 		message.State,
 		message.Confirmed,
 		message.Header.TxType,
@@ -422,6 +430,8 @@ func (s *SQLCommon) msgResult(ctx context.Context, row *sql.Rows) (*core.Message
 		&msg.Header.DataHash,
 		&msg.Hash,
 		&msg.Pins,
+		&msg.Transactions.Batch,
+		&msg.Transactions.Related,
 		&msg.State,
 		&msg.Confirmed,
 		&msg.Header.TxType,

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -554,7 +554,7 @@ func TestGetMessageByIDLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), nil, nil, "confirmed", 0, "pin", nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetMessageByID(context.Background(), "ns1", msgID)
 	assert.Regexp(t, "FF00176", err)
@@ -601,7 +601,7 @@ func TestGetMessagesLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), nil, nil, "confirmed", 0, "pin", nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Gt("confirmed", "0")
 	_, _, err := s.GetMessages(context.Background(), "ns1", f)

--- a/internal/events/persist_batch.go
+++ b/internal/events/persist_batch.go
@@ -108,7 +108,6 @@ func (em *eventManager) validateAndPersistBatchContent(ctx context.Context, batc
 		if valid = em.validateBatchMessage(ctx, batch, i, msg); !valid {
 			return false, nil
 		}
-		msg.LocalNamespace = em.namespace.Name
 	}
 
 	// We require that the batch contains exactly the set of data that is in the messages - no more or less.
@@ -198,7 +197,9 @@ func (em *eventManager) validateBatchMessage(ctx context.Context, batch *core.Ba
 		log.L(ctx).Errorf("Mismatched key/author '%s'/'%s' on message entry %d in batch '%s'", msg.Header.Key, msg.Header.Author, i, batch.ID)
 		return false
 	}
+	msg.LocalNamespace = em.namespace.Name
 	msg.BatchID = batch.ID
+	msg.Transactions.Batch = batch.Payload.TX.ID
 
 	l.Tracef("Batch '%s' message %d: %+v", batch.ID, i, msg)
 

--- a/pkg/core/message.go
+++ b/pkg/core/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -86,6 +86,11 @@ type MessageHeader struct {
 	DataHash  *fftypes.Bytes32      `ffstruct:"MessageHeader" json:"datahash,omitempty" ffexcludeinput:"true"`
 }
 
+type MessageTransactions struct {
+	Batch   *fftypes.UUID `ffstruct:"MessageTransactions" json:"batch,omitempty" ffexcludeinput:"true"`
+	Related *fftypes.UUID `ffstruct:"MessageTransactions" json:"related,omitempty" ffexcludeinput:"true"`
+}
+
 // Message is the envelope by which coordinated data exchange can happen between parties in the network
 // Data is passed by reference in these messages, and a chain of hashes covering the data and the
 // details of the message, provides a verification against tampering.
@@ -98,6 +103,7 @@ type Message struct {
 	Confirmed      *fftypes.FFTime       `ffstruct:"Message" json:"confirmed,omitempty" ffexcludeinput:"true"`
 	Data           DataRefs              `ffstruct:"Message" json:"data" ffexcludeinput:"true"`
 	Pins           fftypes.FFStringArray `ffstruct:"Message" json:"pins,omitempty" ffexcludeinput:"true"`
+	Transactions   MessageTransactions   `ffstruct:"Message" json:"transactions" ffexcludeinput:"true"`
 	IdempotencyKey IdempotencyKey        `ffstruct:"Message" json:"idempotencyKey,omitempty"`
 	Sequence       int64                 `ffstruct:"Message" json:"-"` // Local database sequence used internally for batch assembly
 }
@@ -110,9 +116,10 @@ type Message struct {
 // Fields such as the state/confirmed do NOT transfer, as these are calculated individually by each member.
 func (m *Message) BatchMessage() *Message {
 	return &Message{
-		Header: m.Header,
-		Hash:   m.Hash,
-		Data:   m.Data,
+		Header:       m.Header,
+		Hash:         m.Hash,
+		Data:         m.Data,
+		Transactions: m.Transactions,
 		// The pins are immutable once assigned by the sender, which happens before the batch is sealed
 		Pins: m.Pins,
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -698,6 +698,8 @@ var MessageQueryFactory = &ffapi.QueryFields{
 	"sequence":       &ffapi.Int64Field{},
 	"txtype":         &ffapi.StringField{},
 	"batch":          &ffapi.UUIDField{},
+	"txbatch":        &ffapi.UUIDField{},
+	"txrelated":      &ffapi.UUIDField{},
 }
 
 // BatchQueryFactory filter fields for batches


### PR DESCRIPTION
Tracks the ID of the batch transaction and any other related transaction.

Really just trying this on for size right now to see if it makes sense as a direction. It's related to discussions on both https://github.com/hyperledger/firefly/pull/1157 and https://github.com/hyperledger/firefly-fir/pull/17.

This would give an easier way to look up the `batch_pin` transaction associated with each message (without having to join via the batch), and a way to look up the additional `token_transfer` or `token_approval` transaction associated with messages that were attached to a transfer or approval. It would also potentially support FIR-17 by providing a place to stash a pre-assigned transaction ID on the message, in the case that the transaction is created prior to batch assembly.