### PR TITLE
Fix typo in private & broadcast blob upload docs

### DIFF
--- a/docs/tutorials/broadcast_data.md
+++ b/docs/tutorials/broadcast_data.md
@@ -137,7 +137,7 @@ on the vast majority of your messages.
 
 Here we make two API calls.
 
-1) Create the `data` object explicitly, using a multi-party form upload
+1) Create the `data` object explicitly, using a multi-part form upload
 
   - You can also just post JSON to this endpoint
 

--- a/docs/tutorials/private_send.md
+++ b/docs/tutorials/private_send.md
@@ -200,7 +200,7 @@ on the vast majority of your messages.
 
 Here we make two API calls.
 
-1) Create the `data` object explicitly, using a multi-party form upload
+1) Create the `data` object explicitly, using a multi-part form upload
 - You can also just post JSON to this endpoint
 
 2) Privately send a message referring to that data


### PR DESCRIPTION
I assume this should say `multi-part` (as in the MIME type) as opposed to `multi-party`

Signed-off-by: Matthew Whitehead <matthew1001@gmail.com>