### PR TITLE
Fix nightly integration tests

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -57,8 +57,10 @@ if [ -n "${BLOCKCHAIN_CONNECTOR}" ]; then
 fi
 
 BLOCKCHAIN_NODE_FLAG=""
-if [ -n "${BLOCKCHAIN_NODE}" ]; then
-  BLOCKCHAIN_CONNECTOR_FLAG="--blockchain-node ${BLOCKCHAIN_NODE}"
+if [ "${STACK_TYPE}" != "fabric" ]; then
+  if [ -n "${BLOCKCHAIN_NODE}" ]; then
+    BLOCKCHAIN_CONNECTOR_FLAG="--blockchain-node ${BLOCKCHAIN_NODE}"
+  fi
 fi
 
 if [ -z "${TEST_SUITE}" ]; then


### PR DESCRIPTION
Previously we were passing the `--blockchain-node` flag for all integration tests. The `ff init fabric` subcommand does not support this flag though, so it fails to create the test stack.

Here is an example of a failed run where this happened: https://github.com/hyperledger/firefly/actions/runs/4189374980/jobs/7261623960#step:6:139

```
ff -v --ansi never init fabric --prometheus-enabled --database sqlite3 firefly_e2e 2 --blockchain-node fabric --token-providers erc20_erc721 --manifest ../../manifest.json --sandbox-enabled=false --multiparty=true
Error: unknown flag: --blockchain-node
```