### PR TITLE
Use the channel and signer to query transaction details from fabconnect

### DIFF
--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -914,7 +914,7 @@ func (f *Fabric) GetAndConvertDeprecatedContractConfig(ctx context.Context) (loc
 }
 
 func (f *Fabric) GetTransactionStatus(ctx context.Context, operation *core.Operation) (interface{}, error) {
-	txnID := (&core.PreparedOperation{ID: operation.ID, Namespace: operation.Namespace}).NamespacedIDString()
+	txHash := operation.Output.GetString("transactionHash")
 
 	defaultChannel := f.fabconnectConf.GetString(FabconnectConfigDefaultChannel)
 	if defaultChannel == "" {
@@ -925,7 +925,7 @@ func (f *Fabric) GetTransactionStatus(ctx context.Context, operation *core.Opera
 		return nil, i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
 	}
 
-	transactionRequestPath := fmt.Sprintf("/transactions/%s", txnID)
+	transactionRequestPath := fmt.Sprintf("/transactions/%s", txHash)
 	client := f.client
 	var resErr fabError
 	var statusResponse fftypes.JSONObject

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -2731,6 +2731,10 @@ func TestGetTransactionStatus(t *testing.T) {
 	defer cancel()
 	httpmock.ActivateNonDefault(e.client.GetClient())
 	defer httpmock.DeactivateAndReset()
+	resetConf(e)
+
+	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
+	utFabconnectConf.Set(FabconnectConfigDefaultChannel, "firefly")
 
 	op := &core.Operation{
 		Namespace: "ns1",
@@ -2752,6 +2756,10 @@ func TestGetTransactionStatusNoResult(t *testing.T) {
 	defer cancel()
 	httpmock.ActivateNonDefault(e.client.GetClient())
 	defer httpmock.DeactivateAndReset()
+	resetConf(e)
+
+	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
+	utFabconnectConf.Set(FabconnectConfigDefaultChannel, "firefly")
 
 	op := &core.Operation{
 		Namespace: "ns1",
@@ -2773,6 +2781,10 @@ func TestGetTransactionStatusBadResult(t *testing.T) {
 	defer cancel()
 	httpmock.ActivateNonDefault(e.client.GetClient())
 	defer httpmock.DeactivateAndReset()
+	resetConf(e)
+
+	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
+	utFabconnectConf.Set(FabconnectConfigDefaultChannel, "firefly")
 
 	op := &core.Operation{
 		Namespace: "ns1",

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -2736,12 +2736,13 @@ func TestGetTransactionStatus(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigDefaultChannel, "firefly")
 
+	output := make(map[string]interface{}, 0)
+	output["transactionHash"] = "7cd2549e310898ceb5f8d15112e74e0395c2f7ccd434293cd29cdb6bc358e85a"
 	op := &core.Operation{
-		Namespace: "ns1",
-		ID:        fftypes.MustParseUUID("9ffc50ff-6bfe-4502-adc7-93aea54cc059"),
+		Output: output,
 	}
 
-	httpmock.RegisterResponder("GET", `http://localhost:12345/transactions/ns1:9ffc50ff-6bfe-4502-adc7-93aea54cc059`,
+	httpmock.RegisterResponder("GET", `http://localhost:12345/transactions/7cd2549e310898ceb5f8d15112e74e0395c2f7ccd434293cd29cdb6bc358e85a?fly-channel=firefly&fly-signer=signer001`,
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponderOrPanic(200, make(map[string]interface{}))(req)
 		})
@@ -2761,12 +2762,13 @@ func TestGetTransactionStatusNoResult(t *testing.T) {
 	utFabconnectConf.Set(FabconnectConfigSigner, "signer001")
 	utFabconnectConf.Set(FabconnectConfigDefaultChannel, "firefly")
 
+	output := make(map[string]interface{}, 0)
+	output["transactionHash"] = "7cd2549e310898ceb5f8d15112e74e0395c2f7ccd434293cd29cdb6bc358e85a"
 	op := &core.Operation{
-		Namespace: "ns1",
-		ID:        fftypes.MustParseUUID("9ffc50ff-6bfe-4502-adc7-93aea54cc059"),
+		Output: output,
 	}
 
-	httpmock.RegisterResponder("GET", `http://localhost:12345/transactions/ns1:9ffc50ff-6bfe-4502-adc7-93aea54cc059`,
+	httpmock.RegisterResponder("GET", `http://localhost:12345/transactions/7cd2549e310898ceb5f8d15112e74e0395c2f7ccd434293cd29cdb6bc358e85a?fly-channel=firefly&fly-signer=signer001`,
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponderOrPanic(404, make(map[string]interface{}))(req)
 		})

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -278,4 +278,5 @@ var (
 	MsgMissingNamespace                   = ffe("FF10437", "Missing namespace in request", 400)
 	MsgDeprecatedResetWithAutoReload      = ffe("FF10438", "The deprecated reset API cannot be used when dynamic config reload is enabled", 409)
 	MsgConfigArrayVsRawConfigMismatch     = ffe("FF10439", "Error processing configuration - mismatch between raw and processed array lengths")
+	MsgDefaultChannelNotConfigured        = ffe("FF10440", "No default channel configured for this namespace", 400)
 )


### PR DESCRIPTION
Closes https://github.com/hyperledger/firefly/issues/1206

Screenshot of a fabric operation with these changes:

![image](https://user-images.githubusercontent.com/6599269/226379073-5d5cb1eb-6b1c-457f-9eb1-0b185d7c26e1.png)
