### PR TITLE
Fix spelling of "sequence" rewind and clarify API description

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -23385,7 +23385,8 @@ paths:
   /namespaces/{ns}/pins/rewind:
     post:
       description: Force a rewind of the event aggregator to a previous position,
-        to re-evaluate all unconfirmed pins since that point
+        to re-evaluate (and possibly dispatch) that pin and others after it. Only
+        accepts a sequence or batch ID for a currently undispatched pin
       operationId: postPinsRewindNamespace
       parameters:
       - description: The namespace which scopes this request
@@ -30931,7 +30932,8 @@ paths:
   /pins/rewind:
     post:
       description: Force a rewind of the event aggregator to a previous position,
-        to re-evaluate all unconfirmed pins since that point
+        to re-evaluate (and possibly dispatch) that pin and others after it. Only
+        accepts a sequence or batch ID for a currently undispatched pin
       operationId: postPinsRewind
       parameters:
       - description: Server-side request timeout (milliseconds, or set a custom suffix

--- a/internal/coremsgs/en_api_translations.go
+++ b/internal/coremsgs/en_api_translations.go
@@ -169,7 +169,7 @@ var (
 	APIEndpointsPostNewOrganization             = ffm("api.endpoints.postNewOrganization", "Registers a new org in the network")
 	APIEndpointsPostNewSubscription             = ffm("api.endpoints.postNewSubscription", "Creates a new subscription for an application to receive events from FireFly")
 	APIEndpointsPostOpRetry                     = ffm("api.endpoints.postOpRetry", "Retries a failed operation")
-	APIEndpointsPostPinsRewind                  = ffm("api.endpoints.postPinsRewind", "Force a rewind of the event aggregator to a previous position, to re-evaluate all unconfirmed pins since that point")
+	APIEndpointsPostPinsRewind                  = ffm("api.endpoints.postPinsRewind", "Force a rewind of the event aggregator to a previous position, to re-evaluate (and possibly dispatch) that pin and others after it. Only accepts a sequence or batch ID for a currently undispatched pin")
 	APIEndpointsPostTokenApproval               = ffm("api.endpoints.postTokenApproval", "Creates a token approval")
 	APIEndpointsPostTokenBurn                   = ffm("api.endpoints.postTokenBurn", "Burns some tokens")
 	APIEndpointsPostTokenMint                   = ffm("api.endpoints.postTokenMint", "Mints some tokens")

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -552,7 +552,7 @@ func (or *orchestrator) Authorize(ctx context.Context, authReq *fftypes.AuthReq)
 func (or *orchestrator) RewindPins(ctx context.Context, rewind *core.PinRewind) (*core.PinRewind, error) {
 	if rewind.Sequence > 0 {
 		fb := database.PinQueryFactory.NewFilter(ctx)
-		if pins, _, err := or.GetPins(ctx, fb.And(fb.Eq("seq", rewind.Sequence))); err != nil {
+		if pins, _, err := or.GetPins(ctx, fb.And(fb.Eq("sequence", rewind.Sequence))); err != nil {
 			return nil, err
 		} else if len(pins) > 0 {
 			rewind.Batch = pins[0].Batch


### PR DESCRIPTION
Fixes #1200 

I also clarified the API description to point out the important caveat that the aggregator will only acknowledge a rewind to an undispatched pin. For error recovery purposes, there may be a separate piece of work to be able to force a rewind to a pin even if it's already dispatched.

Also, it's worth noting that there's a double lookup in the case of a "sequence" based rewind - we resolve the sequence number to a batch (in `orchestrator.RewindPins`), then resolve the batch back to a sequence number (in `aggregator.rewindOffchainBatches`). It seems to work well enough, but there's some room for a more direct rewind path.