### PR TITLE
Add route for deleting token pools

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -28395,6 +28395,39 @@ paths:
       tags:
       - Non-Default Namespace
   /namespaces/{ns}/tokens/pools/{nameOrId}:
+    delete:
+      description: Delete a token pool
+      operationId: deleteTokenPoolNamespace
+      parameters:
+      - description: The token pool name or ID
+        in: path
+        name: nameOrId
+        required: true
+        schema:
+          type: string
+      - description: The namespace which scopes this request
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: Server-side request timeout (milliseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 2m0s
+          type: string
+      responses:
+        "204":
+          content:
+            application/json: {}
+          description: Success
+        default:
+          description: ""
+      tags:
+      - Non-Default Namespace
     get:
       description: Gets a token pool by its name or its ID
       operationId: getTokenPoolByNameOrIDNamespace
@@ -35915,6 +35948,32 @@ paths:
       tags:
       - Default Namespace
   /tokens/pools/{nameOrId}:
+    delete:
+      description: Delete a token pool
+      operationId: deleteTokenPool
+      parameters:
+      - description: The token pool name or ID
+        in: path
+        name: nameOrId
+        required: true
+        schema:
+          type: string
+      - description: Server-side request timeout (milliseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 2m0s
+          type: string
+      responses:
+        "204":
+          content:
+            application/json: {}
+          description: Success
+        default:
+          description: ""
+      tags:
+      - Default Namespace
     get:
       description: Gets a token pool by its name or its ID
       operationId: getTokenPoolByNameOrID

--- a/internal/apiserver/route_delete_token_pool.go
+++ b/internal/apiserver/route_delete_token_pool.go
@@ -1,0 +1,43 @@
+// Copyright © 2023 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/hyperledger/firefly-common/pkg/ffapi"
+	"github.com/hyperledger/firefly/internal/coremsgs"
+)
+
+var deleteTokenPool = &ffapi.Route{
+	Name:   "deleteTokenPool",
+	Path:   "tokens/pools/{nameOrId}",
+	Method: http.MethodDelete,
+	PathParams: []*ffapi.PathParam{
+		{Name: "nameOrId", Description: coremsgs.APIParamsTokenPoolNameOrID},
+	},
+	QueryParams:     nil,
+	Description:     coremsgs.APIEndpointsDeleteTokenPool,
+	JSONInputValue:  nil,
+	JSONOutputValue: nil,
+	JSONOutputCodes: []int{http.StatusNoContent}, // Sync operation, no output
+	Extensions: &coreExtensions{
+		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
+			return nil, cr.or.Assets().DeleteTokenPool(cr.ctx, r.PP["nameOrId"])
+		},
+	},
+}

