### PR TITLE
Separate "define" and "publish" for contract interfaces, and allow deleting unpublished interfaces

### DIFF
--- a/db/migrations/postgres/000112_add_ffi_networkname.down.sql
+++ b/db/migrations/postgres/000112_add_ffi_networkname.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP INDEX ffi_networkname;
+ALTER TABLE ffi DROP COLUMN published;
+ALTER TABLE ffi DROP COLUMN network_name;
+COMMIT;

--- a/db/migrations/postgres/000112_add_ffi_networkname.up.sql
+++ b/db/migrations/postgres/000112_add_ffi_networkname.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+ALTER TABLE ffi ADD COLUMN published BOOLEAN DEFAULT false;
+UPDATE ffi SET published = true WHERE message_id IS NOT NULL;
+ALTER TABLE ffi ADD COLUMN network_name VARCHAR(64);
+UPDATE ffi SET network_name = name WHERE message_id IS NOT NULL;
+CREATE UNIQUE INDEX ffi_networkname ON ffi(namespace,network_name,version);
+COMMIT;

--- a/db/migrations/sqlite/000112_add_ffi_networkname.down.sql
+++ b/db/migrations/sqlite/000112_add_ffi_networkname.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX ffi_networkname;
+ALTER TABLE ffi DROP COLUMN published;
+ALTER TABLE ffi DROP COLUMN network_name;

--- a/db/migrations/sqlite/000112_add_ffi_networkname.up.sql
+++ b/db/migrations/sqlite/000112_add_ffi_networkname.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ffi ADD COLUMN published BOOLEAN DEFAULT false;
+UPDATE ffi SET published = true WHERE message_id IS NOT NULL;
+ALTER TABLE ffi ADD COLUMN network_name VARCHAR(64);
+UPDATE ffi SET network_name = name WHERE message_id IS NOT NULL;
+CREATE UNIQUE INDEX ffi_networkname ON ffi(namespace,network_name,version);

