### PR TITLE
Add support for evmconnect's "execution reverted" error code

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -959,7 +959,7 @@ func (e *Ethereum) queryNetworkVersion(ctx context.Context, address string) (ver
 	res, err := e.queryContractMethod(ctx, address, networkVersionMethodABI, []interface{}{}, emptyErrors, nil)
 	if err != nil || !res.IsSuccess() {
 		// "Call failed" is interpreted as "method does not exist, default to version 1"
-		if strings.Contains(err.Error(), "FFEC100148") {
+		if strings.Contains(err.Error(), "FFEC100148") || strings.Contains(err.Error(), "FF23021") {
 			return 1, nil
 		}
 		return 0, err

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,8 @@
   },
   "evmconnect": {
     "image": "ghcr.io/hyperledger/firefly-evmconnect",
-    "tag": "v1.2.2",
-    "sha": "9032e45ea9cee7d881ce88eaea720f450d2ed176e96137feb495c5e7850fab45"
+    "tag": "v1.2.6-20230403-44",
+    "sha": "7181937056fc056cace8e2797e51ad5809a4dde93ea1f075a8ad258dde22a1d1"
   },
   "fabconnect": {
     "image": "ghcr.io/hyperledger/firefly-fabconnect",


### PR DESCRIPTION
When querying network version, look for the unique error codes returned by either ethconnect or evmconnect.

Partial fix for #1245
Depends on https://github.com/hyperledger/firefly-evmconnect/pull/67