### PR TITLE
Update to docker/build-push-action@v4

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -35,7 +35,7 @@ jobs:
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo ::set-output name=BUILD_TAG::$BUILD_TAG
           echo ::set-output name=BUILD_DATE::$BUILD_DATE
-      
+
       - name: Read manifest.json
         id: manifest
         run: |
@@ -48,8 +48,9 @@ jobs:
           echo ::set-output name=UI_RELEASE::$(cat manifest.json | jq -r '.ui.release')
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          provenance: false
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -25,7 +25,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Set latest tag
         if: github.event.action == 'released'
         run: |
@@ -34,17 +34,17 @@ jobs:
       - name: Set alpha tag
         if: github.event.action == 'prereleased' && contains(github.ref, 'alpha')
         run: |
-            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:alpha" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:alpha" >> $GITHUB_ENV
 
       - name: Set beta tag
         if: github.event.action == 'prereleased' && contains(github.ref, 'beta')
         run: |
-            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:beta" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:beta" >> $GITHUB_ENV
 
       - name: Set rc tag
         if: github.event.action == 'prereleased' && contains(github.ref, 'rc')
         run: |
-            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:rc" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:rc" >> $GITHUB_ENV
 
       - name: Set build tag
         id: build_tag_generator
@@ -67,8 +67,9 @@ jobs:
           echo ::set-output name=UI_RELEASE::$(cat manifest.json | jq -r '.ui.release')
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          provenance: false
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
Due to a recent change in the docker/build-push-action GitHub Action https://github.com/docker/build-push-action/issues/778 our images stopped having their manifests published properly. This PR updates our GitHub Actions to use a newer version of the Action, and restores the previously working behavior. I was able to test this on my own fork and created https://github.com/nguyer/firefly/pkgs/container/firefly/67526987 which has a good manifest in it.