### PR TITLE
Add "intent" to address resolver plugin interface and API

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -95,7 +95,7 @@ nav_order: 2
 |retainOriginal|When true the original pre-resolved string is retained after the lookup, and passed down to Ethconnect as the from address|`boolean`|`<nil>`
 |tlsHandshakeTimeout|The maximum amount of time to wait for a successful TLS handshake|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
 |url|The URL of the Address Resolver|`string`|`<nil>`
-|urlTemplate|The URL Go template string to use when calling the Address Resolver|[Go Template](https://pkg.go.dev/text/template) `string`|`<nil>`
+|urlTemplate|The URL Go template string to use when calling the Address Resolver. The template input contains '.Key' and '.Intent' string variables|[Go Template](https://pkg.go.dev/text/template) `string`|`<nil>`
 
 ## blockchain.ethereum.addressResolver.auth
 
@@ -820,7 +820,7 @@ nav_order: 2
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
 |alwaysResolve|Causes the address resolver to be invoked on every API call that submits a signing key, regardless of whether the input string conforms to an 0x address. Also disables any result caching|`boolean`|`<nil>`
-|bodyTemplate|The body go template string to use when making HTTP requests|[Go Template](https://pkg.go.dev/text/template) `string`|`<nil>`
+|bodyTemplate|The body go template string to use when making HTTP requests. The template input contains '.Key' and '.Intent' string variables.|[Go Template](https://pkg.go.dev/text/template) `string`|`<nil>`
 |connectionTimeout|The maximum amount of time that a connection is allowed to remain with no data transmitted|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |expectContinueTimeout|See [ExpectContinueTimeout in the Go docs](https://pkg.go.dev/net/http#Transport)|[`time.Duration`](https://pkg.go.dev/time#Duration)|`1s`
 |headers|Adds custom headers to HTTP requests|`string`|`<nil>`
@@ -833,7 +833,7 @@ nav_order: 2
 |retainOriginal|When true the original pre-resolved string is retained after the lookup, and passed down to Ethconnect as the from address|`boolean`|`<nil>`
 |tlsHandshakeTimeout|The maximum amount of time to wait for a successful TLS handshake|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
 |url|The URL of the Address Resolver|`string`|`<nil>`
-|urlTemplate|The URL Go template string to use when calling the Address Resolver|[Go Template](https://pkg.go.dev/text/template) `string`|`<nil>`
+|urlTemplate|The URL Go template string to use when calling the Address Resolver. The template input contains '.Key' and '.Intent' string variables.|[Go Template](https://pkg.go.dev/text/template) `string`|`<nil>`
 
 ## plugins.blockchain[].ethereum.addressResolver.auth
 

--- a/internal/apiserver/route_post_verifiers_resolve.go
+++ b/internal/apiserver/route_post_verifiers_resolve.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -36,7 +37,9 @@ var postVerifiersResolve = &ffapi.Route{
 	JSONOutputCodes: []int{http.StatusOK},
 	Extensions: &coreExtensions{
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
-			return cr.or.Identity().ResolveInputVerifierRef(cr.ctx, r.Input.(*core.VerifierRef))
+			return cr.or.Identity().ResolveInputVerifierRef(cr.ctx, r.Input.(*core.VerifierRef),
+				blockchain.ResolveKeyIntentLookup, /* This is special - as we are not actually submitting a signing request */
+			)
 		},
 	},
 }

--- a/internal/apiserver/route_post_verifiers_resolve_test.go
+++ b/internal/apiserver/route_post_verifiers_resolve_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly/mocks/identitymanagermocks"
+	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -40,7 +41,7 @@ func TestPostVerifiersResolve(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	im.On("ResolveInputVerifierRef", mock.Anything, mock.AnythingOfType("*core.VerifierRef")).
+	im.On("ResolveInputVerifierRef", mock.Anything, mock.AnythingOfType("*core.VerifierRef"), blockchain.ResolveKeyIntentLookup).
 		Return(&core.VerifierRef{}, nil)
 	r.ServeHTTP(res, req)
 

--- a/internal/blockchain/ethereum/address_resolver.go
+++ b/internal/blockchain/ethereum/address_resolver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hyperledger/firefly/internal/cache"
 	"github.com/hyperledger/firefly/internal/coreconfig"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/pkg/blockchain"
 )
 
 // addressResolver is a REST-pluggable interface to allow arbitrary strings that reference
@@ -49,7 +50,8 @@ type addressResolver struct {
 }
 
 type addressResolverInserts struct {
-	Key string
+	Key    string
+	Intent blockchain.ResolveKeyIntent
 }
 
 func newAddressResolver(ctx context.Context, localConfig config.Section, cacheManager cache.Manager, enableCache bool) (ar *addressResolver, err error) {
@@ -90,7 +92,7 @@ func newAddressResolver(ctx context.Context, localConfig config.Section, cacheMa
 	return ar, nil
 }
 
-func (ar *addressResolver) ResolveInputSigningKey(ctx context.Context, keyDescriptor string) (string, error) {
+func (ar *addressResolver) ResolveSigningKey(ctx context.Context, keyDescriptor string, intent blockchain.ResolveKeyIntent) (string, error) {
 
 	if ar.cache != nil {
 		if cached := ar.cache.GetString(keyDescriptor); cached != "" {
@@ -99,7 +101,8 @@ func (ar *addressResolver) ResolveInputSigningKey(ctx context.Context, keyDescri
 	}
 
 	inserts := &addressResolverInserts{
-		Key: keyDescriptor,
+		Key:    keyDescriptor,
+		Intent: intent,
 	}
 
 	urlStr := &strings.Builder{}

--- a/internal/blockchain/ethereum/config.go
+++ b/internal/blockchain/ethereum/config.go
@@ -60,9 +60,9 @@ const (
 	AddressResolverRetainOriginal = "retainOriginal"
 	// AddressResolverMethod the HTTP method to use to call the address resolver (default GET)
 	AddressResolverMethod = "method"
-	// AddressResolverURLTemplate the URL go template string to use when calling the address resolver
+	// AddressResolverURLTemplate the URL go template string to use when calling the address resolver - a ".intent" string can be used in the go template
 	AddressResolverURLTemplate = "urlTemplate"
-	// AddressResolverBodyTemplate the body go template string to use when calling the address resolver
+	// AddressResolverBodyTemplate the body go template string to use when calling the address resolver - a ".intent" string can be used in the go template
 	AddressResolverBodyTemplate = "bodyTemplate"
 	// AddressResolverResponseField the name of a JSON field that is provided in the response, that contains the ethereum address (default "address")
 	AddressResolverResponseField = "responseField"

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -498,7 +498,7 @@ func formatEthAddress(ctx context.Context, key string) (string, error) {
 	return "", i18n.NewError(ctx, coremsgs.MsgInvalidEthAddress)
 }
 
-func (e *Ethereum) ResolveInputSigningKey(ctx context.Context, key string) (resolved string, err error) {
+func (e *Ethereum) ResolveSigningKey(ctx context.Context, key string, intent blockchain.ResolveKeyIntent) (resolved string, err error) {
 	if !e.addressResolveAlways {
 		// If there's no address resolver plugin, or addressResolveAlways is false,
 		// we check if it's already an ethereum address - in which case we can just return it.
@@ -507,7 +507,7 @@ func (e *Ethereum) ResolveInputSigningKey(ctx context.Context, key string) (reso
 	if e.addressResolveAlways || (err != nil && e.addressResolver != nil) {
 		// Either it's not a valid ethereum address,
 		// or we've been configured to invoke the address resolver on every call
-		resolved, err = e.addressResolver.ResolveInputSigningKey(ctx, key)
+		resolved, err = e.addressResolver.ResolveSigningKey(ctx, key, intent)
 		if err == nil {
 			log.L(ctx).Infof("Key '%s' resolved to '%s'", key, resolved)
 			return resolved, nil

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -1113,10 +1113,10 @@ func TestVerifyEthAddress(t *testing.T) {
 	e, cancel := newTestEthereum()
 	defer cancel()
 
-	_, err := e.ResolveInputSigningKey(context.Background(), "0x12345")
+	_, err := e.ResolveSigningKey(context.Background(), "0x12345", blockchain.ResolveKeyIntentSign)
 	assert.Regexp(t, "FF10141", err)
 
-	key, err := e.ResolveInputSigningKey(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6")
+	key, err := e.ResolveSigningKey(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6", blockchain.ResolveKeyIntentSign)
 	assert.NoError(t, err)
 	assert.Equal(t, "0x2a7c9d5248681ce6c393117e641ad037f5c079f6", key)
 

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -499,7 +499,11 @@ func (f *Fabric) eventLoop() {
 	}
 }
 
-func (f *Fabric) ResolveInputSigningKey(ctx context.Context, signingKeyInput string) (string, error) {
+func (f *Fabric) ResolveSigningKey(ctx context.Context, signingKeyInput string, intent blockchain.ResolveKeyIntent) (string, error) {
+	// Note: "intent" is not currently used for Fabric, as the identity resolution is not
+	//       currently pluggable to external identity resolution systems (as is the case for
+	//       ethereum blockchain connectors).
+
 	// we expand the short user name into the fully qualified onchain identity:
 	// mspid::x509::{ecert DN}::{CA DN}	return signingKeyInput, nil
 	if !fullIdentityPattern.MatchString(signingKeyInput) {

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -959,7 +959,7 @@ func TestResolveFullIDSigner(t *testing.T) {
 	defer cancel()
 
 	id := "org1MSP::x509::CN=admin,OU=client::CN=fabric-ca-server"
-	signKey, err := e.ResolveInputSigningKey(context.Background(), id)
+	signKey, err := e.ResolveSigningKey(context.Background(), id, blockchain.ResolveKeyIntentSign)
 	assert.NoError(t, err)
 	assert.Equal(t, "org1MSP::x509::CN=admin,OU=client::CN=fabric-ca-server", signKey)
 
@@ -979,7 +979,7 @@ func TestResolveSigner(t *testing.T) {
 
 	responder, _ := httpmock.NewJsonResponder(200, res)
 	httpmock.RegisterResponder("GET", `http://localhost:12345/identities/signer001`, responder)
-	resolved, err := e.ResolveInputSigningKey(context.Background(), "signer001")
+	resolved, err := e.ResolveSigningKey(context.Background(), "signer001", blockchain.ResolveKeyIntentSign)
 	assert.NoError(t, err)
 	assert.Equal(t, "org1MSP::x509::CN=admin,OU=client::CN=fabric-ca-server", resolved)
 }
@@ -994,7 +994,7 @@ func TestResolveSignerFailedFabricCARequest(t *testing.T) {
 
 	responder, _ := httpmock.NewJsonResponder(503, res)
 	httpmock.RegisterResponder("GET", `http://localhost:12345/identities/signer001`, responder)
-	_, err := e.ResolveInputSigningKey(context.Background(), "signer001")
+	_, err := e.ResolveSigningKey(context.Background(), "signer001", blockchain.ResolveKeyIntentSign)
 	assert.EqualError(t, err, "FF10284: Error from fabconnect: %!!(MISSING)s(<nil>)")
 }
 
@@ -1012,7 +1012,7 @@ func TestResolveSignerBadECertReturned(t *testing.T) {
 
 	responder, _ := httpmock.NewJsonResponder(200, res)
 	httpmock.RegisterResponder("GET", `http://localhost:12345/identities/signer001`, responder)
-	_, err := e.ResolveInputSigningKey(context.Background(), "signer001")
+	_, err := e.ResolveSigningKey(context.Background(), "signer001", blockchain.ResolveKeyIntentSign)
 	assert.Contains(t, err.Error(), "FF10286: Failed to decode certificate:")
 }
 
@@ -1030,7 +1030,7 @@ func TestResolveSignerBadCACertReturned(t *testing.T) {
 
 	responder, _ := httpmock.NewJsonResponder(200, res)
 	httpmock.RegisterResponder("GET", `http://localhost:12345/identities/signer001`, responder)
-	_, err := e.ResolveInputSigningKey(context.Background(), "signer001")
+	_, err := e.ResolveSigningKey(context.Background(), "signer001", blockchain.ResolveKeyIntentSign)
 	assert.Contains(t, err.Error(), "FF10286: Failed to decode certificate:")
 }
 

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -70,7 +70,7 @@ var (
 	ConfigBlockchainEthereumAddressResolverResponseField  = ffc("config.blockchain.ethereum.addressResolver.responseField", "The name of a JSON field that is provided in the response, that contains the ethereum address (default `address`)", i18n.StringType)
 	ConfigBlockchainEthereumAddressResolverRetainOriginal = ffc("config.blockchain.ethereum.addressResolver.retainOriginal", "When true the original pre-resolved string is retained after the lookup, and passed down to Ethconnect as the from address", i18n.BooleanType)
 	ConfigBlockchainEthereumAddressResolverURL            = ffc("config.blockchain.ethereum.addressResolver.url", "The URL of the Address Resolver", i18n.StringType)
-	ConfigBlockchainEthereumAddressResolverURLTemplate    = ffc("config.blockchain.ethereum.addressResolver.urlTemplate", "The URL Go template string to use when calling the Address Resolver", i18n.GoTemplateType)
+	ConfigBlockchainEthereumAddressResolverURLTemplate    = ffc("config.blockchain.ethereum.addressResolver.urlTemplate", "The URL Go template string to use when calling the Address Resolver. The template input contains '.Key' and '.Intent' string variables", i18n.GoTemplateType)
 	ConfigBlockchainEthereumAddressResolverProxyURL       = ffc("config.blockchain.ethereum.addressResolver.proxy.url", "Optional HTTP proxy server to use when connecting to the Address Resolver", "URL "+i18n.StringType)
 
 	ConfigBlockchainEthereumEthconnectBatchSize    = ffc("config.blockchain.ethereum.ethconnect.batchSize", "The number of events Ethconnect should batch together for delivery to FireFly core. Only applies when automatically creating a new event stream", i18n.IntType)
@@ -145,7 +145,7 @@ var (
 	ConfigPluginBlockchainType = ffc("config.plugins.blockchain[].type", "The type of the configured Blockchain Connector plugin", i18n.StringType)
 
 	ConfigPluginBlockchainEthereumAddressResolverAlwaysResolve         = ffc("config.plugins.blockchain[].ethereum.addressResolver.alwaysResolve", "Causes the address resolver to be invoked on every API call that submits a signing key, regardless of whether the input string conforms to an 0x address. Also disables any result caching", i18n.BooleanType)
-	ConfigPluginBlockchainEthereumAddressResolverBodyTemplate          = ffc("config.plugins.blockchain[].ethereum.addressResolver.bodyTemplate", "The body go template string to use when making HTTP requests", i18n.GoTemplateType)
+	ConfigPluginBlockchainEthereumAddressResolverBodyTemplate          = ffc("config.plugins.blockchain[].ethereum.addressResolver.bodyTemplate", "The body go template string to use when making HTTP requests. The template input contains '.Key' and '.Intent' string variables.", i18n.GoTemplateType)
 	ConfigPluginBlockchainEthereumAddressResolverCustomClient          = ffc("config.plugins.blockchain[].ethereum.addressResolver.customClient", "Used for testing purposes only", i18n.IgnoredType)
 	ConfigPluginBlockchainEthereumAddressResolverExpectContinueTimeout = ffc("config.plugins.blockchain[].ethereum.addressResolver.expectContinueTimeout", "See [ExpectContinueTimeout in the Go docs](https://pkg.go.dev/net/http#Transport)", i18n.TimeDurationType)
 	ConfigPluginBlockchainEthereumAddressResolverHeaders               = ffc("config.plugins.blockchain[].ethereum.addressResolver.headers", "Adds custom headers to HTTP requests", i18n.StringType)
@@ -156,7 +156,7 @@ var (
 	ConfigPluginBlockchainEthereumAddressResolverResponseField  = ffc("config.plugins.blockchain[].ethereum.addressResolver.responseField", "The name of a JSON field that is provided in the response, that contains the ethereum address (default `address`)", i18n.StringType)
 	ConfigPluginBlockchainEthereumAddressResolverRetainOriginal = ffc("config.plugins.blockchain[].ethereum.addressResolver.retainOriginal", "When true the original pre-resolved string is retained after the lookup, and passed down to Ethconnect as the from address", i18n.BooleanType)
 	ConfigPluginBlockchainEthereumAddressResolverURL            = ffc("config.plugins.blockchain[].ethereum.addressResolver.url", "The URL of the Address Resolver", i18n.StringType)
-	ConfigPluginBlockchainEthereumAddressResolverURLTemplate    = ffc("config.plugins.blockchain[].ethereum.addressResolver.urlTemplate", "The URL Go template string to use when calling the Address Resolver", i18n.GoTemplateType)
+	ConfigPluginBlockchainEthereumAddressResolverURLTemplate    = ffc("config.plugins.blockchain[].ethereum.addressResolver.urlTemplate", "The URL Go template string to use when calling the Address Resolver. The template input contains '.Key' and '.Intent' string variables.", i18n.GoTemplateType)
 
 	ConfigPluginBlockchainEthereumAddressResolverProxyURL = ffc("config.plugins.blockchain[].ethereum.addressResolver.proxy.url", "Optional HTTP proxy server to use when connecting to the Address Resolver", "URL "+i18n.StringType)
 

--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -40,7 +40,7 @@ const (
 
 type Manager interface {
 	ResolveInputSigningIdentity(ctx context.Context, signerRef *core.SignerRef) (err error)
-	ResolveInputVerifierRef(ctx context.Context, inputKey *core.VerifierRef) (*core.VerifierRef, error)
+	ResolveInputVerifierRef(ctx context.Context, inputKey *core.VerifierRef, intent blockchain.ResolveKeyIntent) (*core.VerifierRef, error)
 	ResolveInputSigningKey(ctx context.Context, inputKey string, keyNormalizationMode int) (signingKey string, err error)
 	ResolveIdentitySigner(ctx context.Context, identity *core.Identity) (parentSigner *core.SignerRef, err error)
 
@@ -140,7 +140,7 @@ func (im *identityManager) ResolveInputSigningKey(ctx context.Context, inputKey 
 	return signer.Value, nil
 }
 
-func (im *identityManager) ResolveInputVerifierRef(ctx context.Context, inputKey *core.VerifierRef) (*core.VerifierRef, error) {
+func (im *identityManager) ResolveInputVerifierRef(ctx context.Context, inputKey *core.VerifierRef, intent blockchain.ResolveKeyIntent) (*core.VerifierRef, error) {
 	log.L(ctx).Debugf("Resolving input signing key: type='%s' value='%s'", inputKey.Type, inputKey.Value)
 
 	if im.blockchain == nil {
@@ -157,7 +157,7 @@ func (im *identityManager) ResolveInputVerifierRef(ctx context.Context, inputKey
 		return nil, i18n.NewError(ctx, coremsgs.MsgUnknownVerifierType)
 	}
 
-	signingKey, err := im.blockchain.ResolveInputSigningKey(ctx, inputKey.Value)
+	signingKey, err := im.blockchain.ResolveSigningKey(ctx, inputKey.Value, intent)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (im *identityManager) resolveInputKeyViaBlockchainPlugin(ctx context.Contex
 		return nil, i18n.NewError(ctx, coremsgs.MsgBlockchainNotConfigured)
 	}
 
-	keyString, err := im.blockchain.ResolveInputSigningKey(ctx, inputKey)
+	keyString, err := im.blockchain.ResolveSigningKey(ctx, inputKey, blockchain.ResolveKeyIntentSign)
 	if err != nil {
 		return nil, err
 	}

--- a/mocks/blockchainmocks/plugin.go
+++ b/mocks/blockchainmocks/plugin.go
@@ -399,23 +399,23 @@ func (_m *Plugin) RemoveFireflySubscription(ctx context.Context, subID string) {
 	_m.Called(ctx, subID)
 }
 
-// ResolveInputSigningKey provides a mock function with given fields: ctx, keyRef
-func (_m *Plugin) ResolveInputSigningKey(ctx context.Context, keyRef string) (string, error) {
-	ret := _m.Called(ctx, keyRef)
+// ResolveSigningKey provides a mock function with given fields: ctx, keyRef, intent
+func (_m *Plugin) ResolveSigningKey(ctx context.Context, keyRef string, intent blockchain.ResolveKeyIntent) (string, error) {
+	ret := _m.Called(ctx, keyRef, intent)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
-		return rf(ctx, keyRef)
+	if rf, ok := ret.Get(0).(func(context.Context, string, blockchain.ResolveKeyIntent) (string, error)); ok {
+		return rf(ctx, keyRef, intent)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
-		r0 = rf(ctx, keyRef)
+	if rf, ok := ret.Get(0).(func(context.Context, string, blockchain.ResolveKeyIntent) string); ok {
+		r0 = rf(ctx, keyRef, intent)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, keyRef)
+	if rf, ok := ret.Get(1).(func(context.Context, string, blockchain.ResolveKeyIntent) error); ok {
+		r1 = rf(ctx, keyRef, intent)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/identitymanagermocks/manager.go
+++ b/mocks/identitymanagermocks/manager.go
@@ -5,8 +5,11 @@ package identitymanagermocks
 import (
 	context "context"
 
-	fftypes "github.com/hyperledger/firefly-common/pkg/fftypes"
+	blockchain "github.com/hyperledger/firefly/pkg/blockchain"
+
 	core "github.com/hyperledger/firefly/pkg/core"
+
+	fftypes "github.com/hyperledger/firefly-common/pkg/fftypes"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -276,25 +279,25 @@ func (_m *Manager) ResolveInputSigningKey(ctx context.Context, inputKey string, 
 	return r0, r1
 }
 
-// ResolveInputVerifierRef provides a mock function with given fields: ctx, inputKey
-func (_m *Manager) ResolveInputVerifierRef(ctx context.Context, inputKey *core.VerifierRef) (*core.VerifierRef, error) {
-	ret := _m.Called(ctx, inputKey)
+// ResolveInputVerifierRef provides a mock function with given fields: ctx, inputKey, intent
+func (_m *Manager) ResolveInputVerifierRef(ctx context.Context, inputKey *core.VerifierRef, intent blockchain.ResolveKeyIntent) (*core.VerifierRef, error) {
+	ret := _m.Called(ctx, inputKey, intent)
 
 	var r0 *core.VerifierRef
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *core.VerifierRef) (*core.VerifierRef, error)); ok {
-		return rf(ctx, inputKey)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.VerifierRef, blockchain.ResolveKeyIntent) (*core.VerifierRef, error)); ok {
+		return rf(ctx, inputKey, intent)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *core.VerifierRef) *core.VerifierRef); ok {
-		r0 = rf(ctx, inputKey)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.VerifierRef, blockchain.ResolveKeyIntent) *core.VerifierRef); ok {
+		r0 = rf(ctx, inputKey, intent)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*core.VerifierRef)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *core.VerifierRef) error); ok {
-		r1 = rf(ctx, inputKey)
+	if rf, ok := ret.Get(1).(func(context.Context, *core.VerifierRef, blockchain.ResolveKeyIntent) error); ok {
+		r1 = rf(ctx, inputKey, intent)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/blockchain/plugin.go
+++ b/pkg/blockchain/plugin.go
@@ -26,6 +26,14 @@ import (
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
+// ResolveKeyIntent allows us to distinguish between resolving a key just for a lookup, vs. accepting in an action to sign
+type ResolveKeyIntent string
+
+const (
+	ResolveKeyIntentSign   ResolveKeyIntent = "sign"   // used everywhere we accept an signing action (messages, tokens, custom invoke)
+	ResolveKeyIntentLookup ResolveKeyIntent = "lookup" // used only on the /api/v1/resolve API
+)
+
 // Plugin is the interface implemented by each blockchain plugin
 type Plugin interface {
 	core.Named
@@ -53,14 +61,14 @@ type Plugin interface {
 	// VerifierType returns the verifier (key) type that is used by this blockchain
 	VerifierType() core.VerifierType
 
-	// ResolveInputSigningKey allows blockchain specific processing of keys supplied by users
+	// ResolveSigningKey allows blockchain specific processing of keys supplied by users
 	// of this FireFly core API before a transaction is accepted using that signing key.
 	// May perform sophisticated checks and resolution as determined by the blockchain connector,
 	// and associated resolution plugins:
 	// - Such as resolving a Fabric shortname to a MSP ID
 	// - Such using an external REST API plugin to resolve a HD wallet address, or other key alias
 	// - Results in a string that can be stored/compared consistently with the key emitted on events signed by this key
-	ResolveInputSigningKey(ctx context.Context, keyRef string) (string, error)
+	ResolveSigningKey(ctx context.Context, keyRef string, intent ResolveKeyIntent) (string, error)
 
 	// SubmitBatchPin sequences a batch of message globally to all viewers of a given ledger
 	SubmitBatchPin(ctx context.Context, nsOpID, networkNamespace, signingKey string, batch *BatchPin, location *fftypes.JSONAny) error


### PR DESCRIPTION
The address resolver interface is extremely useful as a checking/enforcement point for signing actions being accepted into the system. However, currently there is no way to distinguish between simply a call to `/api/v1/resolve` to request a resolution of an input string to a signing key from the plugin, vs. the other actions (messages, custom invoke, token ops) that actually accept a signing request into the system.

This PR adds a simple addition field of `.Intent` that is `lookup` for `/api/v1/resolve` and `sign` for all other actions, and is passed into the existing Go API to the blockchain connector, and Go templates on the remote API hook (ethereum plugin only).