### PR TITLE
Propagate API context to announce in sync token pool creation cases

### DIFF
--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -78,7 +78,7 @@ type EventManager interface {
 	SharedStorageBlobDownloaded(ss sharedstorage.Plugin, hash fftypes.Bytes32, size int64, payloadRef string, dataID *fftypes.UUID)
 
 	// Bound token callbacks
-	TokenPoolCreated(ti tokens.Plugin, pool *tokens.TokenPool) error
+	TokenPoolCreated(ctx context.Context /* allows security context to be propagated when called in-line with the send TX */, ti tokens.Plugin, pool *tokens.TokenPool) error
 	TokensTransferred(ti tokens.Plugin, transfer *tokens.TokenTransfer) error
 	TokensApproved(ti tokens.Plugin, approval *tokens.TokenApproval) error
 

--- a/internal/events/token_pool_created_test.go
+++ b/internal/events/token_pool_created_test.go
@@ -55,7 +55,7 @@ func TestTokenPoolCreatedIgnore(t *testing.T) {
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil, nil)
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 }
@@ -79,7 +79,7 @@ func TestTokenPoolCreatedIgnoreNoTX(t *testing.T) {
 
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 }
 
@@ -134,7 +134,7 @@ func TestTokenPoolCreatedConfirm(t *testing.T) {
 		return e.Type == core.EventTypePoolConfirmed && *e.Reference == *storedPool.ID
 	})).Return(nil).Once()
 
-	err := em.TokenPoolCreated(mti, chainPool)
+	err := em.TokenPoolCreated(em.ctx, mti, chainPool)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "ERC1155", storedPool.Standard)
@@ -176,7 +176,7 @@ func TestTokenPoolCreatedAlreadyConfirmed(t *testing.T) {
 
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(storedPool, nil)
 
-	err := em.TokenPoolCreated(mti, chainPool)
+	err := em.TokenPoolCreated(em.ctx, mti, chainPool)
 	assert.NoError(t, err)
 
 }
@@ -220,7 +220,7 @@ func TestTokenPoolCreatedConfirmFailBadSymbol(t *testing.T) {
 		ID: opID,
 	}}, nil, nil)
 
-	err := em.TokenPoolCreated(mti, chainPool)
+	err := em.TokenPoolCreated(em.ctx, mti, chainPool)
 	assert.NoError(t, err)
 
 }
@@ -364,7 +364,7 @@ func TestTokenPoolCreatedAnnounce(t *testing.T) {
 		return pool.Pool.Namespace == "ns1" && pool.Pool.Name == "my-pool" && *pool.Pool.ID == *poolID
 	}), false).Return(nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 	mti.AssertExpectations(t)
@@ -415,7 +415,7 @@ func TestTokenPoolCreatedAnnounceBadInterface(t *testing.T) {
 		return pool.Locator == "123" && pool.Name == "my-pool"
 	})).Return(fmt.Errorf("pop"))
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.EqualError(t, err, "pop")
 
 	mti.AssertExpectations(t)
