### PR TITLE
Ensure cached transaction gets updated with new blockchain IDs

### DIFF
--- a/internal/txcommon/txcommon.go
+++ b/internal/txcommon/txcommon.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -138,12 +138,13 @@ func (t *transactionHelper) PersistTransaction(ctx context.Context, id *fftypes.
 			return false, nil
 		}
 
-		newBlockchainIDs, changed := tx.BlockchainIDs.AddToSortedSet(blockchainTXID)
+		var changed bool
+		tx.BlockchainIDs, changed = tx.BlockchainIDs.AddToSortedSet(blockchainTXID)
 		if !changed {
 			return true, nil
 		}
 
-		if err = t.database.UpdateTransaction(ctx, t.namespace, tx.ID, database.TransactionQueryFactory.NewUpdate(ctx).Set("blockchainids", newBlockchainIDs)); err != nil {
+		if err = t.database.UpdateTransaction(ctx, t.namespace, tx.ID, database.TransactionQueryFactory.NewUpdate(ctx).Set("blockchainids", tx.BlockchainIDs)); err != nil {
 			return false, err
 		}
 	} else {

--- a/internal/txcommon/txcommon_test.go
+++ b/internal/txcommon/txcommon_test.go
@@ -178,7 +178,7 @@ func TestPersistTransactionNew(t *testing.T) {
 
 }
 
-func TestPersistTransactionNewInserTFail(t *testing.T) {
+func TestPersistTransactionNewInsertFail(t *testing.T) {
 
 	mdi := &databasemocks.Plugin{}
 	mdm := &datamocks.Manager{}
@@ -205,7 +205,8 @@ func TestPersistTransactionExistingAddBlockchainID(t *testing.T) {
 	mdm := &datamocks.Manager{}
 	ctx := context.Background()
 	cmi := &cachemocks.Manager{}
-	cmi.On("GetCache", mock.Anything).Return(cache.NewUmanagedCache(ctx, 100, 5*time.Minute), nil)
+	cache := cache.NewUmanagedCache(ctx, 100, 5*time.Minute)
+	cmi.On("GetCache", mock.Anything).Return(cache, nil)
 	txHelper, _ := NewTransactionHelper(ctx, "ns1", mdi, mdm, cmi)
 
 	txid := fftypes.NewUUID()
@@ -221,6 +222,9 @@ func TestPersistTransactionExistingAddBlockchainID(t *testing.T) {
 	valid, err := txHelper.PersistTransaction(ctx, txid, core.TransactionTypeBatchPin, "0x222222")
 	assert.NoError(t, err)
 	assert.True(t, valid)
+
+	cachedTX := cache.Get(txid.String()).(*core.Transaction)
+	assert.Equal(t, fftypes.FFStringArray{"0x111111", "0x222222"}, cachedTX.BlockchainIDs)
 
 	mdi.AssertExpectations(t)
 


### PR DESCRIPTION
There are multiple paths that record the blockchainID for a transaction. Along this path, we were updating the column in the database but not the cache - resulting in this field being intermittently out of sync.