### PR TITLE
Fix archive name for integration test logs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: container-logs-${{ matrix.test-suite }}-${{ matrix.blockchain-provider }}-${{ matrix.database-type }}
+          name: container-logs-${{ matrix.test-suite }}-${{ matrix.blockchain-node }}-${{ matrix.database-type }}
           path: containerlogs/logs.txt
 
   migration-test:


### PR DESCRIPTION
This fixes the name of the uploaded log archives from each E2E run. The `blockchain-node` variable was not set, so it was an empty string, causing name collisions. This means that we are missing detailed logs from certain runs, making it hard to debug integration failures.