### PR TITLE
Ensure that when we broadcast we use the org identity, not the default NS identity

### DIFF
--- a/internal/definitions/sender.go
+++ b/internal/definitions/sender.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -105,7 +105,14 @@ func (bm *definitionSender) Name() string {
 }
 
 func (bm *definitionSender) sendDefinitionDefault(ctx context.Context, def core.Definition, tag string, waitConfirm bool) (msg *core.Message, err error) {
-	return bm.sendDefinition(ctx, def, &core.SignerRef{ /* resolve to node default */ }, tag, waitConfirm)
+	org, err := bm.identity.GetMultipartyRootOrg(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return bm.sendDefinition(ctx, def, &core.SignerRef{ /* resolve to node default */
+		Author: org.DID,
+	}, tag, waitConfirm)
 }
 
 func (bm *definitionSender) sendDefinition(ctx context.Context, def core.Definition, signingIdentity *core.SignerRef, tag string, waitConfirm bool) (msg *core.Message, err error) {

--- a/internal/definitions/sender_contracts_test.go
+++ b/internal/definitions/sender_contracts_test.go
@@ -62,7 +62,7 @@ func TestDefineFFIFail(t *testing.T) {
 	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
-	mim.On("ResolveInputSigningIdentity", context.Background(), mock.Anything).Return(fmt.Errorf("pop"))
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(nil, fmt.Errorf("pop"))
 
 	err := ds.DefineFFI(context.Background(), ffi, false)
 	assert.EqualError(t, err, "pop")
@@ -82,6 +82,11 @@ func TestDefineFFIOk(t *testing.T) {
 	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", context.Background(), mock.Anything).Return(nil)
 
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
@@ -137,7 +142,7 @@ func TestDefineContractAPIFail(t *testing.T) {
 	mcm.On("ResolveContractAPI", context.Background(), url, api).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
-	mim.On("ResolveInputSigningIdentity", context.Background(), mock.Anything).Return(fmt.Errorf("pop"))
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(nil, fmt.Errorf("pop"))
 
 	err := ds.DefineContractAPI(context.Background(), url, api, false)
 	assert.EqualError(t, err, "pop")
@@ -158,6 +163,11 @@ func TestDefineContractAPIOk(t *testing.T) {
 	mcm.On("ResolveContractAPI", context.Background(), url, api).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", context.Background(), mock.Anything).Return(nil)
 
 	mbm := ds.broadcast.(*broadcastmocks.Manager)

--- a/internal/definitions/sender_datatype_test.go
+++ b/internal/definitions/sender_datatype_test.go
@@ -48,6 +48,11 @@ func TestBroadcastDatatypeBadValue(t *testing.T) {
 	mdm := ds.data.(*datamocks.Manager)
 	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
 	mim := ds.identity.(*identitymanagermocks.Manager)
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
 	err := ds.DefineDatatype(context.Background(), &core.Datatype{
 		Namespace: "ns1",
@@ -91,6 +96,11 @@ func TestBroadcastOk(t *testing.T) {
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
 	mms := &syncasyncmocks.Sender{}
 
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
 	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
 	mbm.On("NewBroadcast", mock.Anything).Return(mms)

--- a/internal/definitions/sender_test.go
+++ b/internal/definitions/sender_test.go
@@ -73,6 +73,11 @@ func TestCreateDefinitionConfirm(t *testing.T) {
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
 	mms := &syncasyncmocks.Sender{}
 
+	mim.On("GetMultipartyRootOrg", ds.ctx).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
 	mbm.On("NewBroadcast", mock.Anything).Return(mms)
 	mms.On("SendAndWait", mock.Anything).Return(nil)
@@ -94,6 +99,11 @@ func TestCreateDatatypeDefinitionAsNodeConfirm(t *testing.T) {
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
 	mms := &syncasyncmocks.Sender{}
 
+	mim.On("GetMultipartyRootOrg", ds.ctx).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
 	mbm.On("NewBroadcast", mock.Anything).Return(mms)
 	mms.On("SendAndWait", mock.Anything).Return(nil)

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -127,11 +127,16 @@ func TestDefineTokenPoolOk(t *testing.T) {
 		},
 	}
 
+	mim.On("GetMultipartyRootOrg", ds.ctx).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
 	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
 	mbm.On("NewBroadcast", mock.Anything).Return(mms)
-	mms.On("Send", context.Background()).Return(nil)
+	mms.On("Send", ds.ctx).Return(nil)
 
-	err := ds.DefineTokenPool(context.Background(), pool, false)
+	err := ds.DefineTokenPool(ds.ctx, pool, false)
 	assert.NoError(t, err)
 
 	mdm.AssertExpectations(t)

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -78,7 +78,7 @@ type EventManager interface {
 	SharedStorageBlobDownloaded(ss sharedstorage.Plugin, hash fftypes.Bytes32, size int64, payloadRef string, dataID *fftypes.UUID)
 
 	// Bound token callbacks
-	TokenPoolCreated(ti tokens.Plugin, pool *tokens.TokenPool) error
+	TokenPoolCreated(ctx context.Context /* allows security context to be propagated when called in-line with the send TX */, ti tokens.Plugin, pool *tokens.TokenPool) error
 	TokensTransferred(ti tokens.Plugin, transfer *tokens.TokenTransfer) error
 	TokensApproved(ti tokens.Plugin, approval *tokens.TokenApproval) error
 

--- a/internal/events/token_pool_created_test.go
+++ b/internal/events/token_pool_created_test.go
@@ -55,7 +55,7 @@ func TestTokenPoolCreatedIgnore(t *testing.T) {
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil, nil)
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 }
@@ -79,7 +79,7 @@ func TestTokenPoolCreatedIgnoreNoTX(t *testing.T) {
 
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 }
 
@@ -134,7 +134,7 @@ func TestTokenPoolCreatedConfirm(t *testing.T) {
 		return e.Type == core.EventTypePoolConfirmed && *e.Reference == *storedPool.ID
 	})).Return(nil).Once()
 
-	err := em.TokenPoolCreated(mti, chainPool)
+	err := em.TokenPoolCreated(em.ctx, mti, chainPool)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "ERC1155", storedPool.Standard)
@@ -176,7 +176,7 @@ func TestTokenPoolCreatedAlreadyConfirmed(t *testing.T) {
 
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(storedPool, nil)
 
-	err := em.TokenPoolCreated(mti, chainPool)
+	err := em.TokenPoolCreated(em.ctx, mti, chainPool)
 	assert.NoError(t, err)
 
 }
@@ -220,7 +220,7 @@ func TestTokenPoolCreatedConfirmFailBadSymbol(t *testing.T) {
 		ID: opID,
 	}}, nil, nil)
 
-	err := em.TokenPoolCreated(mti, chainPool)
+	err := em.TokenPoolCreated(em.ctx, mti, chainPool)
 	assert.NoError(t, err)
 
 }
@@ -364,7 +364,7 @@ func TestTokenPoolCreatedAnnounce(t *testing.T) {
 		return pool.Pool.Namespace == "ns1" && pool.Pool.Name == "my-pool" && *pool.Pool.ID == *poolID
 	}), false).Return(nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 	mti.AssertExpectations(t)
@@ -415,7 +415,7 @@ func TestTokenPoolCreatedAnnounceBadInterface(t *testing.T) {
 		return pool.Locator == "123" && pool.Name == "my-pool"
 	})).Return(fmt.Errorf("pop"))
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.EqualError(t, err, "pop")
 
 	mti.AssertExpectations(t)
@@ -453,7 +453,7 @@ func TestTokenPoolCreatedAnnounceBadOpInputID(t *testing.T) {
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil)
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 }
@@ -492,7 +492,7 @@ func TestTokenPoolCreatedAnnounceBadOpInputNS(t *testing.T) {
 	em.mdi.On("GetTokenPoolByLocator", em.ctx, "ns1", "erc1155", "123").Return(nil, nil)
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil)
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 }
@@ -536,7 +536,7 @@ func TestTokenPoolCreatedAnnounceBadSymbol(t *testing.T) {
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(nil, nil, fmt.Errorf("pop")).Once()
 	em.mdi.On("GetOperations", em.ctx, "ns1", mock.Anything).Return(operations, nil, nil).Once()
 
-	err := em.TokenPoolCreated(mti, pool)
+	err := em.TokenPoolCreated(em.ctx, mti, pool)
 	assert.NoError(t, err)
 
 	mti.AssertExpectations(t)

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -70,7 +70,7 @@ func (cb *callbacks) OperationUpdate(ctx context.Context, nsOpID string, status 
 func (cb *callbacks) TokenPoolCreated(ctx context.Context, pool *tokens.TokenPool) error {
 	// Deliver token pool creation events to every handler
 	for _, handler := range cb.handlers {
-		if err := handler.TokenPoolCreated(cb.plugin, pool); err != nil {
+		if err := handler.TokenPoolCreated(ctx, cb.plugin, pool); err != nil {
 			return err
 		}
 	}

--- a/mocks/eventmocks/event_manager.go
+++ b/mocks/eventmocks/event_manager.go
@@ -288,13 +288,13 @@ func (_m *EventManager) SubscriptionUpdates() chan<- *fftypes.UUID {
 	return r0
 }
 
-// TokenPoolCreated provides a mock function with given fields: ti, pool
-func (_m *EventManager) TokenPoolCreated(ti tokens.Plugin, pool *tokens.TokenPool) error {
-	ret := _m.Called(ti, pool)
+// TokenPoolCreated provides a mock function with given fields: ctx, ti, pool
+func (_m *EventManager) TokenPoolCreated(ctx context.Context, ti tokens.Plugin, pool *tokens.TokenPool) error {
+	ret := _m.Called(ctx, ti, pool)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(tokens.Plugin, *tokens.TokenPool) error); ok {
-		r0 = rf(ti, pool)
+	if rf, ok := ret.Get(0).(func(context.Context, tokens.Plugin, *tokens.TokenPool) error); ok {
+		r0 = rf(ctx, ti, pool)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/tokenmocks/callbacks.go
+++ b/mocks/tokenmocks/callbacks.go
@@ -3,6 +3,8 @@
 package tokenmocks
 
 import (
+	context "context"
+
 	tokens "github.com/hyperledger/firefly/pkg/tokens"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -12,13 +14,13 @@ type Callbacks struct {
 	mock.Mock
 }
 
-// TokenPoolCreated provides a mock function with given fields: plugin, pool
-func (_m *Callbacks) TokenPoolCreated(plugin tokens.Plugin, pool *tokens.TokenPool) error {
-	ret := _m.Called(plugin, pool)
+// TokenPoolCreated provides a mock function with given fields: ctx, plugin, pool
+func (_m *Callbacks) TokenPoolCreated(ctx context.Context, plugin tokens.Plugin, pool *tokens.TokenPool) error {
+	ret := _m.Called(ctx, plugin, pool)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(tokens.Plugin, *tokens.TokenPool) error); ok {
-		r0 = rf(plugin, pool)
+	if rf, ok := ret.Get(0).(func(context.Context, tokens.Plugin, *tokens.TokenPool) error); ok {
+		r0 = rf(ctx, plugin, pool)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/tokens/plugin.go
+++ b/pkg/tokens/plugin.go
@@ -81,7 +81,11 @@ type Callbacks interface {
 	// submitted by us, or by any other authorized party in the network.
 	//
 	// Error should only be returned in shutdown scenarios
-	TokenPoolCreated(plugin Plugin, pool *TokenPool) error
+	//
+	// Note: The context is passed on this callback (unlike most callbacks), as it might be
+	//       involved in-line with the original REST API call in the special case of the
+	//       submitter.
+	TokenPoolCreated(ctx context.Context, plugin Plugin, pool *TokenPool) error
 
 	// TokensTransferred notifies on a transfer between token accounts.
 	//


### PR DESCRIPTION
Since 1.1 we've had both an org identity (required for mulit-party), and a default namespace identity (optional).
The code for definition broadcasts must use the org identity for that broadcast to be accepted, but the code was using the same priority as generic API calls - which use the NS default identity in preference.

This PR updates that so it's always the org identity, and the call will not fall-back to the default.

> Found this while discussing https://github.com/hyperledger/firefly/pull/1222 and hence in a PR chain with that change