--- a/docs/reference/types/ffi.md
+++ b/docs/reference/types/ffi.md
@@ -122,13 +122,13 @@ nav_order: 9
 | `message` | The UUID of the broadcast message that was used to publish this FFI to the network | [`UUID`](simpletypes#uuid) |
 | `namespace` | The namespace of the FFI | `string` |
 | `name` | The name of the FFI - usually matching the smart contract name | `string` |
-| `networkName` | The shared interface name within the multiparty network | `string` |
+| `networkName` | The published name of the FFI within the multiparty network | `string` |
 | `description` | A description of the smart contract this FFI represents | `string` |
 | `version` | A version for the FFI - use of semantic versioning such as 'v1.0.1' is encouraged | `string` |
 | `methods` | An array of smart contract method definitions | [`FFIMethod[]`](#ffimethod) |
 | `events` | An array of smart contract event definitions | [`FFIEvent[]`](#ffievent) |
 | `errors` | An array of smart contract error definitions | [`FFIError[]`](#ffierror) |
-| `published` | True if the interface has been published to a multiparty network | `bool` |
+| `published` | Indicates if the FFI is published to other members of the multiparty network | `bool` |
 
 ## FFIMethod
 

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -596,11 +596,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -2426,6 +2427,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: networkname
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: published
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: version
         schema:
           type: string
@@ -2686,12 +2697,12 @@ paths:
                       description: The namespace of the FFI
                       type: string
                     networkName:
-                      description: The shared interface name within the multiparty
+                      description: The published name of the FFI within the multiparty
                         network
                       type: string
                     published:
-                      description: True if the interface has been published to a multiparty
-                        network
+                      description: Indicates if the FFI is published to other members
+                        of the multiparty network
                       type: boolean
                     version:
                       description: A version for the FFI - use of semantic versioning
@@ -2713,6 +2724,12 @@ paths:
         name: confirm
         schema:
           example: "true"
+          type: string
+      - description: When true the definition will be published to all other members
+          of the multiparty network
+        in: query
+        name: publish
+        schema:
           type: string
       - description: Server-side request timeout (milliseconds, or set a custom suffix
           like 10s)
@@ -2863,7 +2880,8 @@ paths:
                     name
                   type: string
                 networkName:
-                  description: The shared interface name within the multiparty network
+                  description: The published name of the FFI within the multiparty
+                    network
                   type: string
                 version:
                   description: A version for the FFI - use of semantic versioning
@@ -3084,11 +3102,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -3339,11 +3358,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -3600,11 +3620,509 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
+                    type: boolean
+                  version:
+                    description: A version for the FFI - use of semantic versioning
+                      such as 'v1.0.1' is encouraged
+                    type: string
+                type: object
+          description: Success
+        default:
+          description: ""
+      tags:
+      - Default Namespace
+  /contracts/interfaces/{name}/{version}/publish:
+    post:
+      description: Publish a contract interface to all other members of the multiparty
+        network
+      operationId: postContractInterfacePublish
+      parameters:
+      - description: The name of the contract interface
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: The version of the contract interface
+        in: path
+        name: version
+        required: true
+        schema:
+          type: string
+      - description: When true the HTTP request blocks until the message is confirmed
+        in: query
+        name: confirm
+        schema:
+          type: string
+      - description: Server-side request timeout (milliseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 2m0s
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                networkName:
+                  description: An optional name to be used for publishing this definition
+                    to the multiparty network, which may differ from the local name
+                  type: string
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  description:
+                    description: A description of the smart contract this FFI represents
+                    type: string
+                  errors:
+                    description: An array of smart contract error definitions
+                    items:
+                      description: An array of smart contract error definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract error
+                          type: string
+                        id:
+                          description: The UUID of the FFI error definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this error is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the error
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of error parameter/argument definitions
+                          items:
+                            description: An array of error parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this error within
+                            the FFI for use on URL paths
+                          type: string
+                        signature:
+                          description: The stringified signature of the error, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  events:
+                    description: An array of smart contract event definitions
+                    items:
+                      description: An array of smart contract event definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract event
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this event from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this event from the original smart contract. Used by the
+                            blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI event definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this event is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the event
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of event parameter/argument definitions
+                          items:
+                            description: An array of event parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this event within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple event overrides with the same name
+                          type: string
+                        signature:
+                          description: The stringified signature of the event, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: The UUID of the FireFly interface (FFI) smart contract
+                      definition
+                    format: uuid
+                    type: string
+                  message:
+                    description: The UUID of the broadcast message that was used to
+                      publish this FFI to the network
+                    format: uuid
+                    type: string
+                  methods:
+                    description: An array of smart contract method definitions
+                    items:
+                      description: An array of smart contract method definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract method
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this method from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this method from the original smart contract. Used by
+                            the blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI method definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this method is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the method
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of method parameter/argument definitions
+                          items:
+                            description: An array of method parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this method within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple method overrides with the same name
+                          type: string
+                        returns:
+                          description: An array of method return definitions
+                          items:
+                            description: An array of method return definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  name:
+                    description: The name of the FFI - usually matching the smart
+                      contract name
+                    type: string
+                  namespace:
+                    description: The namespace of the FFI
+                    type: string
+                  networkName:
+                    description: The published name of the FFI within the multiparty
                       network
+                    type: string
+                  published:
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
+                    type: boolean
+                  version:
+                    description: A version for the FFI - use of semantic versioning
+                      such as 'v1.0.1' is encouraged
+                    type: string
+                type: object
+          description: Success
+        "202":
+          content:
+            application/json:
+              schema:
+                properties:
+                  description:
+                    description: A description of the smart contract this FFI represents
+                    type: string
+                  errors:
+                    description: An array of smart contract error definitions
+                    items:
+                      description: An array of smart contract error definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract error
+                          type: string
+                        id:
+                          description: The UUID of the FFI error definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this error is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the error
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of error parameter/argument definitions
+                          items:
+                            description: An array of error parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this error within
+                            the FFI for use on URL paths
+                          type: string
+                        signature:
+                          description: The stringified signature of the error, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  events:
+                    description: An array of smart contract event definitions
+                    items:
+                      description: An array of smart contract event definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract event
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this event from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this event from the original smart contract. Used by the
+                            blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI event definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this event is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the event
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of event parameter/argument definitions
+                          items:
+                            description: An array of event parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this event within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple event overrides with the same name
+                          type: string
+                        signature:
+                          description: The stringified signature of the event, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: The UUID of the FireFly interface (FFI) smart contract
+                      definition
+                    format: uuid
+                    type: string
+                  message:
+                    description: The UUID of the broadcast message that was used to
+                      publish this FFI to the network
+                    format: uuid
+                    type: string
+                  methods:
+                    description: An array of smart contract method definitions
+                    items:
+                      description: An array of smart contract method definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract method
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this method from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this method from the original smart contract. Used by
+                            the blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI method definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this method is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the method
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of method parameter/argument definitions
+                          items:
+                            description: An array of method parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this method within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple method overrides with the same name
+                          type: string
+                        returns:
+                          description: An array of method return definitions
+                          items:
+                            description: An array of method return definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  name:
+                    description: The name of the FFI - usually matching the smart
+                      contract name
+                    type: string
+                  namespace:
+                    description: The namespace of the FFI
+                    type: string
+                  networkName:
+                    description: The published name of the FFI within the multiparty
+                      network
+                    type: string
+                  published:
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -3868,11 +4386,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -11333,11 +11852,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -13646,6 +14166,16 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: networkname
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: published
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: version
         schema:
           type: string
@@ -13906,12 +14436,12 @@ paths:
                       description: The namespace of the FFI
                       type: string
                     networkName:
-                      description: The shared interface name within the multiparty
+                      description: The published name of the FFI within the multiparty
                         network
                       type: string
                     published:
-                      description: True if the interface has been published to a multiparty
-                        network
+                      description: Indicates if the FFI is published to other members
+                        of the multiparty network
                       type: boolean
                     version:
                       description: A version for the FFI - use of semantic versioning
@@ -13940,6 +14470,12 @@ paths:
         name: confirm
         schema:
           example: "true"
+          type: string
+      - description: When true the definition will be published to all other members
+          of the multiparty network
+        in: query
+        name: publish
+        schema:
           type: string
       - description: Server-side request timeout (milliseconds, or set a custom suffix
           like 10s)
@@ -14090,7 +14626,8 @@ paths:
                     name
                   type: string
                 networkName:
-                  description: The shared interface name within the multiparty network
+                  description: The published name of the FFI within the multiparty
+                    network
                   type: string
                 version:
                   description: A version for the FFI - use of semantic versioning
@@ -14311,11 +14848,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -14573,11 +15111,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -14841,11 +15380,516 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
+                    type: boolean
+                  version:
+                    description: A version for the FFI - use of semantic versioning
+                      such as 'v1.0.1' is encouraged
+                    type: string
+                type: object
+          description: Success
+        default:
+          description: ""
+      tags:
+      - Non-Default Namespace
+  /namespaces/{ns}/contracts/interfaces/{name}/{version}/publish:
+    post:
+      description: Publish a contract interface to all other members of the multiparty
+        network
+      operationId: postContractInterfacePublishNamespace
+      parameters:
+      - description: The name of the contract interface
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: The version of the contract interface
+        in: path
+        name: version
+        required: true
+        schema:
+          type: string
+      - description: The namespace which scopes this request
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: When true the HTTP request blocks until the message is confirmed
+        in: query
+        name: confirm
+        schema:
+          type: string
+      - description: Server-side request timeout (milliseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 2m0s
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                networkName:
+                  description: An optional name to be used for publishing this definition
+                    to the multiparty network, which may differ from the local name
+                  type: string
+              type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  description:
+                    description: A description of the smart contract this FFI represents
+                    type: string
+                  errors:
+                    description: An array of smart contract error definitions
+                    items:
+                      description: An array of smart contract error definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract error
+                          type: string
+                        id:
+                          description: The UUID of the FFI error definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this error is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the error
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of error parameter/argument definitions
+                          items:
+                            description: An array of error parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this error within
+                            the FFI for use on URL paths
+                          type: string
+                        signature:
+                          description: The stringified signature of the error, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  events:
+                    description: An array of smart contract event definitions
+                    items:
+                      description: An array of smart contract event definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract event
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this event from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this event from the original smart contract. Used by the
+                            blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI event definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this event is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the event
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of event parameter/argument definitions
+                          items:
+                            description: An array of event parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this event within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple event overrides with the same name
+                          type: string
+                        signature:
+                          description: The stringified signature of the event, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: The UUID of the FireFly interface (FFI) smart contract
+                      definition
+                    format: uuid
+                    type: string
+                  message:
+                    description: The UUID of the broadcast message that was used to
+                      publish this FFI to the network
+                    format: uuid
+                    type: string
+                  methods:
+                    description: An array of smart contract method definitions
+                    items:
+                      description: An array of smart contract method definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract method
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this method from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this method from the original smart contract. Used by
+                            the blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI method definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this method is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the method
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of method parameter/argument definitions
+                          items:
+                            description: An array of method parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this method within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple method overrides with the same name
+                          type: string
+                        returns:
+                          description: An array of method return definitions
+                          items:
+                            description: An array of method return definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  name:
+                    description: The name of the FFI - usually matching the smart
+                      contract name
+                    type: string
+                  namespace:
+                    description: The namespace of the FFI
+                    type: string
+                  networkName:
+                    description: The published name of the FFI within the multiparty
                       network
+                    type: string
+                  published:
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
+                    type: boolean
+                  version:
+                    description: A version for the FFI - use of semantic versioning
+                      such as 'v1.0.1' is encouraged
+                    type: string
+                type: object
+          description: Success
+        "202":
+          content:
+            application/json:
+              schema:
+                properties:
+                  description:
+                    description: A description of the smart contract this FFI represents
+                    type: string
+                  errors:
+                    description: An array of smart contract error definitions
+                    items:
+                      description: An array of smart contract error definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract error
+                          type: string
+                        id:
+                          description: The UUID of the FFI error definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this error is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the error
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of error parameter/argument definitions
+                          items:
+                            description: An array of error parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this error within
+                            the FFI for use on URL paths
+                          type: string
+                        signature:
+                          description: The stringified signature of the error, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  events:
+                    description: An array of smart contract event definitions
+                    items:
+                      description: An array of smart contract event definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract event
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this event from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this event from the original smart contract. Used by the
+                            blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI event definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this event is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the event
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of event parameter/argument definitions
+                          items:
+                            description: An array of event parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this event within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple event overrides with the same name
+                          type: string
+                        signature:
+                          description: The stringified signature of the event, as
+                            computed by the blockchain plugin
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: The UUID of the FireFly interface (FFI) smart contract
+                      definition
+                    format: uuid
+                    type: string
+                  message:
+                    description: The UUID of the broadcast message that was used to
+                      publish this FFI to the network
+                    format: uuid
+                    type: string
+                  methods:
+                    description: An array of smart contract method definitions
+                    items:
+                      description: An array of smart contract method definitions
+                      properties:
+                        description:
+                          description: A description of the smart contract method
+                          type: string
+                        details:
+                          additionalProperties:
+                            description: Additional blockchain specific fields about
+                              this method from the original smart contract. Used by
+                              the blockchain plugin and for documentation generation.
+                          description: Additional blockchain specific fields about
+                            this method from the original smart contract. Used by
+                            the blockchain plugin and for documentation generation.
+                          type: object
+                        id:
+                          description: The UUID of the FFI method definition
+                          format: uuid
+                          type: string
+                        interface:
+                          description: The UUID of the FFI smart contract definition
+                            that this method is part of
+                          format: uuid
+                          type: string
+                        name:
+                          description: The name of the method
+                          type: string
+                        namespace:
+                          description: The namespace of the FFI
+                          type: string
+                        params:
+                          description: An array of method parameter/argument definitions
+                          items:
+                            description: An array of method parameter/argument definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                        pathname:
+                          description: The unique name allocated to this method within
+                            the FFI for use on URL paths. Supports contracts that
+                            have multiple method overrides with the same name
+                          type: string
+                        returns:
+                          description: An array of method return definitions
+                          items:
+                            description: An array of method return definitions
+                            properties:
+                              name:
+                                description: The name of the parameter. Note that
+                                  parameters must be ordered correctly on the FFI,
+                                  according to the order in the blockchain smart contract
+                                type: string
+                              schema:
+                                description: FireFly uses an extended subset of JSON
+                                  Schema to describe parameters, similar to OpenAPI/Swagger.
+                                  Converters are available for native blockchain interface
+                                  definitions / type systems - such as an Ethereum
+                                  ABI. See the documentation for more detail
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  name:
+                    description: The name of the FFI - usually matching the smart
+                      contract name
+                    type: string
+                  namespace:
+                    description: The namespace of the FFI
+                    type: string
+                  networkName:
+                    description: The published name of the FFI within the multiparty
+                      network
+                    type: string
+                  published:
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning
@@ -15116,11 +16160,12 @@ paths:
                     description: The namespace of the FFI
                     type: string
                   networkName:
-                    description: The shared interface name within the multiparty network
+                    description: The published name of the FFI within the multiparty
+                      network
                     type: string
                   published:
-                    description: True if the interface has been published to a multiparty
-                      network
+                    description: Indicates if the FFI is published to other members
+                      of the multiparty network
                     type: boolean
                   version:
                     description: A version for the FFI - use of semantic versioning

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -3120,6 +3120,32 @@ paths:
       tags:
       - Default Namespace
   /contracts/interfaces/{interfaceId}:
+    delete:
+      description: Delete a contract interface
+      operationId: deleteContractInterface
+      parameters:
+      - description: The ID of the contract interface
+        in: path
+        name: interfaceId
+        required: true
+        schema:
+          type: string
+      - description: Server-side request timeout (milliseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 2m0s
+          type: string
+      responses:
+        "204":
+          content:
+            application/json: {}
+          description: Success
+        default:
+          description: ""
+      tags:
+      - Default Namespace
     get:
       description: Gets a contract interface by its ID
       operationId: getContractInterface
@@ -14866,6 +14892,39 @@ paths:
       tags:
       - Non-Default Namespace
   /namespaces/{ns}/contracts/interfaces/{interfaceId}:
+    delete:
+      description: Delete a contract interface
+      operationId: deleteContractInterfaceNamespace
+      parameters:
+      - description: The ID of the contract interface
+        in: path
+        name: interfaceId
+        required: true
+        schema:
+          type: string
+      - description: The namespace which scopes this request
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: Server-side request timeout (milliseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 2m0s
+          type: string
+      responses:
+        "204":
+          content:
+            application/json: {}
+          description: Success
+        default:
+          description: ""
+      tags:
+      - Non-Default Namespace
     get:
       description: Gets a contract interface by its ID
       operationId: getContractInterfaceNamespace

--- a/internal/apiserver/route_delete_contract_interface.go
+++ b/internal/apiserver/route_delete_contract_interface.go
@@ -1,0 +1,48 @@
+// Copyright © 2023 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/hyperledger/firefly-common/pkg/ffapi"
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly/internal/coremsgs"
+)
+
+var deleteContractInterface = &ffapi.Route{
+	Name:   "deleteContractInterface",
+	Path:   "contracts/interfaces/{interfaceId}",
+	Method: http.MethodDelete,
+	PathParams: []*ffapi.PathParam{
+		{Name: "interfaceId", Description: coremsgs.APIParamsContractInterfaceID},
+	},
+	QueryParams:     nil,
+	Description:     coremsgs.APIEndpointsDeleteContractInterface,
+	JSONInputValue:  nil,
+	JSONOutputValue: nil,
+	JSONOutputCodes: []int{http.StatusNoContent}, // Sync operation, no output
+	Extensions: &coreExtensions{
+		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
+			interfaceID, err := fftypes.ParseUUID(cr.ctx, r.PP["interfaceId"])
+			if err != nil {
+				return nil, err
+			}
+			return nil, cr.or.Contracts().DeleteFFI(cr.ctx, interfaceID)
+		},
+	},
+}

--- a/internal/apiserver/route_delete_contract_interface_test.go
+++ b/internal/apiserver/route_delete_contract_interface_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly/mocks/contractmocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDeleteContractInterface(t *testing.T) {
+	o, r := newTestAPIServer()
+	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
+	mcm := &contractmocks.Manager{}
+	o.On("Contracts").Return(mcm)
+	u := fftypes.NewUUID()
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/namespaces/ns1/contracts/interfaces/%s", u), nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	mcm.On("DeleteFFI", mock.Anything, u).Return(nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 204, res.Result().StatusCode)
+}
+
+func TestDeleteContractInterfaceBadID(t *testing.T) {
+	o, r := newTestAPIServer()
+	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/namespaces/ns1/contracts/interfaces/bad"), nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 400, res.Result().StatusCode)
+}

--- a/internal/apiserver/route_get_contract_interface_name_version.go
+++ b/internal/apiserver/route_get_contract_interface_name_version.go
@@ -49,7 +49,7 @@ var getContractInterfaceNameVersion = &ffapi.Route{
 			if strings.EqualFold(r.QP["fetchchildren"], "true") {
 				return cr.or.Contracts().GetFFIWithChildren(cr.ctx, r.PP["name"], r.PP["version"])
 			}
-			return cr.or.Contracts().GetFFI(cr.ctx, r.PP["name"], "", r.PP["version"])
+			return cr.or.Contracts().GetFFI(cr.ctx, r.PP["name"], r.PP["version"])
 		},
 	},
 }

--- a/internal/apiserver/route_get_contract_interface_name_version.go
+++ b/internal/apiserver/route_get_contract_interface_name_version.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -49,7 +49,7 @@ var getContractInterfaceNameVersion = &ffapi.Route{
 			if strings.EqualFold(r.QP["fetchchildren"], "true") {
 				return cr.or.Contracts().GetFFIWithChildren(cr.ctx, r.PP["name"], r.PP["version"])
 			}
-			return cr.or.Contracts().GetFFI(cr.ctx, r.PP["name"], r.PP["version"])
+			return cr.or.Contracts().GetFFI(cr.ctx, r.PP["name"], "", r.PP["version"])
 		},
 	},
 }

--- a/internal/apiserver/route_get_contract_interface_name_version_test.go
+++ b/internal/apiserver/route_get_contract_interface_name_version_test.go
@@ -41,7 +41,7 @@ func TestGetContractInterfaceNameVersion(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	mcm.On("GetFFI", mock.Anything, "banana", "", "v1.0.0").
+	mcm.On("GetFFI", mock.Anything, "banana", "v1.0.0").
 		Return(&fftypes.FFI{}, nil)
 	r.ServeHTTP(res, req)
 

--- a/internal/apiserver/route_get_contract_interface_name_version_test.go
+++ b/internal/apiserver/route_get_contract_interface_name_version_test.go
@@ -41,7 +41,7 @@ func TestGetContractInterfaceNameVersion(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	mcm.On("GetFFI", mock.Anything, "banana", "v1.0.0").
+	mcm.On("GetFFI", mock.Anything, "banana", "", "v1.0.0").
 		Return(&fftypes.FFI{}, nil)
 	r.ServeHTTP(res, req)
 

--- a/internal/apiserver/route_post_contract_interface_publish_test.go
+++ b/internal/apiserver/route_post_contract_interface_publish_test.go
@@ -22,13 +22,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/mocks/definitionsmocks"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestPostTokenPoolPublish(t *testing.T) {
+func TestPostContractInterfacePublish(t *testing.T) {
 	o, r := newTestAPIServer()
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mds := &definitionsmocks.Sender{}
@@ -36,12 +37,12 @@ func TestPostTokenPoolPublish(t *testing.T) {
 	input := core.TokenPool{}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(&input)
-	req := httptest.NewRequest("POST", "/api/v1/namespaces/ns1/tokens/pools/pool1/publish", &buf)
+	req := httptest.NewRequest("POST", "/api/v1/namespaces/ns1/contracts/interfaces/ffi1/1.0/publish", &buf)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
-	pool := &core.TokenPool{}
+	ffi := &fftypes.FFI{}
 
-	mds.On("PublishTokenPool", mock.Anything, "pool1", "", false).Return(pool, nil)
+	mds.On("PublishFFI", mock.Anything, "ffi1", "1.0", "", false).Return(ffi, nil)
 	r.ServeHTTP(res, req)
 
 	assert.Equal(t, 202, res.Result().StatusCode)

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -52,6 +52,7 @@ var routes = append(
 		getWebSockets,
 	}),
 	namespacedRoutes([]*ffapi.Route{
+		deleteContractInterface,
 		deleteContractListener,
 		deleteData,
 		deleteSubscription,

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -128,6 +128,7 @@ var routes = append(
 		postContractAPIQuery,
 		postContractAPIListeners,
 		postContractInterfaceGenerate,
+		postContractInterfacePublish,
 		postContractDeploy,
 		postContractInvoke,
 		postContractQuery,

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -44,7 +44,7 @@ import (
 type Manager interface {
 	core.Named
 
-	GetFFI(ctx context.Context, name, networkName, version string) (*fftypes.FFI, error)
+	GetFFI(ctx context.Context, name, version string) (*fftypes.FFI, error)
 	GetFFIWithChildren(ctx context.Context, name, version string) (*fftypes.FFI, error)
 	GetFFIByID(ctx context.Context, id *fftypes.UUID) (*fftypes.FFI, error)
 	GetFFIByIDWithChildren(ctx context.Context, id *fftypes.UUID) (*fftypes.FFI, error)
@@ -141,8 +141,8 @@ func (cm *contractManager) newFFISchemaCompiler() *jsonschema.Compiler {
 	return c
 }
 
-func (cm *contractManager) GetFFI(ctx context.Context, name, networkName, version string) (*fftypes.FFI, error) {
-	ffi, err := cm.database.GetFFI(ctx, cm.namespace, name, networkName, version)
+func (cm *contractManager) GetFFI(ctx context.Context, name, version string) (*fftypes.FFI, error) {
+	ffi, err := cm.database.GetFFI(ctx, cm.namespace, name, version)
 	if err != nil {
 		return nil, err
 	} else if ffi == nil {
@@ -152,7 +152,7 @@ func (cm *contractManager) GetFFI(ctx context.Context, name, networkName, versio
 }
 
 func (cm *contractManager) GetFFIWithChildren(ctx context.Context, name, version string) (*fftypes.FFI, error) {
-	ffi, err := cm.GetFFI(ctx, name, "", version)
+	ffi, err := cm.GetFFI(ctx, name, version)
 	if err == nil {
 		err = cm.getFFIChildren(ctx, ffi)
 	}
@@ -542,7 +542,7 @@ func (cm *contractManager) ResolveFFIReference(ctx context.Context, ref *fftypes
 		return nil
 
 	case ref.Name != "" && ref.Version != "":
-		ffi, err := cm.database.GetFFI(ctx, cm.namespace, ref.Name, "", ref.Version)
+		ffi, err := cm.database.GetFFI(ctx, cm.namespace, ref.Name, ref.Version)
 		if err != nil {
 			return err
 		} else if ffi == nil {

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -53,6 +53,7 @@ type Manager interface {
 	GetFFIs(ctx context.Context, filter ffapi.AndFilter) ([]*fftypes.FFI, *ffapi.FilterResult, error)
 	ResolveFFI(ctx context.Context, ffi *fftypes.FFI) error
 	ResolveFFIReference(ctx context.Context, ref *fftypes.FFIReference) error
+	DeleteFFI(ctx context.Context, id *fftypes.UUID) error
 
 	DeployContract(ctx context.Context, req *core.ContractDeployRequest, waitConfirm bool) (interface{}, error)
 	InvokeContract(ctx context.Context, req *core.ContractCallRequest, waitConfirm bool) (interface{}, error)
@@ -948,4 +949,20 @@ func (cm *contractManager) buildInvokeMessage(ctx context.Context, in *core.Mess
 	default:
 		return nil, i18n.NewError(ctx, coremsgs.MsgInvalidMessageType, allowedTypes)
 	}
+}
+
+func (cm *contractManager) DeleteFFI(ctx context.Context, id *fftypes.UUID) error {
+	return cm.database.RunAsGroup(ctx, func(ctx context.Context) error {
+		ffi, err := cm.GetFFIByID(ctx, id)
+		if err != nil {
+			return err
+		}
+		if ffi == nil {
+			return i18n.NewError(ctx, coremsgs.Msg404NotFound)
+		}
+		if ffi.Published {
+			return i18n.NewError(ctx, coremsgs.MsgCannotDeletePublished)
+		}
+		return cm.database.DeleteFFI(ctx, cm.namespace, id)
+	})
 }

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -172,9 +172,6 @@ func TestResolveFFI(t *testing.T) {
 
 func TestBroadcastFFIInvalid(t *testing.T) {
 	cm := newTestContractManager()
-	mdb := cm.database.(*databasemocks.Plugin)
-
-	mdb.On("GetFFI", mock.Anything, "ns1", "test", "1.0.0").Return(nil, nil)
 
 	ffi := &fftypes.FFI{
 		Namespace: "ns1",
@@ -196,37 +193,6 @@ func TestBroadcastFFIInvalid(t *testing.T) {
 
 	err := cm.ResolveFFI(context.Background(), ffi)
 	assert.Regexp(t, "does not validate", err)
-
-	mdb.AssertExpectations(t)
-}
-
-func TestResolveFFIExists(t *testing.T) {
-	cm := newTestContractManager()
-	mdb := cm.database.(*databasemocks.Plugin)
-
-	mdb.On("GetFFI", mock.Anything, "ns1", "test", "1.0.0").Return(&fftypes.FFI{}, nil)
-
-	ffi := &fftypes.FFI{
-		Namespace: "ns1",
-		Name:      "test",
-		Version:   "1.0.0",
-		ID:        fftypes.NewUUID(),
-		Methods: []*fftypes.FFIMethod{
-			{
-				Name: "sum",
-			},
-		},
-		Events: []*fftypes.FFIEvent{
-			{
-				FFIEventDefinition: fftypes.FFIEventDefinition{
-					Name: "changed",
-				},
-			},
-		},
-	}
-
-	err := cm.ResolveFFI(context.Background(), ffi)
-	assert.Regexp(t, "FF10302", err)
 }
 
 func TestValidateInvokeContractRequest(t *testing.T) {
@@ -1426,9 +1392,25 @@ func TestAddContractAPIListenerFail(t *testing.T) {
 func TestGetFFI(t *testing.T) {
 	cm := newTestContractManager()
 	mdb := cm.database.(*databasemocks.Plugin)
-	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "v1.0.0").Return(&fftypes.FFI{}, nil)
-	_, err := cm.GetFFI(context.Background(), "ffi", "v1.0.0")
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(&fftypes.FFI{}, nil)
+	_, err := cm.GetFFI(context.Background(), "ffi", "", "v1.0.0")
 	assert.NoError(t, err)
+}
+
+func TestGetFFINotFound(t *testing.T) {
+	cm := newTestContractManager()
+	mdb := cm.database.(*databasemocks.Plugin)
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(nil, nil)
+	_, err := cm.GetFFI(context.Background(), "ffi", "", "v1.0.0")
+	assert.Regexp(t, "FF10109", err)
+}
+
+func TestGetFFIFail(t *testing.T) {
+	cm := newTestContractManager()
+	mdb := cm.database.(*databasemocks.Plugin)
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(nil, fmt.Errorf("pop"))
+	_, err := cm.GetFFI(context.Background(), "ffi", "", "v1.0.0")
+	assert.EqualError(t, err, "pop")
 }
 
 func TestGetFFIWithChildren(t *testing.T) {
@@ -1437,7 +1419,7 @@ func TestGetFFIWithChildren(t *testing.T) {
 	mbi := cm.blockchain.(*blockchainmocks.Plugin)
 
 	cid := fftypes.NewUUID()
-	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "v1.0.0").Return(&fftypes.FFI{ID: cid}, nil)
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(&fftypes.FFI{ID: cid}, nil)
 	mdb.On("GetFFIMethods", mock.Anything, "ns1", mock.Anything).Return([]*fftypes.FFIMethod{
 		{ID: fftypes.NewUUID(), Name: "method1"},
 	}, nil, nil)
@@ -3143,7 +3125,7 @@ func TestResolveContractAPIInterfaceName(t *testing.T) {
 
 	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeCall, api.Location).Return(api.Location, nil)
 	mdb.On("GetContractAPIByName", mock.Anything, api.Namespace, api.Name).Return(nil, nil)
-	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "1").Return(&fftypes.FFI{ID: interfaceID}, nil)
+	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "", "1").Return(&fftypes.FFI{ID: interfaceID}, nil)
 
 	err := cm.ResolveContractAPI(context.Background(), "http://localhost/api", api)
 	assert.NoError(t, err)
@@ -3244,7 +3226,7 @@ func TestResolveContractAPIInterfaceNameFail(t *testing.T) {
 
 	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeCall, api.Location).Return(api.Location, nil)
 	mdb.On("GetContractAPIByName", mock.Anything, api.Namespace, api.Name).Return(nil, nil)
-	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "1").Return(nil, fmt.Errorf("pop"))
+	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "", "1").Return(nil, fmt.Errorf("pop"))
 
 	err := cm.ResolveContractAPI(context.Background(), "http://localhost/api", api)
 	assert.EqualError(t, err, "pop")
@@ -3271,7 +3253,7 @@ func TestResolveContractAPIInterfaceNameNotFound(t *testing.T) {
 
 	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeCall, api.Location).Return(api.Location, nil)
 	mdb.On("GetContractAPIByName", mock.Anything, api.Namespace, api.Name).Return(nil, nil)
-	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "1").Return(nil, nil)
+	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "", "1").Return(nil, nil)
 
 	err := cm.ResolveContractAPI(context.Background(), "http://localhost/api", api)
 	assert.Regexp(t, "FF10303.*my-ffi", err)

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -1392,24 +1392,24 @@ func TestAddContractAPIListenerFail(t *testing.T) {
 func TestGetFFI(t *testing.T) {
 	cm := newTestContractManager()
 	mdb := cm.database.(*databasemocks.Plugin)
-	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(&fftypes.FFI{}, nil)
-	_, err := cm.GetFFI(context.Background(), "ffi", "", "v1.0.0")
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "v1.0.0").Return(&fftypes.FFI{}, nil)
+	_, err := cm.GetFFI(context.Background(), "ffi", "v1.0.0")
 	assert.NoError(t, err)
 }
 
 func TestGetFFINotFound(t *testing.T) {
 	cm := newTestContractManager()
 	mdb := cm.database.(*databasemocks.Plugin)
-	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(nil, nil)
-	_, err := cm.GetFFI(context.Background(), "ffi", "", "v1.0.0")
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "v1.0.0").Return(nil, nil)
+	_, err := cm.GetFFI(context.Background(), "ffi", "v1.0.0")
 	assert.Regexp(t, "FF10109", err)
 }
 
 func TestGetFFIFail(t *testing.T) {
 	cm := newTestContractManager()
 	mdb := cm.database.(*databasemocks.Plugin)
-	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(nil, fmt.Errorf("pop"))
-	_, err := cm.GetFFI(context.Background(), "ffi", "", "v1.0.0")
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "v1.0.0").Return(nil, fmt.Errorf("pop"))
+	_, err := cm.GetFFI(context.Background(), "ffi", "v1.0.0")
 	assert.EqualError(t, err, "pop")
 }
 
@@ -1419,7 +1419,7 @@ func TestGetFFIWithChildren(t *testing.T) {
 	mbi := cm.blockchain.(*blockchainmocks.Plugin)
 
 	cid := fftypes.NewUUID()
-	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "", "v1.0.0").Return(&fftypes.FFI{ID: cid}, nil)
+	mdb.On("GetFFI", mock.Anything, "ns1", "ffi", "v1.0.0").Return(&fftypes.FFI{ID: cid}, nil)
 	mdb.On("GetFFIMethods", mock.Anything, "ns1", mock.Anything).Return([]*fftypes.FFIMethod{
 		{ID: fftypes.NewUUID(), Name: "method1"},
 	}, nil, nil)
@@ -3125,7 +3125,7 @@ func TestResolveContractAPIInterfaceName(t *testing.T) {
 
 	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeCall, api.Location).Return(api.Location, nil)
 	mdb.On("GetContractAPIByName", mock.Anything, api.Namespace, api.Name).Return(nil, nil)
-	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "", "1").Return(&fftypes.FFI{ID: interfaceID}, nil)
+	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "1").Return(&fftypes.FFI{ID: interfaceID}, nil)
 
 	err := cm.ResolveContractAPI(context.Background(), "http://localhost/api", api)
 	assert.NoError(t, err)
@@ -3226,7 +3226,7 @@ func TestResolveContractAPIInterfaceNameFail(t *testing.T) {
 
 	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeCall, api.Location).Return(api.Location, nil)
 	mdb.On("GetContractAPIByName", mock.Anything, api.Namespace, api.Name).Return(nil, nil)
-	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "", "1").Return(nil, fmt.Errorf("pop"))
+	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "1").Return(nil, fmt.Errorf("pop"))
 
 	err := cm.ResolveContractAPI(context.Background(), "http://localhost/api", api)
 	assert.EqualError(t, err, "pop")
@@ -3253,7 +3253,7 @@ func TestResolveContractAPIInterfaceNameNotFound(t *testing.T) {
 
 	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeCall, api.Location).Return(api.Location, nil)
 	mdb.On("GetContractAPIByName", mock.Anything, api.Namespace, api.Name).Return(nil, nil)
-	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "", "1").Return(nil, nil)
+	mdb.On("GetFFI", mock.Anything, "ns1", "my-ffi", "1").Return(nil, nil)
 
 	err := cm.ResolveContractAPI(context.Background(), "http://localhost/api", api)
 	assert.Regexp(t, "FF10303.*my-ffi", err)

--- a/internal/coremsgs/en_api_translations.go
+++ b/internal/coremsgs/en_api_translations.go
@@ -154,6 +154,7 @@ var (
 	APIEndpointsPostContractInterfaceGenerate   = ffm("api.endpoints.postContractInterfaceGenerate", "A convenience method to convert a blockchain specific smart contract format into a FireFly Interface format. The specific blockchain plugin in use must support this functionality.")
 	APIEndpointsPostContractInterfaceInvoke     = ffm("api.endpoints.postContractInterfaceInvoke", "Invokes a method on a smart contract that matches a given contract interface. Performs a blockchain transaction.")
 	APIEndpointsPostContractInterfaceQuery      = ffm("api.endpoints.postContractInterfaceQuery", "Queries a method on a smart contract that matches a given contract interface. Performs a read-only query.")
+	APIEndpointsPostContractInterfacePublish    = ffm("api.endpoints.postContractInterfacePublish", "Publish a contract interface to all other members of the multiparty network")
 	APIEndpointsPostContractInvoke              = ffm("api.endpoints.postContractInvoke", "Invokes a method on a smart contract. Performs a blockchain transaction.")
 	APIEndpointsPostContractQuery               = ffm("api.endpoints.postContractQuery", "Queries a method on a smart contract. Performs a read-only query.")
 	APIEndpointsPostData                        = ffm("api.endpoints.postData", "Creates a new data item in this FireFly node")

--- a/internal/coremsgs/en_api_translations.go
+++ b/internal/coremsgs/en_api_translations.go
@@ -76,8 +76,10 @@ var (
 	APIEndpointsAdminGetListenerByID    = ffm("api.endpoints.adminGetListenerByID", "Gets a contract listener by ID")
 	APIEndpointsAdminGetListeners       = ffm("api.endpoints.adminGetListeners", "Lists contract listeners")
 
+	APIEndpointsDeleteContractInterface         = ffm("api.endpoints.deleteContractInterface", "Delete a contract interface")
 	APIEndpointsDeleteContractListener          = ffm("api.endpoints.deleteContractListener", "Deletes a contract listener referenced by its name or its ID")
 	APIEndpointsDeleteSubscription              = ffm("api.endpoints.deleteSubscription", "Deletes a subscription")
+	APIEndpointsDeleteTokenPool                 = ffm("api.endpoints.deleteTokenPool", "Delete a token pool")
 	APIEndpointsGetBatchBbyID                   = ffm("api.endpoints.getBatchByID", "Gets a message batch")
 	APIEndpointsGetBatches                      = ffm("api.endpoints.getBatches", "Gets a list of message batches")
 	APIEndpointsGetBlockchainEventByID          = ffm("api.endpoints.getBlockchainEventByID", "Gets a blockchain event")
@@ -180,7 +182,6 @@ var (
 	APIEndpointsPostTokenMint                   = ffm("api.endpoints.postTokenMint", "Mints some tokens")
 	APIEndpointsPostTokenPool                   = ffm("api.endpoints.postTokenPool", "Creates a new token pool")
 	APIEndpointsPostTokenPoolPublish            = ffm("api.endpoints.postTokenPoolPublish", "Publish a token pool to all other members of the multiparty network")
-	APIEndpointsDeleteTokenPool                 = ffm("api.endpoints.deleteTokenPool", "Delete a token pool")
 	APIEndpointsPostTokenTransfer               = ffm("api.endpoints.postTokenTransfer", "Transfers some tokens")
 	APIEndpointsPutContractAPI                  = ffm("api.endpoints.putContractAPI", "Updates an existing contract API")
 	APIEndpointsPutSubscription                 = ffm("api.endpoints.putSubscription", "Update an existing subscription")

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -287,4 +287,5 @@ var (
 	MsgNetworkNameExists                  = ffe("FF10448", "Network name already exists", 409)
 	MsgCannotDeletePublished              = ffe("FF10449", "Cannot delete an item that has been published", 409)
 	MsgAlreadyPublished                   = ffe("FF10450", "Item has already been published", 409)
+	MsgContractInterfaceNotPublished      = ffe("FF10451", "Contract interface '%s' has not been published", 409)
 )

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -244,13 +244,13 @@ var (
 	FFIMessage     = ffm("FFI.message", "The UUID of the broadcast message that was used to publish this FFI to the network")
 	FFINamespace   = ffm("FFI.namespace", "The namespace of the FFI")
 	FFIName        = ffm("FFI.name", "The name of the FFI - usually matching the smart contract name")
+	FFINetworkName = ffm("FFI.networkName", "The published name of the FFI within the multiparty network")
 	FFIDescription = ffm("FFI.description", "A description of the smart contract this FFI represents")
 	FFIVersion     = ffm("FFI.version", "A version for the FFI - use of semantic versioning such as 'v1.0.1' is encouraged")
 	FFIMethods     = ffm("FFI.methods", "An array of smart contract method definitions")
 	FFIEvents      = ffm("FFI.events", "An array of smart contract event definitions")
 	FFIErrors      = ffm("FFI.errors", "An array of smart contract error definitions")
-	FFINetworkName = ffm("FFI.networkName", "The shared interface name within the multiparty network")
-	FFIPublished   = ffm("FFI.published", "True if the interface has been published to a multiparty network")
+	FFIPublished   = ffm("FFI.published", "Indicates if the FFI is published to other members of the multiparty network")
 
 	// FFIMethod field descriptions
 	FFIMethodID          = ffm("FFIMethod.id", "The UUID of the FFI method definition")

--- a/internal/database/sqlcommon/ffi_sql_test.go
+++ b/internal/database/sqlcommon/ffi_sql_test.go
@@ -43,6 +43,7 @@ func TestFFIE2EWithDB(t *testing.T) {
 		ID:          id,
 		Namespace:   "ns1",
 		Name:        "math",
+		NetworkName: "math",
 		Version:     "v1.0.0",
 		Description: "Does things and stuff",
 		Message:     fftypes.NewUUID(),
@@ -72,7 +73,7 @@ func TestFFIE2EWithDB(t *testing.T) {
 	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionFFIs, core.ChangeEventTypeCreated, "ns1", ffi.ID).Return()
 	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionFFIs, core.ChangeEventTypeUpdated, "ns1", ffi.ID).Return()
 
-	err := s.UpsertFFI(ctx, ffi)
+	_, err := s.InsertOrGetFFI(ctx, ffi)
 	assert.NoError(t, err)
 
 	// Check we get the correct fields back
@@ -86,8 +87,7 @@ func TestFFIE2EWithDB(t *testing.T) {
 	assert.Equal(t, ffi.Message, dataRead.Message)
 
 	ffi.Version = "v1.1.0"
-
-	err = s.UpsertFFI(ctx, ffi)
+	err = s.UpsertFFI(ctx, ffi, database.UpsertOptimizationExisting)
 	assert.NoError(t, err)
 
 	// Check we get the correct fields back
@@ -99,12 +99,30 @@ func TestFFIE2EWithDB(t *testing.T) {
 	assert.Equal(t, ffi.Name, dataRead.Name)
 	assert.Equal(t, ffi.Version, dataRead.Version)
 	assert.Equal(t, ffi.Message, dataRead.Message)
+
+	// Cannot insert again with same name or network name
+	existing, err := s.InsertOrGetFFI(ctx, &fftypes.FFI{
+		ID:        fftypes.NewUUID(),
+		Name:      "math",
+		Version:   "v1.1.0",
+		Namespace: "ns1",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, ffi.ID, existing.ID)
+	existing, err = s.InsertOrGetFFI(ctx, &fftypes.FFI{
+		ID:          fftypes.NewUUID(),
+		NetworkName: "math",
+		Version:     "v1.1.0",
+		Namespace:   "ns1",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, ffi.ID, existing.ID)
 }
 
 func TestFFIDBFailBeginTransaction(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
-	err := s.UpsertFFI(context.Background(), &fftypes.FFI{})
+	err := s.UpsertFFI(context.Background(), &fftypes.FFI{}, database.UpsertOptimizationNew)
 	assert.Regexp(t, "FF00175", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -113,20 +131,39 @@ func TestFFIDBFailSelect(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
-	err := s.UpsertFFI(context.Background(), &fftypes.FFI{})
+	err := s.UpsertFFI(context.Background(), &fftypes.FFI{}, database.UpsertOptimizationNew)
 	assert.Regexp(t, "pop", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestFFIDBFailInsert(t *testing.T) {
-	rows := sqlmock.NewRows([]string{"id", "namespace", "name", "version"})
+func TestFFIDBFailUpsert(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{}))
+	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
+	err := s.UpsertFFI(context.Background(), &fftypes.FFI{}, database.UpsertOptimizationNew)
+	assert.Regexp(t, "pop", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFFIDBInsertFailBegin(t *testing.T) {
+	s, mock := newMockProvider().init()
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
+	_, err := s.InsertOrGetFFI(context.Background(), &fftypes.FFI{})
+	assert.Regexp(t, "FF00175", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFFIDBFailInsert(t *testing.T) {
+	s, mock := newMockProvider().init()
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{}))
+	mock.ExpectRollback()
 	ffi := &fftypes.FFI{
 		ID: fftypes.NewUUID(),
 	}
-	err := s.UpsertFFI(context.Background(), ffi)
+	_, err := s.InsertOrGetFFI(context.Background(), ffi)
 	assert.Regexp(t, "FF00177", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -141,7 +178,7 @@ func TestFFIDBFailUpdate(t *testing.T) {
 	ffi := &fftypes.FFI{
 		ID: fftypes.NewUUID(),
 	}
-	err := s.UpsertFFI(context.Background(), ffi)
+	err := s.UpsertFFI(context.Background(), ffi, database.UpsertOptimizationNew)
 	assert.Regexp(t, "pop", err)
 }
 
@@ -176,7 +213,7 @@ func TestGetFFIs(t *testing.T) {
 	fb := database.FFIQueryFactory.NewFilter(context.Background())
 	s, mock := newMockProvider().init()
 	rows := sqlmock.NewRows(ffiColumns).
-		AddRow("7e2c001c-e270-4fd7-9e82-9dacee843dc2", "ns1", "math", "v1.0.0", "super mathy things", "acfe07a2-117f-46b7-8d47-e3beb7cc382f")
+		AddRow("7e2c001c-e270-4fd7-9e82-9dacee843dc2", "ns1", "math", "math", "v1.0.0", "super mathy things", "acfe07a2-117f-46b7-8d47-e3beb7cc382f", false)
 	mock.ExpectQuery("SELECT .*").WillReturnRows(rows)
 	_, _, err := s.GetFFIs(context.Background(), "ns1", fb.And())
 	assert.NoError(t, err)
@@ -214,9 +251,9 @@ func TestGetFFIsQueryResultFail(t *testing.T) {
 func TestGetFFI(t *testing.T) {
 	s, mock := newMockProvider().init()
 	rows := sqlmock.NewRows(ffiColumns).
-		AddRow("7e2c001c-e270-4fd7-9e82-9dacee843dc2", "ns1", "math", "v1.0.0", "super mathy things", "acfe07a2-117f-46b7-8d47-e3beb7cc382f")
+		AddRow("7e2c001c-e270-4fd7-9e82-9dacee843dc2", "ns1", "math", "math", "v1.0.0", "super mathy things", "acfe07a2-117f-46b7-8d47-e3beb7cc382f", false)
 	mock.ExpectQuery("SELECT .*").WillReturnRows(rows)
-	ffi, err := s.GetFFI(context.Background(), "ns1", "math", "v1.0.0")
+	ffi, err := s.GetFFI(context.Background(), "ns1", "math", "math", "v1.0.0")
 	assert.NoError(t, err)
 	assert.Equal(t, "ns1", ffi.Namespace)
 	assert.Equal(t, "math", ffi.Name)

--- a/internal/database/sqlcommon/ffi_sql_test.go
+++ b/internal/database/sqlcommon/ffi_sql_test.go
@@ -101,6 +101,15 @@ func TestFFIE2EWithDB(t *testing.T) {
 	assert.Equal(t, ffi.Version, dataRead.Version)
 	assert.Equal(t, ffi.Message, dataRead.Message)
 
+	dataRead, err = s.GetFFIByNetworkName(ctx, "ns1", "math", "v1.1.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, dataRead)
+	assert.Equal(t, ffi.ID, dataRead.ID)
+	assert.Equal(t, ffi.Namespace, dataRead.Namespace)
+	assert.Equal(t, ffi.Name, dataRead.Name)
+	assert.Equal(t, ffi.Version, dataRead.Version)
+	assert.Equal(t, ffi.Message, dataRead.Message)
+
 	// Cannot insert again with same name or network name
 	existing, err := s.InsertOrGetFFI(ctx, &fftypes.FFI{
 		ID:        fftypes.NewUUID(),
@@ -258,7 +267,7 @@ func TestGetFFI(t *testing.T) {
 	rows := sqlmock.NewRows(ffiColumns).
 		AddRow("7e2c001c-e270-4fd7-9e82-9dacee843dc2", "ns1", "math", "math", "v1.0.0", "super mathy things", "acfe07a2-117f-46b7-8d47-e3beb7cc382f", false)
 	mock.ExpectQuery("SELECT .*").WillReturnRows(rows)
-	ffi, err := s.GetFFI(context.Background(), "ns1", "math", "math", "v1.0.0")
+	ffi, err := s.GetFFI(context.Background(), "ns1", "math", "v1.0.0")
 	assert.NoError(t, err)
 	assert.Equal(t, "ns1", ffi.Namespace)
 	assert.Equal(t, "math", ffi.Name)

--- a/internal/definitions/sender.go
+++ b/internal/definitions/sender.go
@@ -44,6 +44,7 @@ type Sender interface {
 	DefineTokenPool(ctx context.Context, pool *core.TokenPool, waitConfirm bool) error
 	PublishTokenPool(ctx context.Context, poolNameOrID, networkName string, waitConfirm bool) (*core.TokenPool, error)
 	DefineFFI(ctx context.Context, ffi *fftypes.FFI, waitConfirm bool) error
+	PublishFFI(ctx context.Context, name, version, networkName string, waitConfirm bool) (*fftypes.FFI, error)
 	DefineContractAPI(ctx context.Context, httpServerURL string, api *core.ContractAPI, waitConfirm bool) error
 }
 

--- a/internal/definitions/sender_contracts.go
+++ b/internal/definitions/sender_contracts.go
@@ -18,9 +18,13 @@ package definitions
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly-common/pkg/i18n"
+	"github.com/hyperledger/firefly/internal/coremsgs"
 	"github.com/hyperledger/firefly/pkg/core"
+	"github.com/hyperledger/firefly/pkg/database"
 )
 
 func (ds *definitionSender) DefineFFI(ctx context.Context, ffi *fftypes.FFI, waitConfirm bool) error {
@@ -35,23 +39,90 @@ func (ds *definitionSender) DefineFFI(ctx context.Context, ffi *fftypes.FFI, wai
 		errorDef.ID = fftypes.NewUUID()
 	}
 
-	if ds.multiparty {
-		if err := ds.contracts.ResolveFFI(ctx, ffi); err != nil {
-			return err
-		}
+	existing, err := ds.contracts.GetFFI(ctx, ffi.Name, ffi.NetworkName, ffi.Version)
+	if existing != nil && err == nil {
+		return i18n.NewError(ctx, coremsgs.MsgContractInterfaceExists, ffi.Namespace, ffi.Name, ffi.Version)
+	}
 
-		ffi.Namespace = ""
-		msg, err := ds.getSenderDefault(ctx, ffi, core.SystemTagDefineFFI).send(ctx, waitConfirm)
-		if msg != nil {
-			ffi.Message = msg.Header.ID
+	if ffi.Published {
+		if !ds.multiparty {
+			return i18n.NewError(ctx, coremsgs.MsgActionNotSupported)
 		}
-		ffi.Namespace = ds.namespace
+		_, err := ds.getFFISender(ctx, ffi).send(ctx, waitConfirm)
 		return err
 	}
 
+	ffi.NetworkName = ""
+
 	return fakeBatch(ctx, func(ctx context.Context, state *core.BatchState) (HandlerResult, error) {
-		return ds.handler.handleFFIDefinition(ctx, state, ffi, nil)
+		hr, err := ds.handler.handleFFIDefinition(ctx, state, ffi, nil)
+		if err != nil {
+			if innerErr := errors.Unwrap(err); innerErr != nil {
+				return hr, innerErr
+			}
+		}
+		return hr, err
 	})
+}
+
+func (ds *definitionSender) getFFISender(ctx context.Context, ffi *fftypes.FFI) *sendWrapper {
+	if err := ds.contracts.ResolveFFI(ctx, ffi); err != nil {
+		return wrapSendError(err)
+	}
+
+	// Prepare the FFI definition to be serialized for broadcast
+	localName := ffi.Name
+	ffi.Name = ""
+	ffi.Namespace = ""
+	ffi.Published = true
+	if ffi.NetworkName == "" {
+		ffi.NetworkName = localName
+	}
+
+	sender := ds.getSenderDefault(ctx, ffi, core.SystemTagDefineFFI)
+	if sender.message != nil {
+		ffi.Message = sender.message.Header.ID
+	}
+
+	ffi.Name = localName
+	ffi.Namespace = ds.namespace
+	return sender
+}
+
+func (ds *definitionSender) PublishFFI(ctx context.Context, name, version, networkName string, waitConfirm bool) (ffi *fftypes.FFI, err error) {
+	if !ds.multiparty {
+		return nil, i18n.NewError(ctx, coremsgs.MsgActionNotSupported)
+	}
+
+	var sender *sendWrapper
+	err = ds.database.RunAsGroup(ctx, func(ctx context.Context) error {
+		if ffi, err = ds.contracts.GetFFI(ctx, name, "", version); err != nil {
+			return err
+		}
+		if networkName != "" {
+			ffi.NetworkName = networkName
+		}
+
+		sender = ds.getFFISender(ctx, ffi)
+		if sender.err != nil {
+			return sender.err
+		}
+		if !waitConfirm {
+			if err = sender.sender.Prepare(ctx); err != nil {
+				return err
+			}
+			if err = ds.database.UpsertFFI(ctx, ffi, database.UpsertOptimizationExisting); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = sender.send(ctx, waitConfirm)
+	return ffi, err
 }
 
 func (ds *definitionSender) DefineContractAPI(ctx context.Context, httpServerURL string, api *core.ContractAPI, waitConfirm bool) error {

--- a/internal/definitions/sender_contracts_test.go
+++ b/internal/definitions/sender_contracts_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly/mocks/broadcastmocks"
 	"github.com/hyperledger/firefly/mocks/contractmocks"
+	"github.com/hyperledger/firefly/mocks/databasemocks"
 	"github.com/hyperledger/firefly/mocks/identitymanagermocks"
 	"github.com/hyperledger/firefly/mocks/syncasyncmocks"
 	"github.com/hyperledger/firefly/pkg/core"
+	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -37,12 +39,16 @@ func TestDefineFFIResolveFail(t *testing.T) {
 	ds.multiparty = true
 
 	ffi := &fftypes.FFI{
-		Methods: []*fftypes.FFIMethod{{}},
-		Events:  []*fftypes.FFIEvent{{}},
-		Errors:  []*fftypes.FFIError{{}},
+		Name:      "ffi1",
+		Version:   "1.0",
+		Methods:   []*fftypes.FFIMethod{{}},
+		Events:    []*fftypes.FFIEvent{{}},
+		Errors:    []*fftypes.FFIError{{}},
+		Published: true,
 	}
 
 	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
 	mcm.On("ResolveFFI", context.Background(), ffi).Return(fmt.Errorf("pop"))
 
 	err := ds.DefineFFI(context.Background(), ffi, false)
@@ -56,9 +62,14 @@ func TestDefineFFIFail(t *testing.T) {
 	defer cancel()
 	ds.multiparty = true
 
-	ffi := &fftypes.FFI{}
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Published: true,
+	}
 
 	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
 	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
@@ -71,14 +82,39 @@ func TestDefineFFIFail(t *testing.T) {
 	mim.AssertExpectations(t)
 }
 
+func TestDefineFFIExists(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Published: true,
+	}
+
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(&fftypes.FFI{}, nil)
+
+	err := ds.DefineFFI(context.Background(), ffi, false)
+	assert.Regexp(t, "FF10302", err)
+
+	mcm.AssertExpectations(t)
+}
+
 func TestDefineFFIOk(t *testing.T) {
 	ds, cancel := newTestDefinitionSender(t)
 	defer cancel()
 	ds.multiparty = true
 
-	ffi := &fftypes.FFI{}
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Published: true,
+	}
 
 	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
 	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
@@ -108,9 +144,14 @@ func TestDefineFFIConfirm(t *testing.T) {
 	defer cancel()
 	ds.multiparty = true
 
-	ffi := &fftypes.FFI{}
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Published: true,
+	}
 
 	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
 	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
@@ -135,14 +176,67 @@ func TestDefineFFIConfirm(t *testing.T) {
 	mms.AssertExpectations(t)
 }
 
+func TestDefineFFIPublishNonMultiparty(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = false
+
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Published: true,
+	}
+
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
+
+	err := ds.DefineFFI(context.Background(), ffi, false)
+	assert.Regexp(t, "FF10414", err)
+
+	mcm.AssertExpectations(t)
+}
+
 func TestDefineFFINonMultiparty(t *testing.T) {
 	ds, cancel := newTestDefinitionSender(t)
 	defer cancel()
 
-	ffi := &fftypes.FFI{}
+	ffi := &fftypes.FFI{
+		Name:    "ffi1",
+		Version: "1.0",
+	}
+
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
+	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
+
+	mdi := ds.database.(*databasemocks.Plugin)
+	mdi.On("InsertOrGetFFI", context.Background(), ffi).Return(nil, nil)
+	mdi.On("InsertEvent", context.Background(), mock.Anything).Return(nil)
+
+	err := ds.DefineFFI(context.Background(), ffi, false)
+	assert.NoError(t, err)
+
+	mcm.AssertExpectations(t)
+	mdi.AssertExpectations(t)
+}
+
+func TestDefineFFINonMultipartyFail(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+
+	ffi := &fftypes.FFI{
+		Name:    "ffi1",
+		Version: "1.0",
+	}
+
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, nil)
+	mcm.On("ResolveFFI", context.Background(), ffi).Return(fmt.Errorf("pop"))
 
 	err := ds.DefineFFI(context.Background(), ffi, false)
 	assert.Regexp(t, "FF10403", err)
+
+	mcm.AssertExpectations(t)
 }
 
 func TestDefineContractAPIResolveFail(t *testing.T) {
@@ -225,4 +319,182 @@ func TestDefineContractAPINonMultiparty(t *testing.T) {
 
 	err := ds.DefineContractAPI(context.Background(), url, api, false)
 	assert.Regexp(t, "FF10403", err)
+}
+
+func TestPublishFFI(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	mdi := ds.database.(*databasemocks.Plugin)
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mim := ds.identity.(*identitymanagermocks.Manager)
+	mbm := ds.broadcast.(*broadcastmocks.Manager)
+	mms := &syncasyncmocks.Sender{}
+
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Namespace: "ns1",
+		Published: false,
+	}
+
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(ffi, nil)
+	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
+	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
+	mbm.On("NewBroadcast", mock.Anything).Return(mms)
+	mms.On("Prepare", context.Background()).Return(nil)
+	mms.On("Send", context.Background()).Return(nil)
+	mdi.On("UpsertFFI", context.Background(), ffi, database.UpsertOptimizationExisting).Return(nil)
+	mockRunAsGroupPassthrough(mdi)
+
+	result, err := ds.PublishFFI(context.Background(), "ffi1", "1.0", "ffi1-shared", false)
+	assert.NoError(t, err)
+	assert.Equal(t, ffi, result)
+	assert.True(t, ffi.Published)
+
+	mdi.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+	mim.AssertExpectations(t)
+	mbm.AssertExpectations(t)
+	mms.AssertExpectations(t)
+}
+
+func TestPublishFFIQueryFail(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	mdi := ds.database.(*databasemocks.Plugin)
+	mcm := ds.contracts.(*contractmocks.Manager)
+
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(nil, fmt.Errorf("pop"))
+	mockRunAsGroupPassthrough(mdi)
+
+	_, err := ds.PublishFFI(context.Background(), "ffi1", "1.0", "ffi1-shared", false)
+	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+}
+
+func TestPublishFFIResolveFail(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	mdi := ds.database.(*databasemocks.Plugin)
+	mcm := ds.contracts.(*contractmocks.Manager)
+
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Namespace: "ns1",
+		Published: false,
+	}
+
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(ffi, nil)
+	mcm.On("ResolveFFI", context.Background(), ffi).Return(fmt.Errorf("pop"))
+	mockRunAsGroupPassthrough(mdi)
+
+	_, err := ds.PublishFFI(context.Background(), "ffi1", "1.0", "ffi1-shared", false)
+	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+}
+
+func TestPublishFFIPrepareFail(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	mdi := ds.database.(*databasemocks.Plugin)
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mim := ds.identity.(*identitymanagermocks.Manager)
+	mbm := ds.broadcast.(*broadcastmocks.Manager)
+	mms := &syncasyncmocks.Sender{}
+
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Namespace: "ns1",
+		Published: false,
+	}
+
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(ffi, nil)
+	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
+	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
+	mbm.On("NewBroadcast", mock.Anything).Return(mms)
+	mms.On("Prepare", context.Background()).Return(fmt.Errorf("pop"))
+	mockRunAsGroupPassthrough(mdi)
+
+	_, err := ds.PublishFFI(context.Background(), "ffi1", "1.0", "ffi1-shared", false)
+	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+	mim.AssertExpectations(t)
+	mbm.AssertExpectations(t)
+	mms.AssertExpectations(t)
+}
+
+func TestPublishFFIUpsertFail(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = true
+
+	mdi := ds.database.(*databasemocks.Plugin)
+	mcm := ds.contracts.(*contractmocks.Manager)
+	mim := ds.identity.(*identitymanagermocks.Manager)
+	mbm := ds.broadcast.(*broadcastmocks.Manager)
+	mms := &syncasyncmocks.Sender{}
+
+	ffi := &fftypes.FFI{
+		Name:      "ffi1",
+		Version:   "1.0",
+		Namespace: "ns1",
+		Published: false,
+	}
+
+	mcm.On("GetFFI", context.Background(), "ffi1", "", "1.0").Return(ffi, nil)
+	mcm.On("ResolveFFI", context.Background(), ffi).Return(nil)
+	mim.On("GetMultipartyRootOrg", context.Background()).Return(&core.Identity{
+		IdentityBase: core.IdentityBase{
+			DID: "firefly:org1",
+		},
+	}, nil)
+	mim.On("ResolveInputSigningIdentity", mock.Anything, mock.Anything).Return(nil)
+	mbm.On("NewBroadcast", mock.Anything).Return(mms)
+	mms.On("Prepare", context.Background()).Return(nil)
+	mdi.On("UpsertFFI", context.Background(), ffi, database.UpsertOptimizationExisting).Return(fmt.Errorf("pop"))
+	mockRunAsGroupPassthrough(mdi)
+
+	_, err := ds.PublishFFI(context.Background(), "ffi1", "1.0", "ffi1-shared", false)
+	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
+	mcm.AssertExpectations(t)
+	mim.AssertExpectations(t)
+	mbm.AssertExpectations(t)
+	mms.AssertExpectations(t)
+}
+
+func TestPublishFFINonMultiparty(t *testing.T) {
+	ds, cancel := newTestDefinitionSender(t)
+	defer cancel()
+	ds.multiparty = false
+
+	_, err := ds.PublishFFI(context.Background(), "ffi1", "1.0", "ffi1-shared", false)
+	assert.Regexp(t, "FF10414", err)
 }

--- a/internal/definitions/sender_datatype_test.go
+++ b/internal/definitions/sender_datatype_test.go
@@ -32,8 +32,8 @@ import (
 )
 
 func TestDefineDatatypeBadType(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 	err := ds.DefineDatatype(context.Background(), &core.Datatype{
 		Validator: core.ValidatorType("wrong"),
@@ -42,8 +42,8 @@ func TestDefineDatatypeBadType(t *testing.T) {
 }
 
 func TestBroadcastDatatypeBadValue(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 	mdm := ds.data.(*datamocks.Manager)
 	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
@@ -67,14 +67,11 @@ func TestBroadcastDatatypeBadValue(t *testing.T) {
 }
 
 func TestDefineDatatypeInvalid(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
-	mdm := ds.data.(*datamocks.Manager)
-	mim := ds.identity.(*identitymanagermocks.Manager)
 
-	mim.On("ResolveInputIdentity", mock.Anything, mock.Anything).Return(nil)
-	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	ds.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	err := ds.DefineDatatype(context.Background(), &core.Datatype{
 		Namespace: "ns1",
@@ -83,13 +80,11 @@ func TestDefineDatatypeInvalid(t *testing.T) {
 		Value:     fftypes.JSONAnyPtr(`{"some": "data"}`),
 	}, false)
 	assert.EqualError(t, err, "pop")
-
-	mdm.AssertExpectations(t)
 }
 
 func TestBroadcastOk(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 	mdm := ds.data.(*datamocks.Manager)
 	mim := ds.identity.(*identitymanagermocks.Manager)
@@ -121,8 +116,8 @@ func TestBroadcastOk(t *testing.T) {
 }
 
 func TestDefineDatatypeNonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = false
 
 	err := ds.DefineDatatype(context.Background(), &core.Datatype{

--- a/internal/definitions/sender_identity_test.go
+++ b/internal/definitions/sender_identity_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 func TestClaimIdentity(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
@@ -56,8 +56,8 @@ func TestClaimIdentity(t *testing.T) {
 }
 
 func TestClaimIdentityFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
@@ -82,8 +82,8 @@ func TestClaimIdentityFail(t *testing.T) {
 }
 
 func TestClaimIdentityFailKey(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
 
@@ -102,8 +102,8 @@ func TestClaimIdentityFailKey(t *testing.T) {
 }
 
 func TestClaimIdentityChild(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
@@ -136,8 +136,8 @@ func TestClaimIdentityChild(t *testing.T) {
 }
 
 func TestClaimIdentityChildFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
@@ -170,8 +170,8 @@ func TestClaimIdentityChildFail(t *testing.T) {
 }
 
 func TestClaimIdentityNonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	dh := ds.handler
 
 	mim := dh.identity.(*identitymanagermocks.Manager)
@@ -190,8 +190,8 @@ func TestClaimIdentityNonMultiparty(t *testing.T) {
 }
 
 func TestUpdateIdentity(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mim := ds.identity.(*identitymanagermocks.Manager)
 	mbm := ds.broadcast.(*broadcastmocks.Manager)
@@ -219,8 +219,8 @@ func TestUpdateIdentity(t *testing.T) {
 }
 
 func TestUpdateIdentityNonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	ds.multiparty = false
 

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -84,8 +84,6 @@ func TestBroadcastTokenPoolPublishNonMultiparty(t *testing.T) {
 	defer cancel()
 	ds.multiparty = false
 
-	mdm := ds.data.(*datamocks.Manager)
-
 	pool := &core.TokenPool{
 		ID:        fftypes.NewUUID(),
 		Namespace: "",
@@ -98,8 +96,6 @@ func TestBroadcastTokenPoolPublishNonMultiparty(t *testing.T) {
 
 	err := ds.DefineTokenPool(context.Background(), pool, false)
 	assert.Regexp(t, "FF10414", err)
-
-	mdm.AssertExpectations(t)
 }
 
 func TestBroadcastTokenPoolInvalidNameMultiparty(t *testing.T) {

--- a/internal/definitions/sender_tokenpool_test.go
+++ b/internal/definitions/sender_tokenpool_test.go
@@ -34,8 +34,8 @@ import (
 )
 
 func TestBroadcastTokenPoolInvalid(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdm := ds.data.(*datamocks.Manager)
@@ -57,8 +57,8 @@ func TestBroadcastTokenPoolInvalid(t *testing.T) {
 }
 
 func TestBroadcastTokenPoolInvalidNonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = false
 
 	mdm := ds.data.(*datamocks.Manager)
@@ -80,8 +80,8 @@ func TestBroadcastTokenPoolInvalidNonMultiparty(t *testing.T) {
 }
 
 func TestBroadcastTokenPoolPublishNonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = false
 
 	pool := &core.TokenPool{
@@ -99,8 +99,8 @@ func TestBroadcastTokenPoolPublishNonMultiparty(t *testing.T) {
 }
 
 func TestBroadcastTokenPoolInvalidNameMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdm := ds.data.(*datamocks.Manager)
@@ -123,8 +123,8 @@ func TestBroadcastTokenPoolInvalidNameMultiparty(t *testing.T) {
 }
 
 func TestDefineTokenPoolOk(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdi := ds.database.(*databasemocks.Plugin)
@@ -165,8 +165,8 @@ func TestDefineTokenPoolOk(t *testing.T) {
 }
 
 func TestDefineTokenPoolkONonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = false
 
 	mdb := ds.database.(*databasemocks.Plugin)
@@ -195,8 +195,8 @@ func TestDefineTokenPoolkONonMultiparty(t *testing.T) {
 }
 
 func TestDefineTokenPoolNonMultipartyTokenPoolFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 
 	mdi := ds.database.(*databasemocks.Plugin)
 
@@ -220,8 +220,8 @@ func TestDefineTokenPoolNonMultipartyTokenPoolFail(t *testing.T) {
 }
 
 func TestDefineTokenPoolBadName(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	pool := &core.TokenPool{
@@ -240,8 +240,8 @@ func TestDefineTokenPoolBadName(t *testing.T) {
 }
 
 func TestPublishTokenPool(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdi := ds.database.(*databasemocks.Plugin)
@@ -287,8 +287,8 @@ func TestPublishTokenPool(t *testing.T) {
 }
 
 func TestPublishTokenPoolNonMultiparty(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = false
 
 	_, err := ds.PublishTokenPool(context.Background(), "pool1", "pool-shared", false)
@@ -296,8 +296,8 @@ func TestPublishTokenPoolNonMultiparty(t *testing.T) {
 }
 
 func TestPublishTokenPoolAlreadyPublished(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mam := ds.assets.(*assetmocks.Manager)
@@ -325,8 +325,8 @@ func TestPublishTokenPoolAlreadyPublished(t *testing.T) {
 }
 
 func TestPublishTokenPoolQueryFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mam := ds.assets.(*assetmocks.Manager)
@@ -343,8 +343,8 @@ func TestPublishTokenPoolQueryFail(t *testing.T) {
 }
 
 func TestPublishTokenPoolNetworkNameError(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mam := ds.assets.(*assetmocks.Manager)
@@ -373,8 +373,8 @@ func TestPublishTokenPoolNetworkNameError(t *testing.T) {
 }
 
 func TestPublishTokenPoolNetworkNameConflict(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mam := ds.assets.(*assetmocks.Manager)
@@ -403,8 +403,8 @@ func TestPublishTokenPoolNetworkNameConflict(t *testing.T) {
 }
 
 func TestPublishTokenPoolResolveFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mam := ds.assets.(*assetmocks.Manager)
@@ -436,8 +436,8 @@ func TestPublishTokenPoolResolveFail(t *testing.T) {
 }
 
 func TestPublishTokenPoolPrepareFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdi := ds.database.(*databasemocks.Plugin)
@@ -481,8 +481,8 @@ func TestPublishTokenPoolPrepareFail(t *testing.T) {
 }
 
 func TestPublishTokenPoolSendFail(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdi := ds.database.(*databasemocks.Plugin)
@@ -527,8 +527,8 @@ func TestPublishTokenPoolSendFail(t *testing.T) {
 }
 
 func TestPublishTokenPoolConfirm(t *testing.T) {
-	ds, cancel := newTestDefinitionSender(t)
-	defer cancel()
+	ds := newTestDefinitionSender(t)
+	defer ds.cleanup(t)
 	ds.multiparty = true
 
 	mdi := ds.database.(*databasemocks.Plugin)

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -85,6 +85,20 @@ func (_m *Manager) DeleteContractListenerByNameOrID(ctx context.Context, nameOrI
 	return r0
 }
 
+// DeleteFFI provides a mock function with given fields: ctx, id
+func (_m *Manager) DeleteFFI(ctx context.Context, id *fftypes.UUID) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeployContract provides a mock function with given fields: ctx, req, waitConfirm
 func (_m *Manager) DeployContract(ctx context.Context, req *core.ContractDeployRequest, waitConfirm bool) (interface{}, error) {
 	ret := _m.Called(ctx, req, waitConfirm)

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -346,25 +346,25 @@ func (_m *Manager) GetContractListeners(ctx context.Context, filter ffapi.AndFil
 	return r0, r1, r2
 }
 
-// GetFFI provides a mock function with given fields: ctx, name, version
-func (_m *Manager) GetFFI(ctx context.Context, name string, version string) (*fftypes.FFI, error) {
-	ret := _m.Called(ctx, name, version)
+// GetFFI provides a mock function with given fields: ctx, name, networkName, version
+func (_m *Manager) GetFFI(ctx context.Context, name string, networkName string, version string) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, name, networkName, version)
 
 	var r0 *fftypes.FFI
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*fftypes.FFI, error)); ok {
-		return rf(ctx, name, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*fftypes.FFI, error)); ok {
+		return rf(ctx, name, networkName, version)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *fftypes.FFI); ok {
-		r0 = rf(ctx, name, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *fftypes.FFI); ok {
+		r0 = rf(ctx, name, networkName, version)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.FFI)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, name, version)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, name, networkName, version)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/contractmocks/manager.go
+++ b/mocks/contractmocks/manager.go
@@ -360,25 +360,25 @@ func (_m *Manager) GetContractListeners(ctx context.Context, filter ffapi.AndFil
 	return r0, r1, r2
 }
 
-// GetFFI provides a mock function with given fields: ctx, name, networkName, version
-func (_m *Manager) GetFFI(ctx context.Context, name string, networkName string, version string) (*fftypes.FFI, error) {
-	ret := _m.Called(ctx, name, networkName, version)
+// GetFFI provides a mock function with given fields: ctx, name, version
+func (_m *Manager) GetFFI(ctx context.Context, name string, version string) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, name, version)
 
 	var r0 *fftypes.FFI
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*fftypes.FFI, error)); ok {
-		return rf(ctx, name, networkName, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*fftypes.FFI, error)); ok {
+		return rf(ctx, name, version)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *fftypes.FFI); ok {
-		r0 = rf(ctx, name, networkName, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *fftypes.FFI); ok {
+		r0 = rf(ctx, name, version)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.FFI)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, name, networkName, version)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, name, version)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -81,6 +81,20 @@ func (_m *Plugin) DeleteData(ctx context.Context, namespace string, id *fftypes.
 	return r0
 }
 
+// DeleteFFI provides a mock function with given fields: ctx, namespace, id
+func (_m *Plugin) DeleteFFI(ctx context.Context, namespace string, id *fftypes.UUID) error {
+	ret := _m.Called(ctx, namespace, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID) error); ok {
+		r0 = rf(ctx, namespace, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteNonce provides a mock function with given fields: ctx, hash
 func (_m *Plugin) DeleteNonce(ctx context.Context, hash *fftypes.Bytes32) error {
 	ret := _m.Called(ctx, hash)

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -924,25 +924,25 @@ func (_m *Plugin) GetEvents(ctx context.Context, namespace string, filter ffapi.
 	return r0, r1, r2
 }
 
-// GetFFI provides a mock function with given fields: ctx, namespace, name, networkName, version
-func (_m *Plugin) GetFFI(ctx context.Context, namespace string, name string, networkName string, version string) (*fftypes.FFI, error) {
-	ret := _m.Called(ctx, namespace, name, networkName, version)
+// GetFFI provides a mock function with given fields: ctx, namespace, name, version
+func (_m *Plugin) GetFFI(ctx context.Context, namespace string, name string, version string) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, namespace, name, version)
 
 	var r0 *fftypes.FFI
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) (*fftypes.FFI, error)); ok {
-		return rf(ctx, namespace, name, networkName, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*fftypes.FFI, error)); ok {
+		return rf(ctx, namespace, name, version)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) *fftypes.FFI); ok {
-		r0 = rf(ctx, namespace, name, networkName, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *fftypes.FFI); ok {
+		r0 = rf(ctx, namespace, name, version)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.FFI)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
-		r1 = rf(ctx, namespace, name, networkName, version)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, namespace, name, version)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -969,6 +969,32 @@ func (_m *Plugin) GetFFIByID(ctx context.Context, namespace string, id *fftypes.
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.UUID) error); ok {
 		r1 = rf(ctx, namespace, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetFFIByNetworkName provides a mock function with given fields: ctx, namespace, networkName, version
+func (_m *Plugin) GetFFIByNetworkName(ctx context.Context, namespace string, networkName string, version string) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, namespace, networkName, version)
+
+	var r0 *fftypes.FFI
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*fftypes.FFI, error)); ok {
+		return rf(ctx, namespace, networkName, version)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *fftypes.FFI); ok {
+		r0 = rf(ctx, namespace, networkName, version)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.FFI)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, namespace, networkName, version)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -910,25 +910,25 @@ func (_m *Plugin) GetEvents(ctx context.Context, namespace string, filter ffapi.
 	return r0, r1, r2
 }
 
-// GetFFI provides a mock function with given fields: ctx, namespace, name, version
-func (_m *Plugin) GetFFI(ctx context.Context, namespace string, name string, version string) (*fftypes.FFI, error) {
-	ret := _m.Called(ctx, namespace, name, version)
+// GetFFI provides a mock function with given fields: ctx, namespace, name, networkName, version
+func (_m *Plugin) GetFFI(ctx context.Context, namespace string, name string, networkName string, version string) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, namespace, name, networkName, version)
 
 	var r0 *fftypes.FFI
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*fftypes.FFI, error)); ok {
-		return rf(ctx, namespace, name, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) (*fftypes.FFI, error)); ok {
+		return rf(ctx, namespace, name, networkName, version)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *fftypes.FFI); ok {
-		r0 = rf(ctx, namespace, name, version)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) *fftypes.FFI); ok {
+		r0 = rf(ctx, namespace, name, networkName, version)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.FFI)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, namespace, name, version)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = rf(ctx, namespace, name, networkName, version)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2619,6 +2619,32 @@ func (_m *Plugin) InsertOrGetBlockchainEvent(ctx context.Context, event *core.Bl
 	return r0, r1
 }
 
+// InsertOrGetFFI provides a mock function with given fields: ctx, ffi
+func (_m *Plugin) InsertOrGetFFI(ctx context.Context, ffi *fftypes.FFI) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, ffi)
+
+	var r0 *fftypes.FFI
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.FFI) (*fftypes.FFI, error)); ok {
+		return rf(ctx, ffi)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.FFI) *fftypes.FFI); ok {
+		r0 = rf(ctx, ffi)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.FFI)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.FFI) error); ok {
+		r1 = rf(ctx, ffi)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // InsertOrGetTokenPool provides a mock function with given fields: ctx, pool
 func (_m *Plugin) InsertOrGetTokenPool(ctx context.Context, pool *core.TokenPool) (*core.TokenPool, error) {
 	ret := _m.Called(ctx, pool)
@@ -2968,13 +2994,13 @@ func (_m *Plugin) UpsertDatatype(ctx context.Context, datadef *core.Datatype, al
 	return r0
 }
 
-// UpsertFFI provides a mock function with given fields: ctx, cd
-func (_m *Plugin) UpsertFFI(ctx context.Context, cd *fftypes.FFI) error {
-	ret := _m.Called(ctx, cd)
+// UpsertFFI provides a mock function with given fields: ctx, ffi, optimization
+func (_m *Plugin) UpsertFFI(ctx context.Context, ffi *fftypes.FFI, optimization database.UpsertOptimization) error {
+	ret := _m.Called(ctx, ffi, optimization)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.FFI) error); ok {
-		r0 = rf(ctx, cd)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.FFI, database.UpsertOptimization) error); ok {
+		r0 = rf(ctx, ffi, optimization)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/definitionsmocks/sender.go
+++ b/mocks/definitionsmocks/sender.go
@@ -101,6 +101,32 @@ func (_m *Sender) Name() string {
 	return r0
 }
 
+// PublishFFI provides a mock function with given fields: ctx, name, version, networkName, waitConfirm
+func (_m *Sender) PublishFFI(ctx context.Context, name string, version string, networkName string, waitConfirm bool) (*fftypes.FFI, error) {
+	ret := _m.Called(ctx, name, version, networkName, waitConfirm)
+
+	var r0 *fftypes.FFI
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, bool) (*fftypes.FFI, error)); ok {
+		return rf(ctx, name, version, networkName, waitConfirm)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, bool) *fftypes.FFI); ok {
+		r0 = rf(ctx, name, version, networkName, waitConfirm)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.FFI)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, bool) error); ok {
+		r1 = rf(ctx, name, version, networkName, waitConfirm)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PublishTokenPool provides a mock function with given fields: ctx, poolNameOrID, networkName, waitConfirm
 func (_m *Sender) PublishTokenPool(ctx context.Context, poolNameOrID string, networkName string, waitConfirm bool) (*core.TokenPool, error) {
 	ret := _m.Called(ctx, poolNameOrID, networkName, waitConfirm)

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -449,6 +449,9 @@ type iFFICollection interface {
 	// GetFFI - Get an FFI by name (or network name) and version
 	// Only one name (local name or network name) must match in order to be returned
 	GetFFI(ctx context.Context, namespace, name, networkName, version string) (*fftypes.FFI, error)
+
+	// DeleteFFI - Delete an FFI
+	DeleteFFI(ctx context.Context, namespace string, id *fftypes.UUID) error
 }
 
 type iFFIMethodCollection interface {

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -446,9 +446,11 @@ type iFFICollection interface {
 	// GetFFIByID - Get an FFI by ID
 	GetFFIByID(ctx context.Context, namespace string, id *fftypes.UUID) (*fftypes.FFI, error)
 
-	// GetFFI - Get an FFI by name (or network name) and version
-	// Only one name (local name or network name) must match in order to be returned
-	GetFFI(ctx context.Context, namespace, name, networkName, version string) (*fftypes.FFI, error)
+	// GetFFI - Get an FFI by name and version
+	GetFFI(ctx context.Context, namespace, name, version string) (*fftypes.FFI, error)
+
+	// GetFFIByNetworkName - Get an FFI by network name and version
+	GetFFIByNetworkName(ctx context.Context, namespace, networkName, version string) (*fftypes.FFI, error)
 
 	// DeleteFFI - Delete an FFI
 	DeleteFFI(ctx context.Context, namespace string, id *fftypes.UUID) error

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -433,8 +433,12 @@ type iTokenApprovalCollection interface {
 }
 
 type iFFICollection interface {
+	// InsertOrGetFFI - Insert an FFI
+	// If an FFI with the same name has already been recorded, does not insert but returns the existing row
+	InsertOrGetFFI(ctx context.Context, ffi *fftypes.FFI) (*fftypes.FFI, error)
+
 	// UpsertFFI - Upsert an FFI
-	UpsertFFI(ctx context.Context, cd *fftypes.FFI) error
+	UpsertFFI(ctx context.Context, ffi *fftypes.FFI, optimization UpsertOptimization) error
 
 	// GetFFIs - Get FFIs
 	GetFFIs(ctx context.Context, namespace string, filter ffapi.Filter) ([]*fftypes.FFI, *ffapi.FilterResult, error)
@@ -442,8 +446,9 @@ type iFFICollection interface {
 	// GetFFIByID - Get an FFI by ID
 	GetFFIByID(ctx context.Context, namespace string, id *fftypes.UUID) (*fftypes.FFI, error)
 
-	// GetFFI - Get an FFI by name and version
-	GetFFI(ctx context.Context, namespace, name, version string) (*fftypes.FFI, error)
+	// GetFFI - Get an FFI by name (or network name) and version
+	// Only one name (local name or network name) must match in order to be returned
+	GetFFI(ctx context.Context, namespace, name, networkName, version string) (*fftypes.FFI, error)
 }
 
 type iFFIMethodCollection interface {
@@ -979,9 +984,11 @@ var TokenApprovalQueryFactory = &ffapi.QueryFields{
 
 // FFIQueryFactory filter fields for contract definitions
 var FFIQueryFactory = &ffapi.QueryFields{
-	"id":      &ffapi.UUIDField{},
-	"name":    &ffapi.StringField{},
-	"version": &ffapi.StringField{},
+	"id":          &ffapi.UUIDField{},
+	"name":        &ffapi.StringField{},
+	"networkname": &ffapi.StringField{},
+	"version":     &ffapi.StringField{},
+	"published":   &ffapi.BoolField{},
 }
 
 // FFIMethodQueryFactory filter fields for contract methods

--- a/test/e2e/client/restclient.go
+++ b/test/e2e/client/restclient.go
@@ -608,7 +608,7 @@ func (client *FireFlyClient) DeleteTokenPool(t *testing.T, poolID *fftypes.UUID,
 	path := client.namespaced(urlTokenPools + "/" + poolID.String())
 	resp, err := client.Client.R().Delete(path)
 	require.NoError(t, err)
-	require.Equal(t, expectedStatus, resp.StatusCode(), "POST %s [%d]: %s", path, resp.StatusCode(), resp.String())
+	require.Equal(t, expectedStatus, resp.StatusCode(), "DELETE %s [%d]: %s", path, resp.StatusCode(), resp.String())
 }
 
 func (client *FireFlyClient) MintTokens(t *testing.T, mint *core.TokenTransferInput, confirm bool, expectedStatus ...int) *core.TokenTransfer {
@@ -888,6 +888,13 @@ func (client *FireFlyClient) PublishFFI(t *testing.T, name, version, networkName
 		expected = 200
 	}
 	require.Equal(t, expected, resp.StatusCode(), "POST %s [%d]: %s", path, resp.StatusCode(), resp.String())
+}
+
+func (client *FireFlyClient) DeleteFFI(t *testing.T, id *fftypes.UUID, expectedStatus int) {
+	path := client.namespaced(urlContractInterface + "/" + id.String())
+	resp, err := client.Client.R().Delete(path)
+	require.NoError(t, err)
+	require.Equal(t, expectedStatus, resp.StatusCode(), "DELETE %s [%d]: %s", path, resp.StatusCode(), resp.String())
 }
 
 func (client *FireFlyClient) CreateContractAPI(t *testing.T, name string, ffiReference *fftypes.FFIReference, location *fftypes.JSONAny) (interface{}, error) {

--- a/test/e2e/client/restclient.go
+++ b/test/e2e/client/restclient.go
@@ -860,17 +860,34 @@ func (client *FireFlyClient) GenerateFFIFromABI(t *testing.T, req *fftypes.FFIGe
 	return &res
 }
 
-func (client *FireFlyClient) CreateFFI(t *testing.T, ffi *fftypes.FFI) (*fftypes.FFI, error) {
+func (client *FireFlyClient) CreateFFI(t *testing.T, ffi *fftypes.FFI, publish bool) (*fftypes.FFI, error) {
 	var res fftypes.FFI
 	path := client.namespaced(urlContractInterface)
 	resp, err := client.Client.R().
 		SetBody(ffi).
 		SetResult(&res).
 		SetQueryParam("confirm", "true").
+		SetQueryParam("publish", strconv.FormatBool(publish)).
 		Post(path)
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode(), "POST %s [%d]: %s", path, resp.StatusCode(), resp.String())
 	return &res, err
+}
+
+func (client *FireFlyClient) PublishFFI(t *testing.T, name, version, networkName string, confirm bool) {
+	path := client.namespaced(urlContractInterface + "/" + name + "/" + version + "/publish")
+	resp, err := client.Client.R().
+		SetBody(&core.DefinitionPublish{
+			NetworkName: networkName,
+		}).
+		SetQueryParam("confirm", strconv.FormatBool(confirm)).
+		Post(path)
+	require.NoError(t, err)
+	expected := 202
+	if confirm {
+		expected = 200
+	}
+	require.Equal(t, expected, resp.StatusCode(), "POST %s [%d]: %s", path, resp.StatusCode(), resp.String())
 }
 
 func (client *FireFlyClient) CreateContractAPI(t *testing.T, name string, ffiReference *fftypes.FFIReference, location *fftypes.JSONAny) (interface{}, error) {

--- a/test/e2e/gateway/ethereum_contracts.go
+++ b/test/e2e/gateway/ethereum_contracts.go
@@ -124,7 +124,7 @@ func (suite *EthereumContractTestSuite) SetupSuite() {
 	suite.ethIdentity = account["address"].(string)
 	suite.contractAddress = deployContract(suite.T(), stack.Name, "simplestorage/simple_storage.json")
 
-	res, err := suite.testState.client1.CreateFFI(suite.T(), simpleStorageFFI())
+	res, err := suite.testState.client1.CreateFFI(suite.T(), simpleStorageFFI(), false)
 	suite.interfaceID = res.ID
 	suite.T().Logf("interfaceID: %s", suite.interfaceID)
 	assert.NoError(suite.T(), err)

--- a/test/e2e/multiparty/common.go
+++ b/test/e2e/multiparty/common.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -181,7 +181,7 @@ func beforeE2ETest(t *testing.T) *testState {
 	t.Logf("Org1: ID=%s DID=%s Key=%s", ts.org1.ID, ts.org1.DID, ts.org1key.Value)
 	t.Logf("Org2: ID=%s DID=%s Key=%s", ts.org2.ID, ts.org2.DID, ts.org2key.Value)
 
-	eventNames := "message_confirmed|token_pool_confirmed|token_transfer_confirmed|blockchain_event_received|token_approval_confirmed|identity_confirmed|message_rejected"
+	eventNames := "message_confirmed|token_pool_confirmed|token_transfer_confirmed|blockchain_event_received|token_approval_confirmed|identity_confirmed|message_rejected|contract_interface_confirmed"
 	queryString := fmt.Sprintf("namespace=%s&ephemeral&autoack&filter.events=%s&changeevents=.*", ts.namespace, eventNames)
 	ts.ws1 = ts.client1.WebSocket(t, queryString, authHeader1)
 	ts.ws2 = ts.client2.WebSocket(t, queryString, authHeader2)

--- a/test/e2e/multiparty/ethereum_contract_message.go
+++ b/test/e2e/multiparty/ethereum_contract_message.go
@@ -54,10 +54,10 @@ func (suite *EthereumContractWithMessageTestSuite) TestCustomContractWithMessage
 
 	ffi := suite.testState.client1.GenerateFFIFromABI(suite.T(), &fftypes.FFIGenerationRequest{
 		Name:    "CustomPin",
-		Version: contractVersion,
+		Version: contractVersion(),
 		Input:   fftypes.JSONAnyPtr(`{"abi":` + suite.contractJSON.GetObjectArray("abi").String() + `}`),
 	})
-	iface, err := suite.testState.client1.CreateFFI(suite.T(), ffi)
+	iface, err := suite.testState.client1.CreateFFI(suite.T(), ffi, true)
 	assert.NoError(suite.T(), err)
 
 	status, _, err := suite.testState.client1.GetStatus()

--- a/test/e2e/multiparty/ethereum_contracts.go
+++ b/test/e2e/multiparty/ethereum_contracts.go
@@ -35,7 +35,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var contractVersion, _ = nanoid.Generate("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", nanoid.DefaultSize)
+func contractVersion() string {
+	versionAlphabet := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	version, _ := nanoid.Generate(versionAlphabet, nanoid.DefaultSize)
+	return version
+}
 
 func simpleStorageFFIChanged() *fftypes.FFIEvent {
 	return &fftypes.FFIEvent{
@@ -55,10 +59,10 @@ func simpleStorageFFIChanged() *fftypes.FFIEvent {
 	}
 }
 
-func simpleStorageFFI() *fftypes.FFI {
+func simpleStorageFFI(version string) *fftypes.FFI {
 	return &fftypes.FFI{
 		Name:    "SimpleStorage",
-		Version: contractVersion,
+		Version: version,
 		Methods: []*fftypes.FFIMethod{
 			simpleStorageFFISet(),
 			simpleStorageFFIGet(),
@@ -124,7 +128,7 @@ func (suite *EthereumContractTestSuite) SetupSuite() {
 	suite.ethIdentity = suite.testState.org1key.Value
 	suite.contractAddress = deployContract(suite.T(), stack.Name, "simplestorage/simple_storage.json")
 
-	res, err := suite.testState.client1.CreateFFI(suite.T(), simpleStorageFFI())
+	res, err := suite.testState.client1.CreateFFI(suite.T(), simpleStorageFFI(contractVersion()), true)
 	suite.interfaceID = res.ID
 	suite.T().Logf("interfaceID: %s", suite.interfaceID)
 	assert.NoError(suite.T(), err)
@@ -322,4 +326,25 @@ func readContractJSON(t *testing.T, contract string) fftypes.JSONObject {
 	err = json.Unmarshal(byteValue, &jsonValue)
 	assert.NoError(t, err)
 	return jsonValue
+}
+
+func (suite *EthereumContractTestSuite) TestContractPublish() {
+	received1 := e2e.WsReader(suite.testState.ws1)
+	received2 := e2e.WsReader(suite.testState.ws2)
+
+	ffi := simpleStorageFFI(contractVersion())
+	networkName := ffi.Name + "-shared"
+	suite.T().Logf("Interface local name: %s", ffi.Name)
+	suite.T().Logf("Interface network name: %s", networkName)
+	suite.T().Logf("Interface version: %s", ffi.Version)
+
+	result, err := suite.testState.client1.CreateFFI(suite.T(), ffi, false)
+	assert.NoError(suite.T(), err)
+
+	e2e.WaitForEvent(suite.T(), received1, core.EventTypeContractInterfaceConfirmed, result.ID)
+
+	suite.testState.client1.PublishFFI(suite.T(), ffi.Name, ffi.Version, networkName, false)
+
+	e2e.WaitForMessageConfirmed(suite.T(), received1, core.MessageTypeDefinition)
+	e2e.WaitForEvent(suite.T(), received2, core.EventTypeContractInterfaceConfirmed, result.ID)
 }

--- a/test/e2e/multiparty/ethereum_contracts.go
+++ b/test/e2e/multiparty/ethereum_contracts.go
@@ -343,6 +343,13 @@ func (suite *EthereumContractTestSuite) TestContractPublish() {
 
 	e2e.WaitForEvent(suite.T(), received1, core.EventTypeContractInterfaceConfirmed, result.ID)
 
+	// Delete and recreate
+	suite.testState.client1.DeleteFFI(suite.T(), result.ID, 204)
+	result, err = suite.testState.client1.CreateFFI(suite.T(), ffi, false)
+	assert.NoError(suite.T(), err)
+
+	e2e.WaitForEvent(suite.T(), received1, core.EventTypeContractInterfaceConfirmed, result.ID)
+
 	suite.testState.client1.PublishFFI(suite.T(), ffi.Name, ffi.Version, networkName, false)
 
 	e2e.WaitForMessageConfirmed(suite.T(), received1, core.MessageTypeDefinition)

--- a/test/e2e/multiparty/ethereum_contracts.go
+++ b/test/e2e/multiparty/ethereum_contracts.go
@@ -347,4 +347,7 @@ func (suite *EthereumContractTestSuite) TestContractPublish() {
 
 	e2e.WaitForMessageConfirmed(suite.T(), received1, core.MessageTypeDefinition)
 	e2e.WaitForEvent(suite.T(), received2, core.EventTypeContractInterfaceConfirmed, result.ID)
+
+	// Cannot delete published interfaces
+	suite.testState.client1.DeleteFFI(suite.T(), result.ID, 409)
 }

--- a/test/e2e/multiparty/ethereum_token_contract.go
+++ b/test/e2e/multiparty/ethereum_token_contract.go
@@ -410,13 +410,14 @@ func (suite *EthereumTokenContractTestSuite) TestTokensWithInterface() {
 	suite.T().Logf("contract: %s", suite.contract)
 	contractAddress := deployContract(suite.T(), suite.testState.stackName, suite.contract)
 	contractJSON := readContractJSON(suite.T(), suite.contract)
+	version := contractVersion()
 
 	ffi := suite.testState.client1.GenerateFFIFromABI(suite.T(), &fftypes.FFIGenerationRequest{
 		Name:    "ERC20",
-		Version: contractVersion,
+		Version: version,
 		Input:   fftypes.JSONAnyPtr(`{"abi":` + contractJSON.GetObjectArray("abi").String() + `}`),
 	})
-	_, err := suite.testState.client1.CreateFFI(suite.T(), ffi)
+	_, err := suite.testState.client1.CreateFFI(suite.T(), ffi, true)
 	assert.NoError(suite.T(), err)
 
 	poolName := fmt.Sprintf("pool_%s", e2e.RandomName(suite.T()))
@@ -428,7 +429,7 @@ func (suite *EthereumTokenContractTestSuite) TestTokensWithInterface() {
 		},
 		Interface: &fftypes.FFIReference{
 			Name:    "ERC20",
-			Version: contractVersion,
+			Version: version,
 		},
 	}
 	poolResp := suite.testState.client1.CreateTokenPool(suite.T(), pool, true, false)

--- a/test/e2e/multiparty/tokens.go
+++ b/test/e2e/multiparty/tokens.go
@@ -379,7 +379,7 @@ func (suite *TokensTestSuite) TestE2ENonFungibleTokensSync() {
 	accountPools = suite.testState.client2.GetTokenAccountPools(suite.T(), suite.testState.org2key.Value)
 	assert.Equal(suite.T(), *poolID, *accountPools[0].Pool)
 
-	// Cannot delete pools in multiparty mode
+	// Cannot delete published pools
 	suite.testState.client1.DeleteTokenPool(suite.T(), poolID, 409)
 }
 
@@ -424,4 +424,7 @@ func (suite *TokensTestSuite) TestE2ETokenPoolPublish() {
 	assert.Equal(suite.T(), core.TokenTypeFungible, pools[0].Type)
 	assert.NotEmpty(suite.T(), pools[0].Locator)
 	assert.NotNil(suite.T(), pools[0].Message)
+
+	// Cannot delete published pools
+	suite.testState.client1.DeleteTokenPool(suite.T(), poolID, 409)
 }


### PR DESCRIPTION
Part of the fix for #1220
~~In a chain with #1261~~
Depends on https://github.com/hyperledger/firefly-common/pull/64