### PR TITLE
Add "txid" and "txparent" to messages

### DIFF
--- a/db/migrations/postgres/000106_add_message_transactions.down.sql
+++ b/db/migrations/postgres/000106_add_message_transactions.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE messages DROP COLUMN tx_id;
+ALTER TABLE messages DROP COLUMN tx_parent_type;
+ALTER TABLE messages DROP COLUMN tx_parent_id;
+COMMIT;

--- a/db/migrations/postgres/000106_add_message_transactions.up.sql
+++ b/db/migrations/postgres/000106_add_message_transactions.up.sql
@@ -1,5 +1,7 @@
 BEGIN;
 ALTER TABLE messages ADD COLUMN tx_id UUID;
+UPDATE messages SET tx_id = batches.tx_id
+  FROM batches WHERE messages.batch_id = batches.id AND messages.tx_id IS NULL;
 ALTER TABLE messages ADD COLUMN tx_parent_type VARCHAR(64);
 ALTER TABLE messages ADD COLUMN tx_parent_id UUID;
 COMMIT;

--- a/db/migrations/postgres/000106_add_message_transactions.up.sql
+++ b/db/migrations/postgres/000106_add_message_transactions.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE messages ADD COLUMN tx_id UUID;
+ALTER TABLE messages ADD COLUMN tx_parent_type VARCHAR(64);
+ALTER TABLE messages ADD COLUMN tx_parent_id UUID;
+COMMIT;

--- a/db/migrations/sqlite/000106_add_message_transactions.down.sql
+++ b/db/migrations/sqlite/000106_add_message_transactions.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE messages DROP COLUMN tx_id;
+ALTER TABLE messages DROP COLUMN tx_parent_type;
+ALTER TABLE messages DROP COLUMN tx_parent_id;

--- a/db/migrations/sqlite/000106_add_message_transactions.up.sql
+++ b/db/migrations/sqlite/000106_add_message_transactions.up.sql
@@ -1,3 +1,5 @@
 ALTER TABLE messages ADD COLUMN tx_id UUID;
+UPDATE messages SET tx_id = batches.tx_id
+  FROM batches WHERE messages.batch_id = batches.id AND messages.tx_id IS NULL;
 ALTER TABLE messages ADD COLUMN tx_parent_type VARCHAR(64);
 ALTER TABLE messages ADD COLUMN tx_parent_id UUID;

--- a/db/migrations/sqlite/000106_add_message_transactions.up.sql
+++ b/db/migrations/sqlite/000106_add_message_transactions.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE messages ADD COLUMN tx_id UUID;
+ALTER TABLE messages ADD COLUMN tx_parent_type VARCHAR(64);
+ALTER TABLE messages ADD COLUMN tx_parent_id UUID;

