### PR TITLE
[tokens] Only Use broadcastName for Multi-Party Namespaces

### DIFF
--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -241,7 +241,7 @@ var (
 	MsgDefRejectedBadPayload              = ffe("FF10400", "Rejected %s message '%s' - invalid payload")
 	MsgDefRejectedAuthorBlank             = ffe("FF10401", "Rejected %s message '%s' - author is blank")
 	MsgDefRejectedSignatureMismatch       = ffe("FF10402", "Rejected %s message '%s' - signature mismatch")
-	MsgDefRejectedValidateFail            = ffe("FF10403", "Rejected %s '%s' - validate failed: %s")
+	MsgDefRejectedValidateFail            = ffe("FF10403", "Rejected %s '%s' - validate failed")
 	MsgDefRejectedIDMismatch              = ffe("FF10404", "Rejected %s '%s' - ID mismatch with existing record")
 	MsgDefRejectedLocationMismatch        = ffe("FF10405", "Rejected %s '%s' - location mismatch with existing record")
 	MsgDefRejectedSchemaFail              = ffe("FF10406", "Rejected %s '%s' - schema check: %s")

--- a/internal/definitions/handler_contracts.go
+++ b/internal/definitions/handler_contracts.go
@@ -29,7 +29,7 @@ import (
 
 func (dh *definitionHandler) persistFFI(ctx context.Context, ffi *fftypes.FFI) (retry bool, err error) {
 	if err = dh.contracts.ResolveFFI(ctx, ffi); err != nil {
-		return false, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "contract interface", ffi.ID, err)
+		return false, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "contract interface", ffi.ID)
 	}
 
 	err = dh.database.UpsertFFI(ctx, ffi)
@@ -58,7 +58,7 @@ func (dh *definitionHandler) persistFFI(ctx context.Context, ffi *fftypes.FFI) (
 
 func (dh *definitionHandler) persistContractAPI(ctx context.Context, httpServerURL string, api *core.ContractAPI) (retry bool, err error) {
 	if err := dh.contracts.ResolveContractAPI(ctx, httpServerURL, api); err != nil {
-		return false, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "contract API", api.ID, err)
+		return false, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "contract API", api.ID)
 	}
 
 	err = dh.database.UpsertContractAPI(ctx, api)
@@ -84,7 +84,7 @@ func (dh *definitionHandler) handleFFIDefinition(ctx context.Context, state *cor
 	l := log.L(ctx)
 	ffi.Namespace = dh.namespace.Name
 	if err := ffi.Validate(ctx, true); err != nil {
-		return HandlerResult{Action: ActionReject}, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "contract interface", ffi.ID, err)
+		return HandlerResult{Action: ActionReject}, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "contract interface", ffi.ID)
 	}
 
 	if retry, err := dh.persistFFI(ctx, ffi); err != nil {
@@ -115,7 +115,7 @@ func (dh *definitionHandler) handleContractAPIDefinition(ctx context.Context, st
 	l := log.L(ctx)
 	api.Namespace = dh.namespace.Name
 	if err := api.Validate(ctx, true); err != nil {
-		return HandlerResult{Action: ActionReject}, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "contract API", api.ID, err)
+		return HandlerResult{Action: ActionReject}, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "contract API", api.ID)
 	}
 
 	if retry, err := dh.persistContractAPI(ctx, httpServerURL, api); err != nil {

--- a/internal/definitions/handler_identity_update.go
+++ b/internal/definitions/handler_identity_update.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -45,7 +45,7 @@ func (dh *definitionHandler) handleIdentityUpdateBroadcast(ctx context.Context, 
 
 func (dh *definitionHandler) handleIdentityUpdate(ctx context.Context, state *core.BatchState, msg *identityUpdateMsgInfo, update *core.IdentityUpdate) (HandlerResult, error) {
 	if err := update.Identity.Validate(ctx); err != nil {
-		return HandlerResult{Action: ActionReject}, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "identity update", update.Identity.ID, err)
+		return HandlerResult{Action: ActionReject}, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "identity update", update.Identity.ID)
 	}
 
 	// Get the existing identity (must be a confirmed identity at the point an update is issued)

--- a/internal/definitions/handler_identity_verification.go
+++ b/internal/definitions/handler_identity_verification.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -33,7 +33,7 @@ func (dh *definitionHandler) handleIdentityVerificationBroadcast(ctx context.Con
 	verification.Identity.Namespace = dh.namespace.Name
 	err := verification.Identity.Validate(ctx)
 	if err != nil || verification.Identity.Parent == nil || verification.Claim.ID == nil || verification.Claim.Hash == nil {
-		return HandlerResult{Action: ActionReject}, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "identity verification", verifyMsg.Header.ID, err)
+		return HandlerResult{Action: ActionReject}, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "identity verification", verifyMsg.Header.ID)
 	}
 
 	// Check the verification is signed by the correct org

