### PR TITLE
Actually start the legacy "ff_system" namespace when needed

### DIFF
--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -262,6 +262,12 @@ func (nm *namespaceManager) startV1NamespaceIfRequired(nsToCheck *namespace) err
 		// Ok - we've now initialized the system NS
 		nm.namespaces[core.LegacySystemNamespace] = systemNS
 		log.L(nm.ctx).Infof("Initialized namespace '%s' as a copy of '%s'", core.LegacySystemNamespace, nsToCheck.Name)
+		err := systemNS.orchestrator.Start()
+		if err == nil {
+			log.L(nm.ctx).Infof("Namespace %s started", core.LegacySystemNamespace)
+			systemNS.started = true
+		}
+		return err
 	}
 
 	return nil

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -69,7 +69,7 @@ func PollForUp(t *testing.T, client *client.FireFlyClient) {
 		time.Sleep(5 * time.Second)
 	}
 	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode())
+	require.Equal(t, 200, resp.StatusCode())
 }
 
 func ValidateAccountBalances(t *testing.T, client *client.FireFlyClient, poolID *fftypes.UUID, tokenIndex string, balances map[string]int64) {

--- a/test/e2e/multiparty/contract_migration.go
+++ b/test/e2e/multiparty/contract_migration.go
@@ -102,11 +102,11 @@ func runMigrationTest(suite *ContractMigrationTestSuite, address1, address2 stri
 	// Reset both nodes to pick up the new namespace
 	e2e.ResetFireFly(suite.T(), admin1)
 	e2e.ResetFireFly(suite.T(), admin2)
-	e2e.PollForUp(suite.T(), suite.testState.client1)
-	e2e.PollForUp(suite.T(), suite.testState.client2)
 
 	client1 := client.NewFireFly(suite.T(), suite.testState.client1.Hostname, testNamespace)
 	client2 := client.NewFireFly(suite.T(), suite.testState.client2.Hostname, testNamespace)
+	e2e.PollForUp(suite.T(), client1)
+	e2e.PollForUp(suite.T(), client2)
 
 	eventNames := "message_confirmed|blockchain_event_received"
 	queryString := fmt.Sprintf("namespace=%s&ephemeral&autoack&filter.events=%s", testNamespace, eventNames)
@@ -116,6 +116,8 @@ func runMigrationTest(suite *ContractMigrationTestSuite, address1, address2 stri
 	if startOnV1 {
 		systemClient1 := client.NewFireFly(suite.T(), suite.testState.client1.Hostname, "ff_system")
 		systemClient2 := client.NewFireFly(suite.T(), suite.testState.client2.Hostname, "ff_system")
+		e2e.PollForUp(suite.T(), systemClient1)
+		e2e.PollForUp(suite.T(), systemClient2)
 
 		// Register org/node identities on ff_system if not registered (but not on the new namespace)
 		if systemClient1.GetOrganization(suite.T(), suite.testState.org1.Name) == nil {


### PR DESCRIPTION
Partial fix for #1245

Somewhere in the refactoring of namespace manager, it looks like we ended up in a situation where we _initialize_ but do not _start_ the legacy "ff_system" namespace.