@@ -453,7 +453,7 @@ func TestTokenPoolCreatedAnnounceBadOpInputID(t *testing.T) {
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil)
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 }
@@ -492,7 +492,7 @@ func TestTokenPoolCreatedAnnounceBadOpInputNS(t *testing.T) {
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil)
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 }
@@ -536,7 +536,7 @@ func TestTokenPoolCreatedAnnounceBadSymbol(t *testing.T) {
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(nil, nil, fmt.Errorf("pop")).Once()
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil).Once()
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 	mti.AssertExpectations(t)

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -70,7 +70,7 @@ func (cb *callbacks) OperationUpdate(ctx context.Context, nsOpID string, status 
 func (cb *callbacks) TokenPoolCreated(ctx context.Context, pool *tokens.TokenPool) error {
 	// Deliver token pool creation events to every handler
 	for _, handler := range cb.handlers {
-		if err := handler.TokenPoolCreated(cb.plugin, pool); err != nil {
+		if err := handler.TokenPoolCreated(ctx, cb.plugin, pool); err != nil {
 			return err
 		}
 	}

--- a/mocks/eventmocks/event_manager.go
+++ b/mocks/eventmocks/event_manager.go
@@ -288,13 +288,13 @@ func (_m *EventManager) SubscriptionUpdates() chan<- *fftypes.UUID {
 	return r0
 }
 
-// TokenPoolCreated provides a mock function with given fields: ti, pool
-func (_m *EventManager) TokenPoolCreated(ti tokens.Plugin, pool *tokens.TokenPool) error {
-	ret := _m.Called(ti, pool)
+// TokenPoolCreated provides a mock function with given fields: ctx, ti, pool
+func (_m *EventManager) TokenPoolCreated(ctx context.Context, ti tokens.Plugin, pool *tokens.TokenPool) error {
+	ret := _m.Called(ctx, ti, pool)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(tokens.Plugin, *tokens.TokenPool) error); ok {
-		r0 = rf(ti, pool)
+	if rf, ok := ret.Get(0).(func(context.Context, tokens.Plugin, *tokens.TokenPool) error); ok {
+		r0 = rf(ctx, ti, pool)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/tokenmocks/callbacks.go
+++ b/mocks/tokenmocks/callbacks.go
@@ -3,6 +3,8 @@
 package tokenmocks
 
 import (
+	context "context"
+
 	tokens "github.com/hyperledger/firefly/pkg/tokens"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -12,13 +14,13 @@ type Callbacks struct {
 	mock.Mock
 }
 
-// TokenPoolCreated provides a mock function with given fields: plugin, pool
-func (_m *Callbacks) TokenPoolCreated(plugin tokens.Plugin, pool *tokens.TokenPool) error {
-	ret := _m.Called(plugin, pool)
+// TokenPoolCreated provides a mock function with given fields: ctx, plugin, pool
+func (_m *Callbacks) TokenPoolCreated(ctx context.Context, plugin tokens.Plugin, pool *tokens.TokenPool) error {
+	ret := _m.Called(ctx, plugin, pool)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(tokens.Plugin, *tokens.TokenPool) error); ok {
-		r0 = rf(plugin, pool)
+	if rf, ok := ret.Get(0).(func(context.Context, tokens.Plugin, *tokens.TokenPool) error); ok {
+		r0 = rf(ctx, plugin, pool)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/tokens/plugin.go
+++ b/pkg/tokens/plugin.go
@@ -81,7 +81,11 @@ type Callbacks interface {
 	// submitted by us, or by any other authorized party in the network.
 	//
 	// Error should only be returned in shutdown scenarios
-	TokenPoolCreated(plugin Plugin, pool *TokenPool) error
+	//
+	// Note: The context is passed on this callback (unlike most callbacks), as it might be
+	//       involved in-line with the original REST API call in the special case of the
+	//       submitter.
+	TokenPoolCreated(ctx context.Context, plugin Plugin, pool *TokenPool) error
 
 	// TokensTransferred notifies on a transfer between token accounts.
 	//


### PR DESCRIPTION
When a token pool is created, the token connector can either confirm the token pool:
1. Synchronously if the token pool exists already on-chain - with a `200` return code
2. Asynchronously when using a factory contract - with a `202` return code, followed at some point with a websocket event

At this confirm stage, in a multi-party enabled namespace, the token pool is currently automatically published via .broadcast to all members of the network.

This automatic publishing occurs on the organization signing key, which might be different to the original key used to create the token pool on-chain (in the asynchronous case). This automated publishing is a little problematic for authentication checking based on the REST API context of the original token pool creation in the async case, because it is an asynchronous side effect of another REST API call.

In the synchronous case it's not problematic as it happens in-line with the REST API call. However, the code does not propagate the right context through the callbacks correctly to allow address resolution to occur with the right security context - meaning it might fail.

So this PR makes the small change to propagate that REST API context down into the callback in the synchronous case, such that the 2nd address resolution can occur correctly.

> This PR does **not** attempt to address the wider concern that publishing automatically as an asynchronous side-effect of creating a token pool, is not necessarily the right answer for all business networks and security models. That is a wider consideration that the community should consider outside the scope of this PR.