--- a/internal/definitions/handler_tokenpool.go
+++ b/internal/definitions/handler_tokenpool.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/definitions/handler_tokenpool.go
+++ b/internal/definitions/handler_tokenpool.go
@@ -52,7 +52,7 @@ func (dh *definitionHandler) handleTokenPoolDefinition(ctx context.Context, stat
 
 	pool.Namespace = dh.namespace.Name
 	if err := pool.Validate(ctx); err != nil {
-		return HandlerResult{Action: ActionReject, CustomCorrelator: correlator}, i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "token pool", pool.ID, err)
+		return HandlerResult{Action: ActionReject, CustomCorrelator: correlator}, i18n.WrapError(ctx, err, coremsgs.MsgDefRejectedValidateFail, "token pool", pool.ID)
 	}
 
 	// Check if pool has already been confirmed on chain (and confirm the message if so)

--- a/internal/definitions/sender_tokenpool.go
+++ b/internal/definitions/sender_tokenpool.go
@@ -56,8 +56,7 @@ func (bm *definitionSender) DefineTokenPool(ctx context.Context, pool *core.Toke
 			if innerErr := errors.Unwrap(err); innerErr != nil {
 				return hr, innerErr
 			}
-			return hr, err
 		}
-		return hr, nil
+		return hr, err
 	})
 }