--- a/internal/apiserver/route_delete_token_pool_test.go
+++ b/internal/apiserver/route_delete_token_pool_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly/mocks/assetmocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDeleteTokenPool(t *testing.T) {
+	o, r := newTestAPIServer()
+	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
+	mam := &assetmocks.Manager{}
+	o.On("Assets").Return(mam)
+	u := fftypes.NewUUID()
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/namespaces/ns1/tokens/pools/%s", u), nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	mam.On("DeleteTokenPool", mock.Anything, u.String()).Return(nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 204, res.Result().StatusCode)
+}

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -55,6 +55,7 @@ var routes = append(
 		deleteContractListener,
 		deleteData,
 		deleteSubscription,
+		deleteTokenPool,
 		getBatchByID,
 		getBatches,
 		getBlockchainEventByID,

--- a/internal/assets/manager.go
+++ b/internal/assets/manager.go
@@ -45,6 +45,7 @@ type Manager interface {
 	GetTokenPool(ctx context.Context, connector, poolName string) (*core.TokenPool, error)
 	GetTokenPoolByNameOrID(ctx context.Context, poolNameOrID string) (*core.TokenPool, error)
 	ResolvePoolMethods(ctx context.Context, pool *core.TokenPool) error
+	DeleteTokenPool(ctx context.Context, poolNameOrID string) error
 
 	GetTokenBalances(ctx context.Context, filter ffapi.AndFilter) ([]*core.TokenBalance, *ffapi.FilterResult, error)
 	GetTokenAccounts(ctx context.Context, filter ffapi.AndFilter) ([]*core.TokenAccount, *ffapi.FilterResult, error)

--- a/internal/assets/token_pool.go
+++ b/internal/assets/token_pool.go
@@ -204,3 +204,22 @@ func (am *assetManager) ResolvePoolMethods(ctx context.Context, pool *core.Token
 	}
 	return err
 }
+
+func (am *assetManager) DeleteTokenPool(ctx context.Context, poolNameOrID string) error {
+	return am.database.RunAsGroup(ctx, func(ctx context.Context) error {
+		pool, err := am.GetTokenPoolByNameOrID(ctx, poolNameOrID)
+		if err != nil {
+			return err
+		}
+		if err = am.database.DeleteTokenPool(ctx, am.namespace, pool.ID); err != nil {
+			return err
+		}
+		if err = am.database.DeleteTokenTransfers(ctx, am.namespace, pool.ID); err != nil {
+			return err
+		}
+		if err = am.database.DeleteTokenApprovals(ctx, am.namespace, pool.ID); err != nil {
+			return err
+		}
+		return am.database.DeleteTokenBalances(ctx, am.namespace, pool.ID)
+	})
+}

--- a/internal/coremsgs/en_api_translations.go
+++ b/internal/coremsgs/en_api_translations.go
@@ -178,6 +178,7 @@ var (
 	APIEndpointsPostTokenBurn                   = ffm("api.endpoints.postTokenBurn", "Burns some tokens")
 	APIEndpointsPostTokenMint                   = ffm("api.endpoints.postTokenMint", "Mints some tokens")
 	APIEndpointsPostTokenPool                   = ffm("api.endpoints.postTokenPool", "Creates a new token pool")
+	APIEndpointsDeleteTokenPool                 = ffm("api.endpoints.deleteTokenPool", "Delete a token pool")
 	APIEndpointsPostTokenTransfer               = ffm("api.endpoints.postTokenTransfer", "Transfers some tokens")
 	APIEndpointsPutContractAPI                  = ffm("api.endpoints.putContractAPI", "Updates an existing contract API")
 	APIEndpointsPutSubscription                 = ffm("api.endpoints.putSubscription", "Update an existing subscription")

--- a/internal/database/sqlcommon/tokenapproval_sql.go
+++ b/internal/database/sqlcommon/tokenapproval_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -254,6 +254,24 @@ func (s *SQLCommon) UpdateTokenApprovals(ctx context.Context, filter ffapi.Filte
 
 	_, err = s.UpdateTx(ctx, tokenapprovalTable, tx, query, nil /* no change events filter based update */)
 	if err != nil {
+		return err
+	}
+
+	return s.CommitTx(ctx, tx, autoCommit)
+}
+
+func (s *SQLCommon) DeleteTokenApprovals(ctx context.Context, namespace string, poolID *fftypes.UUID) error {
+	ctx, tx, autoCommit, err := s.BeginOrUseTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.RollbackTx(ctx, tx, autoCommit)
+
+	err = s.DeleteTx(ctx, tokenapprovalTable, tx, sq.Delete(tokenapprovalTable).Where(sq.Eq{
+		"namespace": namespace,
+		"pool_id":   poolID,
+	}), nil)
+	if err != nil && err != fftypes.DeleteRecordNotFound {
 		return err
 	}
 

--- a/internal/database/sqlcommon/tokenbalance_sql.go
+++ b/internal/database/sqlcommon/tokenbalance_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -258,4 +258,22 @@ func (s *SQLCommon) GetTokenAccountPools(ctx context.Context, namespace, key str
 	}
 
 	return pools, s.QueryRes(ctx, tokenbalanceTable, tx, fop, fi), err
+}
+
+func (s *SQLCommon) DeleteTokenBalances(ctx context.Context, namespace string, poolID *fftypes.UUID) error {
+	ctx, tx, autoCommit, err := s.BeginOrUseTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.RollbackTx(ctx, tx, autoCommit)
+
+	err = s.DeleteTx(ctx, tokenbalanceTable, tx, sq.Delete(tokenbalanceTable).Where(sq.Eq{
+		"namespace": namespace,
+		"pool_id":   poolID,
+	}), nil)
+	if err != nil && err != fftypes.DeleteRecordNotFound {
+		return err
+	}
+
+	return s.CommitTx(ctx, tx, autoCommit)
 }

--- a/internal/database/sqlcommon/tokenpool_sql.go
+++ b/internal/database/sqlcommon/tokenpool_sql.go
@@ -254,3 +254,22 @@ func (s *SQLCommon) GetTokenPools(ctx context.Context, namespace string, filter 
 
 	return pools, s.QueryRes(ctx, tokenpoolTable, tx, fop, fi), err
 }
+
+func (s *SQLCommon) DeleteTokenPool(ctx context.Context, namespace string, id *fftypes.UUID) error {
+	ctx, tx, autoCommit, err := s.BeginOrUseTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.RollbackTx(ctx, tx, autoCommit)
+
+	err = s.DeleteTx(ctx, "tokenpool", tx, sq.Delete("tokenpool").Where(sq.Eq{
+		"id": id, "namespace": namespace,
+	}), func() {
+		s.callbacks.UUIDCollectionNSEvent(database.CollectionTokenPools, core.ChangeEventTypeDeleted, namespace, id)
+	})
+	if err != nil {
+		return err
+	}
+
+	return s.CommitTx(ctx, tx, autoCommit)
+}

--- a/internal/database/sqlcommon/tokentransfer_sql.go
+++ b/internal/database/sqlcommon/tokentransfer_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -238,4 +238,22 @@ func (s *SQLCommon) GetTokenTransfers(ctx context.Context, namespace string, fil
 	}
 
 	return transfers, s.QueryRes(ctx, tokentransferTable, tx, fop, fi), err
+}
+
+func (s *SQLCommon) DeleteTokenTransfers(ctx context.Context, namespace string, poolID *fftypes.UUID) error {
+	ctx, tx, autoCommit, err := s.BeginOrUseTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.RollbackTx(ctx, tx, autoCommit)
+
+	err = s.DeleteTx(ctx, tokentransferTable, tx, sq.Delete(tokentransferTable).Where(sq.Eq{
+		"namespace": namespace,
+		"pool_id":   poolID,
+	}), nil)
+	if err != nil && err != fftypes.DeleteRecordNotFound {
+		return err
+	}
+
+	return s.CommitTx(ctx, tx, autoCommit)
 }

--- a/mocks/assetmocks/manager.go
+++ b/mocks/assetmocks/manager.go
@@ -86,6 +86,20 @@ func (_m *Manager) CreateTokenPool(ctx context.Context, pool *core.TokenPoolInpu
 	return r0, r1
 }
 
+// DeleteTokenPool provides a mock function with given fields: ctx, poolNameOrID
+func (_m *Manager) DeleteTokenPool(ctx context.Context, poolNameOrID string) error {
+	ret := _m.Called(ctx, poolNameOrID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, poolNameOrID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetTokenAccountPools provides a mock function with given fields: ctx, key, filter
 func (_m *Manager) GetTokenAccountPools(ctx context.Context, key string, filter ffapi.AndFilter) ([]*core.TokenAccountPool, *ffapi.FilterResult, error) {
 	ret := _m.Called(ctx, key, filter)

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -123,6 +123,62 @@ func (_m *Plugin) DeleteSubscriptionByID(ctx context.Context, namespace string, 
 	return r0
 }
 
+// DeleteTokenApprovals provides a mock function with given fields: ctx, namespace, poolID
+func (_m *Plugin) DeleteTokenApprovals(ctx context.Context, namespace string, poolID *fftypes.UUID) error {
+	ret := _m.Called(ctx, namespace, poolID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID) error); ok {
+		r0 = rf(ctx, namespace, poolID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteTokenBalances provides a mock function with given fields: ctx, namespace, poolID
+func (_m *Plugin) DeleteTokenBalances(ctx context.Context, namespace string, poolID *fftypes.UUID) error {
+	ret := _m.Called(ctx, namespace, poolID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID) error); ok {
+		r0 = rf(ctx, namespace, poolID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteTokenPool provides a mock function with given fields: ctx, namespace, id
+func (_m *Plugin) DeleteTokenPool(ctx context.Context, namespace string, id *fftypes.UUID) error {
+	ret := _m.Called(ctx, namespace, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID) error); ok {
+		r0 = rf(ctx, namespace, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteTokenTransfers provides a mock function with given fields: ctx, namespace, poolID
+func (_m *Plugin) DeleteTokenTransfers(ctx context.Context, namespace string, poolID *fftypes.UUID) error {
+	ret := _m.Called(ctx, namespace, poolID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID) error); ok {
+		r0 = rf(ctx, namespace, poolID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetBatchByID provides a mock function with given fields: ctx, namespace, id
 func (_m *Plugin) GetBatchByID(ctx context.Context, namespace string, id *fftypes.UUID) (*core.BatchPersisted, error) {
 	ret := _m.Called(ctx, namespace, id)

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -366,6 +366,9 @@ type iTokenPoolCollection interface {
 
 	// GetTokenPools - Get token pools
 	GetTokenPools(ctx context.Context, namespace string, filter ffapi.Filter) ([]*core.TokenPool, *ffapi.FilterResult, error)
+
+	// DeleteTokenPool - delete a token pool
+	DeleteTokenPool(ctx context.Context, namespace string, id *fftypes.UUID) error
 }
 
 type iTokenBalanceCollection interface {
@@ -383,6 +386,9 @@ type iTokenBalanceCollection interface {
 
 	// GetTokenAccountPools - Get the list of pools referenced by a given account
 	GetTokenAccountPools(ctx context.Context, namespace, key string, filter ffapi.Filter) ([]*core.TokenAccountPool, *ffapi.FilterResult, error)
+
+	// DeleteTokenBalances - Delete token balances from a particular pool
+	DeleteTokenBalances(ctx context.Context, namespace string, poolID *fftypes.UUID) error
 }
 
 type iTokenTransferCollection interface {
@@ -397,6 +403,9 @@ type iTokenTransferCollection interface {
 
 	// GetTokenTransfers - Get token transfers
 	GetTokenTransfers(ctx context.Context, namespace string, filter ffapi.Filter) ([]*core.TokenTransfer, *ffapi.FilterResult, error)
+
+	// DeleteTokenTransfers - Delete token transfers from a particular pool
+	DeleteTokenTransfers(ctx context.Context, namespace string, poolID *fftypes.UUID) error
 }
 
 type iTokenApprovalCollection interface {
@@ -414,6 +423,9 @@ type iTokenApprovalCollection interface {
 
 	// GetTokenApprovals - Get token approvals
 	GetTokenApprovals(ctx context.Context, namespace string, filter ffapi.Filter) ([]*core.TokenApproval, *ffapi.FilterResult, error)
+
+	// DeleteTokenApprovals - Delete token approvals from a particular pool
+	DeleteTokenApprovals(ctx context.Context, namespace string, poolID *fftypes.UUID) error
 }
 
 type iFFICollection interface {


### PR DESCRIPTION
This allows deleting any token pool, regardless of gateway or multiparty mode, along with all associated token transfers, balances, and approvals.

Note that in multiparty mode, if you delete a token pool that was broadcast to the network, you will be voluntarily out of sync with other nodes.

This represents the simplest implementation of (4) from https://github.com/hyperledger/firefly/issues/1220#issuecomment-1496422542, in the context of token pools only.

Note that this does not purge event listeners from the token connector (events will just be ignored). Probably need to find a way to delete them though.