--- a/docs/reference/types/message.md
+++ b/docs/reference/types/message.md
@@ -61,7 +61,6 @@ nav_order: 15
 | `hash` | The hash of the message. Derived from the header, which includes the data hash | `Bytes32` |
 | `batch` | The UUID of the batch in which the message was pinned/transferred | [`UUID`](simpletypes#uuid) |
 | `txid` | The ID of the transaction used to order/deliver this message | [`UUID`](simpletypes#uuid) |
-| `txparent` | The parent transaction that originally triggered this message | [`TransactionRef`](#transactionref) |
 | `state` | The current state of the message | `FFEnum`:<br/>`"staged"`<br/>`"ready"`<br/>`"sent"`<br/>`"pending"`<br/>`"confirmed"`<br/>`"rejected"` |
 | `confirmed` | The timestamp of when the message was confirmed/rejected | [`FFTime`](simpletypes#fftime) |
 | `data` | The list of data elements attached to the message | [`DataRef[]`](#dataref) |
@@ -83,7 +82,7 @@ nav_order: 15
 | `topics` | A message topic associates this message with an ordered stream of data. A custom topic should be assigned - using the default topic is discouraged | `string[]` |
 | `tag` | The message tag indicates the purpose of the message to the applications that process it | `string` |
 | `datahash` | A single hash representing all data in the message. Derived from the array of data ids+hashes attached to this message | `Bytes32` |
-
+| `txparent` | The parent transaction that originally triggered this message | [`TransactionRef`](#transactionref) |
 
 ## TransactionRef
 
@@ -91,6 +90,7 @@ nav_order: 15
 |------------|-------------|------|
 | `type` | The type of the FireFly transaction | `FFEnum`: |
 | `id` | The UUID of the FireFly transaction | [`UUID`](simpletypes#uuid) |
+
 
 
 ## DataRef

--- a/docs/reference/types/message.md
+++ b/docs/reference/types/message.md
@@ -60,6 +60,8 @@ nav_order: 15
 | `localNamespace` | The local namespace of the message | `string` |
 | `hash` | The hash of the message. Derived from the header, which includes the data hash | `Bytes32` |
 | `batch` | The UUID of the batch in which the message was pinned/transferred | [`UUID`](simpletypes#uuid) |
+| `txid` | The ID of the transaction used to order/deliver this message | [`UUID`](simpletypes#uuid) |
+| `txparent` | The parent transaction that originally triggered this message | [`TransactionRef`](#transactionref) |
 | `state` | The current state of the message | `FFEnum`:<br/>`"staged"`<br/>`"ready"`<br/>`"sent"`<br/>`"pending"`<br/>`"confirmed"`<br/>`"rejected"` |
 | `confirmed` | The timestamp of when the message was confirmed/rejected | [`FFTime`](simpletypes#fftime) |
 | `data` | The list of data elements attached to the message | [`DataRef[]`](#dataref) |
@@ -81,6 +83,14 @@ nav_order: 15
 | `topics` | A message topic associates this message with an ordered stream of data. A custom topic should be assigned - using the default topic is discouraged | `string[]` |
 | `tag` | The message tag indicates the purpose of the message to the applications that process it | `string` |
 | `datahash` | A single hash representing all data in the message. Derived from the array of data ids+hashes attached to this message | `Bytes32` |
+
+
+## TransactionRef
+
+| Field Name | Description | Type |
+|------------|-------------|------|
+| `type` | The type of the FireFly transaction | `FFEnum`: |
+| `id` | The UUID of the FireFly transaction | [`UUID`](simpletypes#uuid) |
 
 
 ## DataRef

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5272,6 +5272,21 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -5529,6 +5544,21 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -5713,6 +5743,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -5816,6 +5863,21 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: topics
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -7966,6 +8028,21 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -8152,6 +8229,23 @@ paths:
                       - confirmed
                       - rejected
                       type: string
+                    txid:
+                      description: The ID of the transaction used to order/deliver
+                        this message
+                      format: uuid
+                      type: string
+                    txparent:
+                      description: The parent transaction that originally triggered
+                        this message
+                      properties:
+                        id:
+                          description: The UUID of the FireFly transaction
+                          format: uuid
+                          type: string
+                        type:
+                          description: The type of the FireFly transaction
+                          type: string
+                      type: object
                   type: object
                 type: array
           description: Success
@@ -8197,51 +8291,10 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: For input allows you to specify data in-line in the
-                      message, that will be turned into data attachments. For output
-                      when fetchdata is used on API calls, includes the in-line data
-                      payloads of all data attachments
+                    description: The list of data elements attached to the message
                     items:
-                      description: For input allows you to specify data in-line in
-                        the message, that will be turned into data attachments. For
-                        output when fetchdata is used on API calls, includes the in-line
-                        data payloads of all data attachments
+                      description: The list of data elements attached to the message
                       properties:
-                        blob:
-                          description: An optional in-line hash reference to a previously
-                            uploaded binary data blob
-                          properties:
-                            hash:
-                              description: The hash of the binary blob data
-                              format: byte
-                              type: string
-                            name:
-                              description: The name field from the metadata attached
-                                to the blob, commonly used as a path/filename, and
-                                indexed for search
-                              type: string
-                            public:
-                              description: If the blob data has been published to
-                                shared storage, this field is the id of the data in
-                                the shared storage plugin (IPFS hash etc.)
-                              type: string
-                            size:
-                              description: The size of the binary data
-                              format: int64
-                              type: integer
-                          type: object
-                        datatype:
-                          description: The optional datatype to use for validation
-                            of the in-line data
-                          properties:
-                            name:
-                              description: The name of the datatype
-                              type: string
-                            version:
-                              description: The version of the datatype. Semantic versioning
-                                is encouraged, such as v1.0.1
-                              type: string
-                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -8250,13 +8303,6 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
-                        validator:
-                          description: The data validator type to use for in-line
-                            data
-                          type: string
-                        value:
-                          description: The in-line value for the data. Can be any
-                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -8404,6 +8450,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -8878,6 +8941,18 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
+                txparent:
+                  description: The parent transaction that originally triggered this
+                    message
+                  properties:
+                    id:
+                      description: The UUID of the FireFly transaction
+                      format: uuid
+                      type: string
+                    type:
+                      description: The type of the FireFly transaction
+                      type: string
+                  type: object
               type: object
       responses:
         "200":
@@ -9015,6 +9090,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -9152,6 +9244,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -9316,6 +9425,18 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
+                txparent:
+                  description: The parent transaction that originally triggered this
+                    message
+                  properties:
+                    id:
+                      description: The UUID of the FireFly transaction
+                      format: uuid
+                      type: string
+                    type:
+                      description: The type of the FireFly transaction
+                      type: string
+                  type: object
               type: object
       responses:
         "200":
@@ -9459,6 +9580,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -9602,6 +9740,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -9762,6 +9917,18 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
+                txparent:
+                  description: The parent transaction that originally triggered this
+                    message
+                  properties:
+                    id:
+                      description: The UUID of the FireFly transaction
+                      format: uuid
+                      type: string
+                    type:
+                      description: The type of the FireFly transaction
+                      type: string
+                  type: object
               type: object
       responses:
         "200":
@@ -9778,51 +9945,10 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: For input allows you to specify data in-line in the
-                      message, that will be turned into data attachments. For output
-                      when fetchdata is used on API calls, includes the in-line data
-                      payloads of all data attachments
+                    description: The list of data elements attached to the message
                     items:
-                      description: For input allows you to specify data in-line in
-                        the message, that will be turned into data attachments. For
-                        output when fetchdata is used on API calls, includes the in-line
-                        data payloads of all data attachments
+                      description: The list of data elements attached to the message
                       properties:
-                        blob:
-                          description: An optional in-line hash reference to a previously
-                            uploaded binary data blob
-                          properties:
-                            hash:
-                              description: The hash of the binary blob data
-                              format: byte
-                              type: string
-                            name:
-                              description: The name field from the metadata attached
-                                to the blob, commonly used as a path/filename, and
-                                indexed for search
-                              type: string
-                            public:
-                              description: If the blob data has been published to
-                                shared storage, this field is the id of the data in
-                                the shared storage plugin (IPFS hash etc.)
-                              type: string
-                            size:
-                              description: The size of the binary data
-                              format: int64
-                              type: integer
-                          type: object
-                        datatype:
-                          description: The optional datatype to use for validation
-                            of the in-line data
-                          properties:
-                            name:
-                              description: The name of the datatype
-                              type: string
-                            version:
-                              description: The version of the datatype. Semantic versioning
-                                is encouraged, such as v1.0.1
-                              type: string
-                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -9831,13 +9957,6 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
-                        validator:
-                          description: The data validator type to use for in-line
-                            data
-                          type: string
-                        value:
-                          description: The in-line value for the data. Can be any
-                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -9985,6 +10104,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -15813,6 +15949,21 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -16084,6 +16235,21 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -16268,6 +16434,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -16378,6 +16561,21 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: topics
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -18640,6 +18838,21 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: txid
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.id
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: txparent.type
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: txtype
         schema:
           type: string
@@ -18826,6 +19039,23 @@ paths:
                       - confirmed
                       - rejected
                       type: string
+                    txid:
+                      description: The ID of the transaction used to order/deliver
+                        this message
+                      format: uuid
+                      type: string
+                    txparent:
+                      description: The parent transaction that originally triggered
+                        this message
+                      properties:
+                        id:
+                          description: The UUID of the FireFly transaction
+                          format: uuid
+                          type: string
+                        type:
+                          description: The type of the FireFly transaction
+                          type: string
+                      type: object
                   type: object
                 type: array
           description: Success
@@ -18878,51 +19108,10 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: For input allows you to specify data in-line in the
-                      message, that will be turned into data attachments. For output
-                      when fetchdata is used on API calls, includes the in-line data
-                      payloads of all data attachments
+                    description: The list of data elements attached to the message
                     items:
-                      description: For input allows you to specify data in-line in
-                        the message, that will be turned into data attachments. For
-                        output when fetchdata is used on API calls, includes the in-line
-                        data payloads of all data attachments
+                      description: The list of data elements attached to the message
                       properties:
-                        blob:
-                          description: An optional in-line hash reference to a previously
-                            uploaded binary data blob
-                          properties:
-                            hash:
-                              description: The hash of the binary blob data
-                              format: byte
-                              type: string
-                            name:
-                              description: The name field from the metadata attached
-                                to the blob, commonly used as a path/filename, and
-                                indexed for search
-                              type: string
-                            public:
-                              description: If the blob data has been published to
-                                shared storage, this field is the id of the data in
-                                the shared storage plugin (IPFS hash etc.)
-                              type: string
-                            size:
-                              description: The size of the binary data
-                              format: int64
-                              type: integer
-                          type: object
-                        datatype:
-                          description: The optional datatype to use for validation
-                            of the in-line data
-                          properties:
-                            name:
-                              description: The name of the datatype
-                              type: string
-                            version:
-                              description: The version of the datatype. Semantic versioning
-                                is encouraged, such as v1.0.1
-                              type: string
-                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -18931,13 +19120,6 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
-                        validator:
-                          description: The data validator type to use for in-line
-                            data
-                          type: string
-                        value:
-                          description: The in-line value for the data. Can be any
-                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -19085,6 +19267,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -19625,6 +19824,18 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
+                txparent:
+                  description: The parent transaction that originally triggered this
+                    message
+                  properties:
+                    id:
+                      description: The UUID of the FireFly transaction
+                      format: uuid
+                      type: string
+                    type:
+                      description: The type of the FireFly transaction
+                      type: string
+                  type: object
               type: object
       responses:
         "200":
@@ -19768,6 +19979,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -19911,6 +20139,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -20082,6 +20327,18 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
+                txparent:
+                  description: The parent transaction that originally triggered this
+                    message
+                  properties:
+                    id:
+                      description: The UUID of the FireFly transaction
+                      format: uuid
+                      type: string
+                    type:
+                      description: The type of the FireFly transaction
+                      type: string
+                  type: object
               type: object
       responses:
         "200":
@@ -20225,6 +20482,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         "202":
@@ -20368,6 +20642,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:
@@ -20535,6 +20826,18 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
+                txparent:
+                  description: The parent transaction that originally triggered this
+                    message
+                  properties:
+                    id:
+                      description: The UUID of the FireFly transaction
+                      format: uuid
+                      type: string
+                    type:
+                      description: The type of the FireFly transaction
+                      type: string
+                  type: object
               type: object
       responses:
         "200":
@@ -20551,51 +20854,10 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: For input allows you to specify data in-line in the
-                      message, that will be turned into data attachments. For output
-                      when fetchdata is used on API calls, includes the in-line data
-                      payloads of all data attachments
+                    description: The list of data elements attached to the message
                     items:
-                      description: For input allows you to specify data in-line in
-                        the message, that will be turned into data attachments. For
-                        output when fetchdata is used on API calls, includes the in-line
-                        data payloads of all data attachments
+                      description: The list of data elements attached to the message
                       properties:
-                        blob:
-                          description: An optional in-line hash reference to a previously
-                            uploaded binary data blob
-                          properties:
-                            hash:
-                              description: The hash of the binary blob data
-                              format: byte
-                              type: string
-                            name:
-                              description: The name field from the metadata attached
-                                to the blob, commonly used as a path/filename, and
-                                indexed for search
-                              type: string
-                            public:
-                              description: If the blob data has been published to
-                                shared storage, this field is the id of the data in
-                                the shared storage plugin (IPFS hash etc.)
-                              type: string
-                            size:
-                              description: The size of the binary data
-                              format: int64
-                              type: integer
-                          type: object
-                        datatype:
-                          description: The optional datatype to use for validation
-                            of the in-line data
-                          properties:
-                            name:
-                              description: The name of the datatype
-                              type: string
-                            version:
-                              description: The version of the datatype. Semantic versioning
-                                is encouraged, such as v1.0.1
-                              type: string
-                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -20604,13 +20866,6 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
-                        validator:
-                          description: The data validator type to use for in-line
-                            data
-                          type: string
-                        value:
-                          description: The in-line value for the data. Can be any
-                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -20758,6 +21013,23 @@ paths:
                     - confirmed
                     - rejected
                     type: string
+                  txid:
+                    description: The ID of the transaction used to order/deliver this
+                      message
+                    format: uuid
+                    type: string
+                  txparent:
+                    description: The parent transaction that originally triggered
+                      this message
+                    properties:
+                      id:
+                        description: The UUID of the FireFly transaction
+                        format: uuid
+                        type: string
+                      type:
+                        description: The type of the FireFly transaction
+                        type: string
+                    type: object
                 type: object
           description: Success
         default:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5688,6 +5688,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -5748,18 +5760,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -8174,6 +8174,18 @@ paths:
                               assigned - using the default topic is discouraged
                             type: string
                           type: array
+                        txparent:
+                          description: The parent transaction that originally triggered
+                            this message
+                          properties:
+                            id:
+                              description: The UUID of the FireFly transaction
+                              format: uuid
+                              type: string
+                            type:
+                              description: The type of the FireFly transaction
+                              type: string
+                          type: object
                         txtype:
                           description: The type of transaction used to order/deliver
                             this message
@@ -8234,18 +8246,6 @@ paths:
                         this message
                       format: uuid
                       type: string
-                    txparent:
-                      description: The parent transaction that originally triggered
-                        this message
-                      properties:
-                        id:
-                          description: The UUID of the FireFly transaction
-                          format: uuid
-                          type: string
-                        type:
-                          description: The type of the FireFly transaction
-                          type: string
-                      type: object
                   type: object
                 type: array
           description: Success
@@ -8291,10 +8291,51 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: The list of data elements attached to the message
+                    description: For input allows you to specify data in-line in the
+                      message, that will be turned into data attachments. For output
+                      when fetchdata is used on API calls, includes the in-line data
+                      payloads of all data attachments
                     items:
-                      description: The list of data elements attached to the message
+                      description: For input allows you to specify data in-line in
+                        the message, that will be turned into data attachments. For
+                        output when fetchdata is used on API calls, includes the in-line
+                        data payloads of all data attachments
                       properties:
+                        blob:
+                          description: An optional in-line hash reference to a previously
+                            uploaded binary data blob
+                          properties:
+                            hash:
+                              description: The hash of the binary blob data
+                              format: byte
+                              type: string
+                            name:
+                              description: The name field from the metadata attached
+                                to the blob, commonly used as a path/filename, and
+                                indexed for search
+                              type: string
+                            public:
+                              description: If the blob data has been published to
+                                shared storage, this field is the id of the data in
+                                the shared storage plugin (IPFS hash etc.)
+                              type: string
+                            size:
+                              description: The size of the binary data
+                              format: int64
+                              type: integer
+                          type: object
+                        datatype:
+                          description: The optional datatype to use for validation
+                            of the in-line data
+                          properties:
+                            name:
+                              description: The name of the datatype
+                              type: string
+                            version:
+                              description: The version of the datatype. Semantic versioning
+                                is encouraged, such as v1.0.1
+                              type: string
+                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -8303,6 +8344,13 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
+                        validator:
+                          description: The data validator type to use for in-line
+                            data
+                          type: string
+                        value:
+                          description: The in-line value for the data. Can be any
+                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -8395,6 +8443,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -8455,18 +8515,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -8941,18 +8989,6 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
-                txparent:
-                  description: The parent transaction that originally triggered this
-                    message
-                  properties:
-                    id:
-                      description: The UUID of the FireFly transaction
-                      format: uuid
-                      type: string
-                    type:
-                      description: The type of the FireFly transaction
-                      type: string
-                  type: object
               type: object
       responses:
         "200":
@@ -9035,6 +9071,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -9095,18 +9143,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         "202":
@@ -9189,6 +9225,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -9249,18 +9297,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -9425,18 +9461,6 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
-                txparent:
-                  description: The parent transaction that originally triggered this
-                    message
-                  properties:
-                    id:
-                      description: The UUID of the FireFly transaction
-                      format: uuid
-                      type: string
-                    type:
-                      description: The type of the FireFly transaction
-                      type: string
-                  type: object
               type: object
       responses:
         "200":
@@ -9525,6 +9549,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -9585,18 +9621,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         "202":
@@ -9685,6 +9709,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -9745,18 +9781,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -9917,18 +9941,6 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
-                txparent:
-                  description: The parent transaction that originally triggered this
-                    message
-                  properties:
-                    id:
-                      description: The UUID of the FireFly transaction
-                      format: uuid
-                      type: string
-                    type:
-                      description: The type of the FireFly transaction
-                      type: string
-                  type: object
               type: object
       responses:
         "200":
@@ -9945,10 +9957,51 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: The list of data elements attached to the message
+                    description: For input allows you to specify data in-line in the
+                      message, that will be turned into data attachments. For output
+                      when fetchdata is used on API calls, includes the in-line data
+                      payloads of all data attachments
                     items:
-                      description: The list of data elements attached to the message
+                      description: For input allows you to specify data in-line in
+                        the message, that will be turned into data attachments. For
+                        output when fetchdata is used on API calls, includes the in-line
+                        data payloads of all data attachments
                       properties:
+                        blob:
+                          description: An optional in-line hash reference to a previously
+                            uploaded binary data blob
+                          properties:
+                            hash:
+                              description: The hash of the binary blob data
+                              format: byte
+                              type: string
+                            name:
+                              description: The name field from the metadata attached
+                                to the blob, commonly used as a path/filename, and
+                                indexed for search
+                              type: string
+                            public:
+                              description: If the blob data has been published to
+                                shared storage, this field is the id of the data in
+                                the shared storage plugin (IPFS hash etc.)
+                              type: string
+                            size:
+                              description: The size of the binary data
+                              format: int64
+                              type: integer
+                          type: object
+                        datatype:
+                          description: The optional datatype to use for validation
+                            of the in-line data
+                          properties:
+                            name:
+                              description: The name of the datatype
+                              type: string
+                            version:
+                              description: The version of the datatype. Semantic versioning
+                                is encouraged, such as v1.0.1
+                              type: string
+                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -9957,6 +10010,13 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
+                        validator:
+                          description: The data validator type to use for in-line
+                            data
+                          type: string
+                        value:
+                          description: The in-line value for the data. Can be any
+                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -10049,6 +10109,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -10109,18 +10181,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -16379,6 +16439,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -16439,18 +16511,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -18984,6 +19044,18 @@ paths:
                               assigned - using the default topic is discouraged
                             type: string
                           type: array
+                        txparent:
+                          description: The parent transaction that originally triggered
+                            this message
+                          properties:
+                            id:
+                              description: The UUID of the FireFly transaction
+                              format: uuid
+                              type: string
+                            type:
+                              description: The type of the FireFly transaction
+                              type: string
+                          type: object
                         txtype:
                           description: The type of transaction used to order/deliver
                             this message
@@ -19044,18 +19116,6 @@ paths:
                         this message
                       format: uuid
                       type: string
-                    txparent:
-                      description: The parent transaction that originally triggered
-                        this message
-                      properties:
-                        id:
-                          description: The UUID of the FireFly transaction
-                          format: uuid
-                          type: string
-                        type:
-                          description: The type of the FireFly transaction
-                          type: string
-                      type: object
                   type: object
                 type: array
           description: Success
@@ -19108,10 +19168,51 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: The list of data elements attached to the message
+                    description: For input allows you to specify data in-line in the
+                      message, that will be turned into data attachments. For output
+                      when fetchdata is used on API calls, includes the in-line data
+                      payloads of all data attachments
                     items:
-                      description: The list of data elements attached to the message
+                      description: For input allows you to specify data in-line in
+                        the message, that will be turned into data attachments. For
+                        output when fetchdata is used on API calls, includes the in-line
+                        data payloads of all data attachments
                       properties:
+                        blob:
+                          description: An optional in-line hash reference to a previously
+                            uploaded binary data blob
+                          properties:
+                            hash:
+                              description: The hash of the binary blob data
+                              format: byte
+                              type: string
+                            name:
+                              description: The name field from the metadata attached
+                                to the blob, commonly used as a path/filename, and
+                                indexed for search
+                              type: string
+                            public:
+                              description: If the blob data has been published to
+                                shared storage, this field is the id of the data in
+                                the shared storage plugin (IPFS hash etc.)
+                              type: string
+                            size:
+                              description: The size of the binary data
+                              format: int64
+                              type: integer
+                          type: object
+                        datatype:
+                          description: The optional datatype to use for validation
+                            of the in-line data
+                          properties:
+                            name:
+                              description: The name of the datatype
+                              type: string
+                            version:
+                              description: The version of the datatype. Semantic versioning
+                                is encouraged, such as v1.0.1
+                              type: string
+                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -19120,6 +19221,13 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
+                        validator:
+                          description: The data validator type to use for in-line
+                            data
+                          type: string
+                        value:
+                          description: The in-line value for the data. Can be any
+                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -19212,6 +19320,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -19272,18 +19392,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -19824,18 +19932,6 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
-                txparent:
-                  description: The parent transaction that originally triggered this
-                    message
-                  properties:
-                    id:
-                      description: The UUID of the FireFly transaction
-                      format: uuid
-                      type: string
-                    type:
-                      description: The type of the FireFly transaction
-                      type: string
-                  type: object
               type: object
       responses:
         "200":
@@ -19924,6 +20020,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -19984,18 +20092,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         "202":
@@ -20084,6 +20180,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -20144,18 +20252,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -20327,18 +20423,6 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
-                txparent:
-                  description: The parent transaction that originally triggered this
-                    message
-                  properties:
-                    id:
-                      description: The UUID of the FireFly transaction
-                      format: uuid
-                      type: string
-                    type:
-                      description: The type of the FireFly transaction
-                      type: string
-                  type: object
               type: object
       responses:
         "200":
@@ -20427,6 +20511,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -20487,18 +20583,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         "202":
@@ -20587,6 +20671,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -20647,18 +20743,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:
@@ -20826,18 +20910,6 @@ paths:
                     of messages to the API. Local only - not transferred when the
                     message is sent to other members of the network
                   type: string
-                txparent:
-                  description: The parent transaction that originally triggered this
-                    message
-                  properties:
-                    id:
-                      description: The UUID of the FireFly transaction
-                      format: uuid
-                      type: string
-                    type:
-                      description: The type of the FireFly transaction
-                      type: string
-                  type: object
               type: object
       responses:
         "200":
@@ -20854,10 +20926,51 @@ paths:
                     format: date-time
                     type: string
                   data:
-                    description: The list of data elements attached to the message
+                    description: For input allows you to specify data in-line in the
+                      message, that will be turned into data attachments. For output
+                      when fetchdata is used on API calls, includes the in-line data
+                      payloads of all data attachments
                     items:
-                      description: The list of data elements attached to the message
+                      description: For input allows you to specify data in-line in
+                        the message, that will be turned into data attachments. For
+                        output when fetchdata is used on API calls, includes the in-line
+                        data payloads of all data attachments
                       properties:
+                        blob:
+                          description: An optional in-line hash reference to a previously
+                            uploaded binary data blob
+                          properties:
+                            hash:
+                              description: The hash of the binary blob data
+                              format: byte
+                              type: string
+                            name:
+                              description: The name field from the metadata attached
+                                to the blob, commonly used as a path/filename, and
+                                indexed for search
+                              type: string
+                            public:
+                              description: If the blob data has been published to
+                                shared storage, this field is the id of the data in
+                                the shared storage plugin (IPFS hash etc.)
+                              type: string
+                            size:
+                              description: The size of the binary data
+                              format: int64
+                              type: integer
+                          type: object
+                        datatype:
+                          description: The optional datatype to use for validation
+                            of the in-line data
+                          properties:
+                            name:
+                              description: The name of the datatype
+                              type: string
+                            version:
+                              description: The version of the datatype. Semantic versioning
+                                is encouraged, such as v1.0.1
+                              type: string
+                          type: object
                         hash:
                           description: The hash of the referenced data
                           format: byte
@@ -20866,6 +20979,13 @@ paths:
                           description: The UUID of the referenced data resource
                           format: uuid
                           type: string
+                        validator:
+                          description: The data validator type to use for in-line
+                            data
+                          type: string
+                        value:
+                          description: The in-line value for the data. Can be any
+                            JSON type - object, array, string, number or boolean
                       type: object
                     type: array
                   group:
@@ -20958,6 +21078,18 @@ paths:
                             - using the default topic is discouraged
                           type: string
                         type: array
+                      txparent:
+                        description: The parent transaction that originally triggered
+                          this message
+                        properties:
+                          id:
+                            description: The UUID of the FireFly transaction
+                            format: uuid
+                            type: string
+                          type:
+                            description: The type of the FireFly transaction
+                            type: string
+                        type: object
                       txtype:
                         description: The type of transaction used to order/deliver
                           this message
@@ -21018,18 +21150,6 @@ paths:
                       message
                     format: uuid
                     type: string
-                  txparent:
-                    description: The parent transaction that originally triggered
-                      this message
-                    properties:
-                      id:
-                        description: The UUID of the FireFly transaction
-                        format: uuid
-                        type: string
-                      type:
-                        description: The type of the FireFly transaction
-                        type: string
-                    type: object
                 type: object
           description: Success
         default:

--- a/internal/assets/token_approval.go
+++ b/internal/assets/token_approval.go
@@ -142,6 +142,12 @@ func (s *approveSender) sendInternal(ctx context.Context, method sendMethod) (er
 		}
 		s.approval.TX.ID = txid
 		s.approval.TX.Type = core.TransactionTypeTokenApproval
+		if s.approval.Message != nil {
+			s.approval.Message.TxParent = &core.TransactionRef{
+				ID:   txid,
+				Type: core.TransactionTypeTokenApproval,
+			}
+		}
 
 		op = core.NewOperation(
 			plugin,

--- a/internal/assets/token_approval.go
+++ b/internal/assets/token_approval.go
@@ -200,19 +200,21 @@ func (am *assetManager) validateApproval(ctx context.Context, approval *core.Tok
 
 func (s *approveSender) buildApprovalMessage(ctx context.Context, in *core.MessageInOut) (syncasync.Sender, error) {
 	allowedTypes := []fftypes.FFEnum{
-		core.MessageTypeApprovalBroadcast,
-		core.MessageTypeApprovalPrivate,
+		core.MessageTypeBroadcast,
+		core.MessageTypePrivate,
+		core.MessageTypeDeprecatedApprovalBroadcast,
+		core.MessageTypeDeprecatedApprovalPrivate,
 	}
 	if in.Header.Type == "" {
-		in.Header.Type = core.MessageTypeApprovalBroadcast
+		in.Header.Type = core.MessageTypeBroadcast
 	}
 	switch in.Header.Type {
-	case core.MessageTypeApprovalBroadcast:
+	case core.MessageTypeBroadcast, core.MessageTypeDeprecatedApprovalBroadcast:
 		if s.mgr.broadcast == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}
 		return s.mgr.broadcast.NewBroadcast(in), nil
-	case core.MessageTypeApprovalPrivate:
+	case core.MessageTypePrivate, core.MessageTypeDeprecatedApprovalPrivate:
 		if s.mgr.messaging == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}

--- a/internal/assets/token_approval_test.go
+++ b/internal/assets/token_approval_test.go
@@ -615,7 +615,7 @@ func TestApprovalWithPrivateMessage(t *testing.T) {
 			Message: core.Message{
 				Header: core.MessageHeader{
 					ID:   msgID,
-					Type: core.MessageTypeApprovalPrivate,
+					Type: core.MessageTypePrivate,
 				},
 				Hash: hash,
 			},
@@ -681,7 +681,7 @@ func TestApprovalWithPrivateMessageDisabled(t *testing.T) {
 			Message: core.Message{
 				Header: core.MessageHeader{
 					ID:   msgID,
-					Type: core.MessageTypeApprovalPrivate,
+					Type: core.MessageTypeDeprecatedApprovalPrivate,
 				},
 				Hash: hash,
 			},

--- a/internal/assets/token_approval_test.go
+++ b/internal/assets/token_approval_test.go
@@ -139,7 +139,8 @@ func TestApprovalBadConnector(t *testing.T) {
 			Operator: "operator",
 			Key:      "key",
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 	}
 	pool := &core.TokenPool{
 		Locator:   "F1",
@@ -149,14 +150,17 @@ func TestApprovalBadConnector(t *testing.T) {
 
 	mdi := am.database.(*databasemocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("ResolveInputSigningKey", context.Background(), "key", identity.KeyNormalizationBlockchainPlugin).Return("0x12345", nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.Regexp(t, "FF10272", err)
 
 	mdi.AssertExpectations(t)
 	mim.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalDefaultPoolSuccess(t *testing.T) {
@@ -222,9 +226,11 @@ func TestApprovalDefaultPoolNoPool(t *testing.T) {
 			Operator: "operator",
 			Key:      "key",
 		},
+		IdempotencyKey: "idem1",
 	}
 
 	mdi := am.database.(*databasemocks.Plugin)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	fb := database.TokenPoolQueryFactory.NewFilter(context.Background())
 	f := fb.And()
 	f.Limit(1).Count(true)
@@ -237,9 +243,13 @@ func TestApprovalDefaultPoolNoPool(t *testing.T) {
 		info, _ := f.Finalize()
 		return info.Count && info.Limit == 1
 	}))).Return(tokenPools, filterResult, nil)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.Regexp(t, "FF10292", err)
+
+	mdi.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalBadPool(t *testing.T) {
@@ -252,16 +262,20 @@ func TestApprovalBadPool(t *testing.T) {
 			Operator: "operator",
 			Key:      "key",
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 	}
 
 	mdi := am.database.(*databasemocks.Plugin)
-	mim := am.identity.(*identitymanagermocks.Manager)
-	mim.On("ResolveInputSigningKey", context.Background(), "key", identity.KeyNormalizationBlockchainPlugin).Return("0x12345", nil)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(nil, fmt.Errorf("pop"))
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalUnconfirmedPool(t *testing.T) {
@@ -273,7 +287,8 @@ func TestApprovalUnconfirmedPool(t *testing.T) {
 			Approved: true,
 			Operator: "operator",
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 	}
 	pool := &core.TokenPool{
 		Locator:   "F1",
@@ -282,12 +297,15 @@ func TestApprovalUnconfirmedPool(t *testing.T) {
 	}
 
 	mdi := am.database.(*databasemocks.Plugin)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.Regexp(t, "FF10293", err)
 
 	mdi.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalIdentityFail(t *testing.T) {
@@ -299,7 +317,8 @@ func TestApprovalIdentityFail(t *testing.T) {
 			Approved: true,
 			Operator: "operator",
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 	}
 	pool := &core.TokenPool{
 		Locator:   "F1",
@@ -309,14 +328,17 @@ func TestApprovalIdentityFail(t *testing.T) {
 
 	mdi := am.database.(*databasemocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("ResolveInputSigningKey", context.Background(), "", identity.KeyNormalizationBlockchainPlugin).Return("", fmt.Errorf("pop"))
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.EqualError(t, err, "pop")
 
 	mdi.AssertExpectations(t)
 	mim.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalFail(t *testing.T) {
@@ -372,24 +394,14 @@ func TestApprovalTransactionFail(t *testing.T) {
 		Pool:           "pool1",
 		IdempotencyKey: "idem1",
 	}
-	pool := &core.TokenPool{
-		Locator:   "F1",
-		Connector: "magic-tokens",
-		State:     core.TokenPoolStateConfirmed,
-	}
 
-	mdi := am.database.(*databasemocks.Plugin)
-	mim := am.identity.(*identitymanagermocks.Manager)
 	mth := am.txHelper.(*txcommonmocks.Helper)
-	mim.On("ResolveInputSigningKey", context.Background(), "", identity.KeyNormalizationBlockchainPlugin).Return("0x12345", nil)
-	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(nil, fmt.Errorf("pop"))
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.EqualError(t, err, "pop")
 
-	mim.AssertExpectations(t)
-	mdi.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalWithBroadcastMessage(t *testing.T) {
@@ -484,8 +496,13 @@ func TestApprovalWithBroadcastMessageDisabled(t *testing.T) {
 		IdempotencyKey: "idem1",
 	}
 
+	mth := am.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
+
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.Regexp(t, "FF10415", err)
+
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalWithBroadcastMessageSendFail(t *testing.T) {
@@ -556,7 +573,8 @@ func TestApprovalWithBroadcastPrepareFail(t *testing.T) {
 			Operator: "B",
 			Approved: true,
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 		Message: &core.MessageInOut{
 			InlineData: core.InlineData{
 				{
@@ -568,14 +586,17 @@ func TestApprovalWithBroadcastPrepareFail(t *testing.T) {
 
 	mbm := am.broadcast.(*broadcastmocks.Manager)
 	mms := &syncasyncmocks.Sender{}
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mbm.On("NewBroadcast", approval.Message).Return(mms)
 	mms.On("Prepare", context.Background()).Return(fmt.Errorf("pop"))
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.EqualError(t, err, "pop")
 
 	mbm.AssertExpectations(t)
 	mms.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalWithPrivateMessage(t *testing.T) {
@@ -654,7 +675,8 @@ func TestApprovalWithPrivateMessageDisabled(t *testing.T) {
 			Operator: "B",
 			Approved: true,
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 		Message: &core.MessageInOut{
 			Message: core.Message{
 				Header: core.MessageHeader{
@@ -671,8 +693,13 @@ func TestApprovalWithPrivateMessageDisabled(t *testing.T) {
 		},
 	}
 
+	mth := am.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
+
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.Regexp(t, "FF10415", err)
+
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalWithInvalidMessage(t *testing.T) {
@@ -684,7 +711,8 @@ func TestApprovalWithInvalidMessage(t *testing.T) {
 			Operator: "B",
 			Approved: true,
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 		Message: &core.MessageInOut{
 			Message: core.Message{
 				Header: core.MessageHeader{
@@ -699,8 +727,13 @@ func TestApprovalWithInvalidMessage(t *testing.T) {
 		},
 	}
 
+	mth := am.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
+
 	_, err := am.TokenApproval(context.Background(), approval, false)
 	assert.Regexp(t, "FF10287", err)
+
+	mth.AssertExpectations(t)
 }
 
 func TestApprovalOperationsFail(t *testing.T) {
@@ -878,7 +911,8 @@ func TestApprovalPrepare(t *testing.T) {
 			Operator: "operator",
 			Key:      "key",
 		},
-		Pool: "pool1",
+		Pool:           "pool1",
+		IdempotencyKey: "idem1",
 	}
 	pool := &core.TokenPool{
 		Locator:   "F1",
@@ -890,12 +924,15 @@ func TestApprovalPrepare(t *testing.T) {
 
 	mdi := am.database.(*databasemocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("ResolveInputSigningKey", context.Background(), "key", identity.KeyNormalizationBlockchainPlugin).Return("0x12345", nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
+	mth.On("SubmitNewTransaction", context.Background(), core.TransactionTypeTokenApproval, core.IdempotencyKey("idem1")).Return(fftypes.NewUUID(), nil)
 
 	err := sender.Prepare(context.Background())
 	assert.NoError(t, err)
 
 	mdi.AssertExpectations(t)
 	mim.AssertExpectations(t)
+	mth.AssertExpectations(t)
 }

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -267,19 +267,21 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) (e
 
 func (s *transferSender) buildTransferMessage(ctx context.Context, in *core.MessageInOut) (syncasync.Sender, error) {
 	allowedTypes := []fftypes.FFEnum{
-		core.MessageTypeTransferBroadcast,
-		core.MessageTypeTransferPrivate,
+		core.MessageTypeBroadcast,
+		core.MessageTypePrivate,
+		core.MessageTypeDeprecatedTransferBroadcast,
+		core.MessageTypeDeprecatedTransferPrivate,
 	}
 	if in.Header.Type == "" {
-		in.Header.Type = core.MessageTypeTransferBroadcast
+		in.Header.Type = core.MessageTypeBroadcast
 	}
 	switch in.Header.Type {
-	case core.MessageTypeTransferBroadcast:
+	case core.MessageTypeBroadcast, core.MessageTypeDeprecatedTransferBroadcast:
 		if s.mgr.broadcast == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}
 		return s.mgr.broadcast.NewBroadcast(in), nil
-	case core.MessageTypeTransferPrivate:
+	case core.MessageTypePrivate, core.MessageTypeDeprecatedTransferPrivate:
 		if s.mgr.messaging == nil {
 			return nil, i18n.NewError(ctx, coremsgs.MsgMessagesNotSupported)
 		}

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -231,6 +231,12 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) (e
 		}
 		s.transfer.TX.ID = txid
 		s.transfer.TX.Type = core.TransactionTypeTokenTransfer
+		if s.transfer.Message != nil {
+			s.transfer.Message.TxParent = &core.TransactionRef{
+				ID:   txid,
+				Type: core.TransactionTypeTokenTransfer,
+			}
+		}
 
 		op = core.NewOperation(
 			plugin,

--- a/internal/assets/token_transfer_test.go
+++ b/internal/assets/token_transfer_test.go
@@ -945,7 +945,7 @@ func TestTransferTokensWithPrivateMessage(t *testing.T) {
 			Message: core.Message{
 				Header: core.MessageHeader{
 					ID:   msgID,
-					Type: core.MessageTypeTransferPrivate,
+					Type: core.MessageTypePrivate,
 				},
 				Hash: hash,
 			},
@@ -1012,7 +1012,7 @@ func TestTransferTokensWithPrivateMessageDisabled(t *testing.T) {
 			Message: core.Message{
 				Header: core.MessageHeader{
 					ID:   msgID,
-					Type: core.MessageTypeTransferPrivate,
+					Type: core.MessageTypeDeprecatedTransferPrivate,
 				},
 				Hash: hash,
 			},

--- a/internal/broadcast/manager.go
+++ b/internal/broadcast/manager.go
@@ -109,8 +109,8 @@ func NewBroadcastManager(ctx context.Context, ns *core.Namespace, di database.Pl
 			[]core.MessageType{
 				core.MessageTypeBroadcast,
 				core.MessageTypeDefinition,
-				core.MessageTypeTransferBroadcast,
-				core.MessageTypeApprovalBroadcast,
+				core.MessageTypeDeprecatedTransferBroadcast,
+				core.MessageTypeDeprecatedApprovalBroadcast,
 			}, bm.dispatchBatch, bo)
 	}
 

--- a/internal/broadcast/manager_test.go
+++ b/internal/broadcast/manager_test.go
@@ -66,8 +66,8 @@ func newTestBroadcastCommon(t *testing.T, metricsEnabled bool) (*broadcastManage
 		[]core.MessageType{
 			core.MessageTypeBroadcast,
 			core.MessageTypeDefinition,
-			core.MessageTypeTransferBroadcast,
-			core.MessageTypeApprovalBroadcast,
+			core.MessageTypeDeprecatedTransferBroadcast,
+			core.MessageTypeDeprecatedApprovalBroadcast,
 		}, mock.Anything, mock.Anything).Return()
 	mom.On("RegisterHandler", mock.Anything, mock.Anything, mock.Anything)
 

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -58,6 +58,7 @@ var (
 	MessageHeaderTopics    = ffm("MessageHeader.topics", "A message topic associates this message with an ordered stream of data. A custom topic should be assigned - using the default topic is discouraged")
 	MessageHeaderTag       = ffm("MessageHeader.tag", "The message tag indicates the purpose of the message to the applications that process it")
 	MessageHeaderDataHash  = ffm("MessageHeader.datahash", "A single hash representing all data in the message. Derived from the array of data ids+hashes attached to this message")
+	MessageTxParent        = ffm("MessageHeader.txparent", "The parent transaction that originally triggered this message")
 
 	// Message field descriptions
 	MessageHeader         = ffm("Message.header", "The message header contains all fields that are used to build the message hash")
@@ -69,7 +70,6 @@ var (
 	MessageData           = ffm("Message.data", "The list of data elements attached to the message")
 	MessagePins           = ffm("Message.pins", "For private messages, a unique pin hash:nonce is assigned for each topic")
 	MessageTransactionID  = ffm("Message.txid", "The ID of the transaction used to order/deliver this message")
-	MessageTxParent       = ffm("Message.txparent", "The parent transaction that originally triggered this message")
 	MessageIdempotencyKey = ffm("Message.idempotencyKey", "An optional unique identifier for a message. Cannot be duplicated within a namespace, thus allowing idempotent submission of messages to the API. Local only - not transferred when the message is sent to other members of the network")
 
 	// MessageInOut field descriptions

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -68,6 +68,8 @@ var (
 	MessageConfirmed      = ffm("Message.confirmed", "The timestamp of when the message was confirmed/rejected")
 	MessageData           = ffm("Message.data", "The list of data elements attached to the message")
 	MessagePins           = ffm("Message.pins", "For private messages, a unique pin hash:nonce is assigned for each topic")
+	MessageTransactionID  = ffm("Message.txid", "The ID of the transaction used to order/deliver this message")
+	MessageTxParent       = ffm("Message.txparent", "The parent transaction that originally triggered this message")
 	MessageIdempotencyKey = ffm("Message.idempotencyKey", "An optional unique identifier for a message. Cannot be duplicated within a namespace, thus allowing idempotent submission of messages to the API. Local only - not transferred when the message is sent to other members of the network")
 
 	// MessageInOut field descriptions

--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -48,12 +48,12 @@ var (
 		"datahash",
 		"hash",
 		"pins",
-		"tx_id",
-		"tx_parent_type",
-		"tx_parent_id",
 		"state",
 		"confirmed",
 		"tx_type",
+		"tx_id",
+		"tx_parent_type",
+		"tx_parent_id",
 		"batch_id",
 		"idempotency_key",
 	}
@@ -75,9 +75,9 @@ const messagesDataJoinTable = "messages_data"
 func (s *SQLCommon) attemptMessageUpdate(ctx context.Context, tx *dbsql.TXWrapper, message *core.Message) (int64, error) {
 	var txParentID *fftypes.UUID
 	var txParentType core.TransactionType
-	if message.TxParent != nil {
-		txParentID = message.TxParent.ID
-		txParentType = message.TxParent.Type
+	if message.Header.TxParent != nil {
+		txParentID = message.Header.TxParent.ID
+		txParentType = message.Header.TxParent.Type
 	}
 
 	return s.UpdateTx(ctx, messagesTable, tx,
@@ -93,12 +93,12 @@ func (s *SQLCommon) attemptMessageUpdate(ctx context.Context, tx *dbsql.TXWrappe
 			Set("datahash", message.Header.DataHash).
 			Set("hash", message.Hash).
 			Set("pins", message.Pins).
-			Set("tx_id", message.TransactionID).
-			Set("tx_parent_type", txParentType).
-			Set("tx_parent_id", txParentID).
 			Set("state", message.State).
 			Set("confirmed", message.Confirmed).
 			Set("tx_type", message.Header.TxType).
+			Set("tx_id", message.TransactionID).
+			Set("tx_parent_type", txParentType).
+			Set("tx_parent_id", txParentID).
 			Set("batch_id", message.BatchID).
 			Set("idempotency_key", message.IdempotencyKey).
 			Where(sq.Eq{
@@ -115,9 +115,9 @@ func (s *SQLCommon) attemptMessageUpdate(ctx context.Context, tx *dbsql.TXWrappe
 func (s *SQLCommon) setMessageInsertValues(query sq.InsertBuilder, message *core.Message) sq.InsertBuilder {
 	var txParentID *fftypes.UUID
 	var txParentType core.TransactionType
-	if message.TxParent != nil {
-		txParentID = message.TxParent.ID
-		txParentType = message.TxParent.Type
+	if message.Header.TxParent != nil {
+		txParentID = message.Header.TxParent.ID
+		txParentType = message.Header.TxParent.Type
 	}
 
 	return query.Values(
@@ -135,12 +135,12 @@ func (s *SQLCommon) setMessageInsertValues(query sq.InsertBuilder, message *core
 		message.Header.DataHash,
 		message.Hash,
 		message.Pins,
-		message.TransactionID,
-		txParentType,
-		txParentID,
 		message.State,
 		message.Confirmed,
 		message.Header.TxType,
+		message.TransactionID,
+		txParentType,
+		txParentID,
 		message.BatchID,
 		message.IdempotencyKey,
 	)
@@ -449,12 +449,12 @@ func (s *SQLCommon) msgResult(ctx context.Context, row *sql.Rows) (*core.Message
 		&msg.Header.DataHash,
 		&msg.Hash,
 		&msg.Pins,
-		&msg.TransactionID,
-		&txParent.Type,
-		&txParent.ID,
 		&msg.State,
 		&msg.Confirmed,
 		&msg.Header.TxType,
+		&msg.TransactionID,
+		&txParent.Type,
+		&txParent.ID,
 		&msg.BatchID,
 		&msg.IdempotencyKey,
 		// Must be added to the list of columns in all selects
@@ -464,7 +464,7 @@ func (s *SQLCommon) msgResult(ctx context.Context, row *sql.Rows) (*core.Message
 		return nil, i18n.WrapError(ctx, err, coremsgs.MsgDBReadErr, messagesTable)
 	}
 	if txParent.ID != nil {
-		msg.TxParent = &txParent
+		msg.Header.TxParent = &txParent
 	}
 	return &msg, nil
 }

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -554,7 +554,7 @@ func TestGetMessageByIDLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), nil, "", nil, "confirmed", 0, "pin", nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetMessageByID(context.Background(), "ns1", msgID)
 	assert.Regexp(t, "FF00176", err)
@@ -601,7 +601,7 @@ func TestGetMessagesLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), nil, "", nil, "confirmed", 0, "pin", nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Gt("confirmed", "0")
 	_, _, err := s.GetMessages(context.Background(), "ns1", f)

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -61,6 +61,10 @@ func TestUpsertE2EWithDB(t *testing.T) {
 			Group:     nil,
 			DataHash:  fftypes.NewRandB32(),
 			TxType:    core.TransactionTypeUnpinned,
+			TxParent: &core.TransactionRef{
+				Type: core.TransactionTypeTokenTransfer,
+				ID:   fftypes.NewUUID(),
+			},
 		},
 		Hash:      fftypes.NewRandB32(),
 		State:     core.MessageStateStaged,
@@ -109,6 +113,10 @@ func TestUpsertE2EWithDB(t *testing.T) {
 			Group:     gid,
 			DataHash:  fftypes.NewRandB32(),
 			TxType:    core.TransactionTypeBatchPin,
+			TxParent: &core.TransactionRef{
+				Type: core.TransactionTypeTokenTransfer,
+				ID:   fftypes.NewUUID(),
+			},
 		},
 		Hash:           fftypes.NewRandB32(),
 		Pins:           []string{fftypes.NewRandB32().String(), fftypes.NewRandB32().String()},
@@ -554,7 +562,7 @@ func TestGetMessageByIDLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), nil, "", nil, "confirmed", 0, "pin", nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "", nil, nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetMessageByID(context.Background(), "ns1", msgID)
 	assert.Regexp(t, "FF00176", err)
@@ -601,7 +609,7 @@ func TestGetMessagesLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), nil, "", nil, "confirmed", 0, "pin", nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "", nil, nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Gt("confirmed", "0")
 	_, _, err := s.GetMessages(context.Background(), "ns1", f)

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -534,14 +534,14 @@ func (ag *aggregator) processMessage(ctx context.Context, manifest *core.BatchMa
 
 func needsTokenTransfer(msg *core.Message) bool {
 	return (msg.Header.TxParent != nil && msg.Header.TxParent.Type == core.TransactionTypeTokenTransfer) ||
-		msg.Header.Type == core.MessageTypeTransferBroadcast ||
-		msg.Header.Type == core.MessageTypeTransferPrivate
+		msg.Header.Type == core.MessageTypeDeprecatedTransferBroadcast ||
+		msg.Header.Type == core.MessageTypeDeprecatedTransferPrivate
 }
 
 func needsTokenApproval(msg *core.Message) bool {
 	return (msg.Header.TxParent != nil && msg.Header.TxParent.Type == core.TransactionTypeTokenApproval) ||
-		msg.Header.Type == core.MessageTypeApprovalBroadcast ||
-		msg.Header.Type == core.MessageTypeApprovalPrivate
+		msg.Header.Type == core.MessageTypeDeprecatedApprovalBroadcast ||
+		msg.Header.Type == core.MessageTypeDeprecatedApprovalPrivate
 }
 
 func (ag *aggregator) attemptMessageDispatch(ctx context.Context, msg *core.Message, data core.DataArray, tx *fftypes.UUID, state *batchState, pin *core.Pin) (newState core.MessageState, dispatched bool, err error) {

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -533,13 +533,13 @@ func (ag *aggregator) processMessage(ctx context.Context, manifest *core.BatchMa
 }
 
 func needsTokenTransfer(msg *core.Message) bool {
-	return (msg.TxParent != nil && msg.TxParent.Type == core.TransactionTypeTokenTransfer) ||
+	return (msg.Header.TxParent != nil && msg.Header.TxParent.Type == core.TransactionTypeTokenTransfer) ||
 		msg.Header.Type == core.MessageTypeTransferBroadcast ||
 		msg.Header.Type == core.MessageTypeTransferPrivate
 }
 
 func needsTokenApproval(msg *core.Message) bool {
-	return (msg.TxParent != nil && msg.TxParent.Type == core.TransactionTypeTokenApproval) ||
+	return (msg.Header.TxParent != nil && msg.Header.TxParent.Type == core.TransactionTypeTokenApproval) ||
 		msg.Header.Type == core.MessageTypeApprovalBroadcast ||
 		msg.Header.Type == core.MessageTypeApprovalPrivate
 }

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -1515,7 +1515,7 @@ func TestAttemptMessageDispatchMissingTransfers(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:   fftypes.NewUUID(),
-			Type: core.MessageTypeTransferBroadcast,
+			Type: core.MessageTypeDeprecatedTransferBroadcast,
 			SignerRef: core.SignerRef{
 				Author: org1.DID,
 				Key:    "0x12345",
@@ -1541,7 +1541,7 @@ func TestAttemptMessageDispatchGetTransfersFail(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeTransferBroadcast,
+			Type:      core.MessageTypeDeprecatedTransferBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}
@@ -1561,7 +1561,7 @@ func TestAttemptMessageDispatchTransferMismatch(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeTransferBroadcast,
+			Type:      core.MessageTypeDeprecatedTransferBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}
@@ -1594,7 +1594,7 @@ func TestAttemptMessageDispatchGetApprovalsFail(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeApprovalBroadcast,
+			Type:      core.MessageTypeDeprecatedApprovalBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}
@@ -1614,7 +1614,7 @@ func TestAttemptMessageDispatchApprovalMismatch(t *testing.T) {
 	msg := &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
-			Type:      core.MessageTypeApprovalBroadcast,
+			Type:      core.MessageTypeDeprecatedApprovalBroadcast,
 			SignerRef: core.SignerRef{Key: "0x12345", Author: org1.DID},
 		},
 	}

--- a/internal/events/persist_batch.go
+++ b/internal/events/persist_batch.go
@@ -108,7 +108,6 @@ func (em *eventManager) validateAndPersistBatchContent(ctx context.Context, batc
 		if valid = em.validateBatchMessage(ctx, batch, i, msg); !valid {
 			return false, nil
 		}
-		msg.LocalNamespace = em.namespace.Name
 	}
 
 	// We require that the batch contains exactly the set of data that is in the messages - no more or less.
@@ -198,7 +197,9 @@ func (em *eventManager) validateBatchMessage(ctx context.Context, batch *core.Ba
 		log.L(ctx).Errorf("Mismatched key/author '%s'/'%s' on message entry %d in batch '%s'", msg.Header.Key, msg.Header.Author, i, batch.ID)
 		return false
 	}
+	msg.LocalNamespace = em.namespace.Name
 	msg.BatchID = batch.ID
+	msg.TransactionID = batch.Payload.TX.ID
 
 	l.Tracef("Batch '%s' message %d: %+v", batch.ID, i, msg)
 

--- a/internal/privatemessaging/privatemessaging.go
+++ b/internal/privatemessaging/privatemessaging.go
@@ -141,8 +141,8 @@ func NewPrivateMessaging(ctx context.Context, ns *core.Namespace, di database.Pl
 		[]core.MessageType{
 			core.MessageTypeGroupInit,
 			core.MessageTypePrivate,
-			core.MessageTypeTransferPrivate,
-			core.MessageTypeApprovalPrivate,
+			core.MessageTypeDeprecatedTransferPrivate,
+			core.MessageTypeDeprecatedApprovalPrivate,
 		},
 		pm.dispatchPinnedBatch, bo)
 

--- a/internal/privatemessaging/privatemessaging_test.go
+++ b/internal/privatemessaging/privatemessaging_test.go
@@ -70,8 +70,8 @@ func newTestPrivateMessagingCommon(t *testing.T, metricsEnabled bool) (*privateM
 		[]core.MessageType{
 			core.MessageTypeGroupInit,
 			core.MessageTypePrivate,
-			core.MessageTypeTransferPrivate,
-			core.MessageTypeApprovalPrivate,
+			core.MessageTypeDeprecatedTransferPrivate,
+			core.MessageTypeDeprecatedApprovalPrivate,
 		}, mock.Anything, mock.Anything).Return()
 
 	mba.On("RegisterDispatcher",

--- a/pkg/core/message.go
+++ b/pkg/core/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -94,6 +94,8 @@ type Message struct {
 	LocalNamespace string                `ffstruct:"Message" json:"localNamespace,omitempty" ffexcludeinput:"true"`
 	Hash           *fftypes.Bytes32      `ffstruct:"Message" json:"hash,omitempty" ffexcludeinput:"true"`
 	BatchID        *fftypes.UUID         `ffstruct:"Message" json:"batch,omitempty" ffexcludeinput:"true"`
+	TransactionID  *fftypes.UUID         `ffstruct:"Message" json:"txid,omitempty" ffexcludeinput:"true"`
+	TxParent       *TransactionRef       `ffstruct:"Message" json:"txparent,omitempty"`
 	State          MessageState          `ffstruct:"Message" json:"state,omitempty" ffenum:"messagestate" ffexcludeinput:"true"`
 	Confirmed      *fftypes.FFTime       `ffstruct:"Message" json:"confirmed,omitempty" ffexcludeinput:"true"`
 	Data           DataRefs              `ffstruct:"Message" json:"data" ffexcludeinput:"true"`
@@ -110,9 +112,10 @@ type Message struct {
 // Fields such as the state/confirmed do NOT transfer, as these are calculated individually by each member.
 func (m *Message) BatchMessage() *Message {
 	return &Message{
-		Header: m.Header,
-		Hash:   m.Hash,
-		Data:   m.Data,
+		Header:   m.Header,
+		Hash:     m.Hash,
+		Data:     m.Data,
+		TxParent: m.TxParent, // TODO: this should really move inside Header
 		// The pins are immutable once assigned by the sender, which happens before the batch is sealed
 		Pins: m.Pins,
 	}

--- a/pkg/core/message.go
+++ b/pkg/core/message.go
@@ -84,6 +84,7 @@ type MessageHeader struct {
 	Topics    fftypes.FFStringArray `ffstruct:"MessageHeader" json:"topics,omitempty"`
 	Tag       string                `ffstruct:"MessageHeader" json:"tag,omitempty"`
 	DataHash  *fftypes.Bytes32      `ffstruct:"MessageHeader" json:"datahash,omitempty" ffexcludeinput:"true"`
+	TxParent  *TransactionRef       `ffstruct:"MessageHeader" json:"txparent,omitempty" ffexcludeinput:"true"`
 }
 
 // Message is the envelope by which coordinated data exchange can happen between parties in the network
@@ -95,7 +96,6 @@ type Message struct {
 	Hash           *fftypes.Bytes32      `ffstruct:"Message" json:"hash,omitempty" ffexcludeinput:"true"`
 	BatchID        *fftypes.UUID         `ffstruct:"Message" json:"batch,omitempty" ffexcludeinput:"true"`
 	TransactionID  *fftypes.UUID         `ffstruct:"Message" json:"txid,omitempty" ffexcludeinput:"true"`
-	TxParent       *TransactionRef       `ffstruct:"Message" json:"txparent,omitempty"`
 	State          MessageState          `ffstruct:"Message" json:"state,omitempty" ffenum:"messagestate" ffexcludeinput:"true"`
 	Confirmed      *fftypes.FFTime       `ffstruct:"Message" json:"confirmed,omitempty" ffexcludeinput:"true"`
 	Data           DataRefs              `ffstruct:"Message" json:"data" ffexcludeinput:"true"`
@@ -112,10 +112,9 @@ type Message struct {
 // Fields such as the state/confirmed do NOT transfer, as these are calculated individually by each member.
 func (m *Message) BatchMessage() *Message {
 	return &Message{
-		Header:   m.Header,
-		Hash:     m.Hash,
-		Data:     m.Data,
-		TxParent: m.TxParent, // TODO: this should really move inside Header
+		Header: m.Header,
+		Hash:   m.Hash,
+		Data:   m.Data,
 		// The pins are immutable once assigned by the sender, which happens before the batch is sealed
 		Pins: m.Pins,
 	}

--- a/pkg/core/message.go
+++ b/pkg/core/message.go
@@ -42,14 +42,14 @@ var (
 	MessageTypePrivate = fftypes.FFEnumValue("messagetype", "private")
 	// MessageTypeGroupInit is a special private message that contains the definition of the group
 	MessageTypeGroupInit = fftypes.FFEnumValue("messagetype", "groupinit")
-	// MessageTypeTransferBroadcast is a broadcast message to accompany/annotate a token transfer
-	MessageTypeTransferBroadcast = fftypes.FFEnumValue("messagetype", "transfer_broadcast")
-	// MessageTypeTransferPrivate is a private message to accompany/annotate a token transfer
-	MessageTypeTransferPrivate = fftypes.FFEnumValue("messagetype", "transfer_private")
-	// MessageTypeApprovalBroadcast is a broadcast message to accompany/annotate a token approval
-	MessageTypeApprovalBroadcast = fftypes.FFEnumValue("messagetype", "approval_broadcast")
-	// MessageTypeApprovalPrivate is a private message to accompany/annotate a token approval
-	MessageTypeApprovalPrivate = fftypes.FFEnumValue("messagetype", "approval_private")
+	// MessageTypeDeprecatedTransferBroadcast is deprecated - use MessageTypeBroadcast (and refer to TxParent.Type)
+	MessageTypeDeprecatedTransferBroadcast = fftypes.FFEnumValue("messagetype", "transfer_broadcast")
+	// MessageTypeDeprecatedTransferPrivate is deprecated - use MessageTypePrivate (and refer to TxParent.Type)
+	MessageTypeDeprecatedTransferPrivate = fftypes.FFEnumValue("messagetype", "transfer_private")
+	// MessageTypeDeprecatedApprovalBroadcast is deprecated - use MessageTypeBroadcast (and refer to TxParent.Type)
+	MessageTypeDeprecatedApprovalBroadcast = fftypes.FFEnumValue("messagetype", "approval_broadcast")
+	// MessageTypeDeprecatedApprovalPrivate is a deprecated - use MessageTypePrivate (and refer to TxParent.Type)
+	MessageTypeDeprecatedApprovalPrivate = fftypes.FFEnumValue("messagetype", "approval_private")
 )
 
 // MessageState is the current transmission/confirmation state of a message

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -698,6 +698,9 @@ var MessageQueryFactory = &ffapi.QueryFields{
 	"sequence":       &ffapi.Int64Field{},
 	"txtype":         &ffapi.StringField{},
 	"batch":          &ffapi.UUIDField{},
+	"txid":           &ffapi.UUIDField{},
+	"txparent.type":  &ffapi.StringField{},
+	"txparent.id":    &ffapi.UUIDField{},
 }
 
 // BatchQueryFactory filter fields for batches


### PR DESCRIPTION
Propagate the `batch_pin` transaction ID onto the message when the batch is assembled (sender) or when it is persisted (receiver), as a new `txid` field.

For token transfers and approvals that come with a message, store the `token_transfer` or `token_approval` transaction details on the message up-front, as a new `txparent` field.

Illustration of changes to the message object:
<img width="912" alt="message with transfer" src="https://user-images.githubusercontent.com/1993829/215154143-3199d9d1-4f12-4bdc-a0d8-5da14f84caaa.png">

This does mean the allocation of the `token_transfer` or `token_approval` transaction ID happens earlier and outside a database transaction, but I don't see a problem with this.

This probably supersedes both #1157 and #1162, as I think it's a cleaner route toward solving that problem _and_ teeing up [FIR-17](https://github.com/hyperledger/firefly-fir/pull/17).