--- a/internal/definitions/sender_tokenpool.go
+++ b/internal/definitions/sender_tokenpool.go
@@ -18,7 +18,6 @@ package definitions
 
 import (
 	"context"
-
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly/internal/coremsgs"
@@ -26,15 +25,16 @@ import (
 )
 
 func (bm *definitionSender) DefineTokenPool(ctx context.Context, pool *core.TokenPoolAnnouncement, waitConfirm bool) error {
-	// Map token connector name -> broadcast name
-	if broadcastName, exists := bm.tokenBroadcastNames[pool.Pool.Connector]; exists {
-		pool.Pool.Connector = broadcastName
-	} else {
-		log.L(ctx).Infof("Could not find broadcast name for token connector: %s", pool.Pool.Connector)
-		return i18n.NewError(ctx, coremsgs.MsgInvalidConnectorName, broadcastName, "token")
-	}
 
 	if bm.multiparty {
+		// Map token connector name -> broadcast name
+		if broadcastName, exists := bm.tokenBroadcastNames[pool.Pool.Connector]; exists {
+			pool.Pool.Connector = broadcastName
+		} else {
+			log.L(ctx).Infof("Could not find broadcast name for token connector: %s", pool.Pool.Connector)
+			return i18n.NewError(ctx, coremsgs.MsgInvalidConnectorName, broadcastName, "token")
+		}
+
 		if err := pool.Pool.Validate(ctx); err != nil {
 			return err
 		}

--- a/internal/definitions/sender_tokenpool.go
+++ b/internal/definitions/sender_tokenpool.go
@@ -54,9 +54,9 @@ func (bm *definitionSender) DefineTokenPool(ctx context.Context, pool *core.Toke
 		hr, err := bm.handler.handleTokenPoolDefinition(ctx, state, pool.Pool)
 		if err != nil {
 			if innerErr := errors.Unwrap(err); innerErr != nil {
-				return HandlerResult{}, innerErr
+				return hr, innerErr
 			}
-			return HandlerResult{}, err
+			return hr, err
 		}
 		return hr, nil
 	})

--- a/internal/definitions/sender_tokenpool.go
+++ b/internal/definitions/sender_tokenpool.go
@@ -18,6 +18,7 @@ package definitions
 
 import (
 	"context"
+
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly/internal/coremsgs"

--- a/internal/definitions/sender_tokenpool.go
+++ b/internal/definitions/sender_tokenpool.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -36,7 +36,7 @@ func (bm *definitionSender) DefineTokenPool(ctx context.Context, pool *core.Toke
 		}
 
 		if err := pool.Pool.Validate(ctx); err != nil {
-			return err
+			return i18n.NewError(ctx, coremsgs.MsgDefRejectedValidateFail, "token pool", pool.Pool.ID, err)
 		}
 
 		pool.Pool.Namespace = ""

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -140,6 +140,37 @@ func TestDefineTokenPoolOk(t *testing.T) {
 	mms.AssertExpectations(t)
 }
 
+func TestDefineTokenPoolkONonMultiparty(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = false
+
+	mdm := ds.data.(*datamocks.Manager)
+	mdb := ds.database.(*databasemocks.Plugin)
+
+	pool := &core.TokenPool{
+		ID:        fftypes.NewUUID(),
+		Namespace: "ns1",
+		Name:      "mypool",
+		Type:      core.TokenTypeNonFungible,
+		Locator:   "N1",
+		Symbol:    "COIN",
+		Connector: "connector1",
+		State:     core.TokenPoolStateConfirmed,
+	}
+	poolAnnouncement := &core.TokenPoolAnnouncement{
+		Pool: pool,
+	}
+
+	mdb.On("GetTokenPoolByID", mock.Anything, mock.Anything, mock.Anything).Return(pool, nil)
+
+	err := ds.DefineTokenPool(context.Background(), poolAnnouncement, false)
+	assert.NoError(t, err)
+
+	mdm.AssertExpectations(t)
+	mdb.AssertExpectations(t)
+}
+
 func TestDefineTokenPoolNonMultipartyTokenPoolFail(t *testing.T) {
 	ds, cancel := newTestDefinitionSender(t)
 	defer cancel()

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -75,7 +75,7 @@ func TestBroadcastTokenPoolInvalidNonMultiparty(t *testing.T) {
 	}
 
 	err := ds.DefineTokenPool(context.Background(), pool, false)
-	assert.Regexp(t, "FF10403", err)
+	assert.Regexp(t, "FF00140", err)
 
 	mdm.AssertExpectations(t)
 }
@@ -100,7 +100,7 @@ func TestBroadcastTokenPoolInvalidNameMultiparty(t *testing.T) {
 	}
 
 	err := ds.DefineTokenPool(context.Background(), pool, false)
-	assert.Regexp(t, "FF10403", err)
+	assert.Regexp(t, "FF00140", err)
 
 	mdm.AssertExpectations(t)
 }

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -56,10 +56,10 @@ func TestBroadcastTokenPoolInvalid(t *testing.T) {
 	mdm.AssertExpectations(t)
 }
 
-func TestBroadcastTokenPoolInvalidNonMultiparty(t *testing.T) {
+func TestBroadcastTokenPoolInvalidMultiparty(t *testing.T) {
 	ds, cancel := newTestDefinitionSender(t)
 	defer cancel()
-	ds.multiparty = false
+	ds.multiparty = true
 
 	mdm := ds.data.(*datamocks.Manager)
 

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -56,10 +56,10 @@ func TestBroadcastTokenPoolInvalid(t *testing.T) {
 	mdm.AssertExpectations(t)
 }
 
-func TestBroadcastTokenPoolInvalidMultiparty(t *testing.T) {
+func TestBroadcastTokenPoolInvalidNonMultiparty(t *testing.T) {
 	ds, cancel := newTestDefinitionSender(t)
 	defer cancel()
-	ds.multiparty = true
+	ds.multiparty = false
 
 	mdm := ds.data.(*datamocks.Manager)
 
@@ -75,7 +75,32 @@ func TestBroadcastTokenPoolInvalidMultiparty(t *testing.T) {
 	}
 
 	err := ds.DefineTokenPool(context.Background(), pool, false)
-	assert.Regexp(t, "FF10420", err)
+	assert.Regexp(t, "FF10403", err)
+
+	mdm.AssertExpectations(t)
+}
+
+func TestBroadcastTokenPoolInvalidNameMultiparty(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	mdm := ds.data.(*datamocks.Manager)
+
+	pool := &core.TokenPoolAnnouncement{
+		Pool: &core.TokenPool{
+			ID:        fftypes.NewUUID(),
+			Namespace: "",
+			Name:      "",
+			Type:      core.TokenTypeNonFungible,
+			Locator:   "N1",
+			Symbol:    "COIN",
+			Connector: "connector1",
+		},
+	}
+
+	err := ds.DefineTokenPool(context.Background(), pool, false)
+	assert.Regexp(t, "FF10403", err)
 
 	mdm.AssertExpectations(t)
 }

--- a/test/e2e/gateway/tokens_only.go
+++ b/test/e2e/gateway/tokens_only.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/test/e2e/gateway/tokens_only.go
+++ b/test/e2e/gateway/tokens_only.go
@@ -71,6 +71,7 @@ func (suite *TokensOnlyTestSuite) TestTokensOnlyNamespaces() {
 
 	// Add the new namespace
 	data1 := e2e.ReadConfig(suite.T(), suite.testState.configFile1)
+	e2e.AddPluginBroadcastName(data1, "tokens", "testremote")
 	e2e.AddNamespace(data1, namespaceInfo)
 	e2e.WriteConfig(suite.T(), suite.testState.configFile1, data1)
 


### PR DESCRIPTION
We saw if `broadcastName` was set on a tokens plugin, token pools would fail to create within gateway namespaces:
```
[2023-03-01T20:25:10.568Z] ERROR Failed to activate token pool 'f2de67bb-5adf-4b98-ac06-7d25a19805ad': FF10272: Unknown tokens plugin 'erc20-erc721' ns=cok pid=1 role=event-manager
[2023-03-01T20:25:10.568Z] DEBUG fftokens updating operation cok:fb435cab-a2a5-4d1a-af28-f0bf84840c0b status=Failed error=FF10272: Unknown tokens plugin 'erc20-erc721' ns=cok pid=1
[2023-03-01T20:25:10.568Z] DEBUG SQL-> begin dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.568Z] DEBUG SQL<- begin dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.569Z] DEBUG SQL-> update operations dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.569Z] DEBUG SQL<- update operations affected=1 dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.569Z] DEBUG SQL-> lock cok dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.570Z] DEBUG SQL<- lock cok dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.570Z] DEBUG SQL-> insert events dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.570Z] DEBUG SQL<- insert events sequences=[9] dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.570Z] DEBUG SQL-> commit dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.573Z] DEBUG SQL<- commit dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.573Z]  INFO Emitted token_pool_op_failed event 47472d4f-70f7-4f3e-827d-a3e70c76cf72 for cok:fb435cab-a2a5-4d1a-af28-f0bf84840c0b (correlator=f2de67bb-5adf-4b98-ac06-7d25a19805ad,topic=f2de67bb-5adf-4b98-ac06-7d25a19805ad) dbtx=N1fXw8pi ns=cok pid=1
[2023-03-01T20:25:10.573Z]  INFO Inflight request 'f2de67bb-5adf-4b98-ac06-7d25a19805ad' resolved with timeout after 2068.43ms ns=cok pid=1 role=sync-async-bridge
[2023-03-01T20:25:10.573Z]  INFO <-- POST /api/v1/namespaces/cok/tokens/pools [400] (2071.90ms): FF10272: Unknown tokens plugin 'erc20-erc721' httpreq=hzG60xJW pid=1 req=Rd7exmVy
```

This is bc the definition handler doesn't know how to map the remote name back to the local name within gateway namespaces: https://github.com/hyperledger/firefly/blob/3b728534d50c0cee6ed27890114b5a4c44fcec5c/internal/definitions/handler_tokenpool.go#L36-L42

This fixes that by only using the `broadcastName` for multi-party namespaces when sending the token pool definition.