### PR TITLE
Keep Docker state between builds

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -48,4 +48,4 @@ docker buildx build \
     --build-arg UI_RELEASE=$UI_RELEASE \
     $@ \
     .
-docker buildx rm firefly
+docker buildx rm firefly --keep-state


### PR DESCRIPTION
Greatly reduces incremental build time for "make docker".