### PR TITLE
Fail gracefully when inserting many data rows on sqlite

### DIFF
--- a/internal/database/sqlcommon/data_sql.go
+++ b/internal/database/sqlcommon/data_sql.go
@@ -212,7 +212,7 @@ func (s *SQLCommon) InsertDataArray(ctx context.Context, dataArray core.DataArra
 	} else {
 		// Fall back to individual inserts grouped in a TX
 		for _, data := range dataArray {
-			_, err := s.attemptDataInsert(ctx, tx, data, false)
+			_, err := s.attemptDataInsert(ctx, tx, data, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Need to pass requestConflictEmptyResult=true on this path, the same as we do on the postgres path.

Fixes #1196