### PR TITLE
Add contractLocation field to deploy transaction output

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -35,7 +35,7 @@ jobs:
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo ::set-output name=BUILD_TAG::$BUILD_TAG
           echo ::set-output name=BUILD_DATE::$BUILD_DATE
-      
+
       - name: Read manifest.json
         id: manifest
         run: |
@@ -50,6 +50,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          provenance: false
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -48,7 +48,7 @@ jobs:
           echo ::set-output name=UI_RELEASE::$(cat manifest.json | jq -r '.ui.release')
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           provenance: false
           context: ./

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -25,7 +25,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Set latest tag
         if: github.event.action == 'released'
         run: |
@@ -34,17 +34,17 @@ jobs:
       - name: Set alpha tag
         if: github.event.action == 'prereleased' && contains(github.ref, 'alpha')
         run: |
-            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:alpha" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:alpha" >> $GITHUB_ENV
 
       - name: Set beta tag
         if: github.event.action == 'prereleased' && contains(github.ref, 'beta')
         run: |
-            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:beta" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:beta" >> $GITHUB_ENV
 
       - name: Set rc tag
         if: github.event.action == 'prereleased' && contains(github.ref, 'rc')
         run: |
-            echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:rc" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},ghcr.io/${{ github.repository_owner }}/firefly:rc" >> $GITHUB_ENV
 
       - name: Set build tag
         id: build_tag_generator
@@ -69,6 +69,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          provenance: false
           context: ./
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -67,7 +67,7 @@ jobs:
           echo ::set-output name=UI_RELEASE::$(cat manifest.json | jq -r '.ui.release')
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           provenance: false
           context: ./

--- a/internal/blockchain/common/common.go
+++ b/internal/blockchain/common/common.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -78,10 +78,11 @@ type BlockchainReceiptHeaders struct {
 }
 
 type BlockchainReceiptNotification struct {
-	Headers    BlockchainReceiptHeaders
-	TxHash     string `json:"transactionHash,omitempty"`
-	Message    string `json:"errorMessage,omitempty"`
-	ProtocolID string `json:"protocolId,omitempty"`
+	Headers          BlockchainReceiptHeaders `json:"headers,omitempty"`
+	TxHash           string                   `json:"transactionHash,omitempty"`
+	Message          string                   `json:"errorMessage,omitempty"`
+	ProtocolID       string                   `json:"protocolId,omitempty"`
+	ContractLocation *fftypes.JSONAny         `json:"contractLocation,omitempty"`
 }
 
 func NewBlockchainCallbacks() BlockchainCallbacks {
@@ -297,6 +298,7 @@ func HandleReceipt(ctx context.Context, plugin core.Named, reply *BlockchainRece
 	if reply.Headers.ReceiptID == "" || reply.Headers.ReplyType == "" {
 		return fmt.Errorf("reply cannot be processed - missing fields: %+v", reply)
 	}
+
 	var updateType core.OpStatus
 	switch reply.Headers.ReplyType {
 	case "TransactionSuccess":

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,8 @@
   },
   "evmconnect": {
     "image": "ghcr.io/hyperledger/firefly-evmconnect",
-    "tag": "v1.2.1",
-    "sha": "5f5ada5da90e7e49ba60f82737f7613d6759134248faa363210b74d89996d9b8"
+    "tag": "v1.2.2",
+    "sha": "9032e45ea9cee7d881ce88eaea720f450d2ed176e96137feb495c5e7850fab45"
   },
   "fabconnect": {
     "image": "ghcr.io/hyperledger/firefly-fabconnect",


### PR DESCRIPTION
This brings the contract address of a deployed contract all the way through to the transaction output when deploying a new smart contract. This shows up in a `JSONAny` field called `contractLocation` and looks like this in FireFly:

```json
...
    "output": {
        "headers": {
            "requestId": "default:aa155a3c-2591-410e-bc9d-68ae7de34689",
            "type": "TransactionSuccess"
        },
        "contractLocation": {
            "address": "0x24746b95d118b2b4e8d07b06b1bad988fbf9415d"
        },
        "protocolId": "000000000024/000000",
        "transactionHash": "0x32d1144091877266d7f0426e48db157e7d1a857c62e6f488319bb09243f0f851"
    },
...
```