### PR TITLE
Fix timing issue between Init and ConfigReload of Namespace Manager

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    env:
+      TEST_ARGS: -v
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOGC=30
 
 all: build test go-mod-tidy
 test: deps lint
-		$(VGO) test ./internal/... ./pkg/... ./cmd/... ./docs ./ffconfig/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
+		$(VGO) test ./internal/... ./pkg/... ./cmd/... ./docs ./ffconfig/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s ${TEST_ARGS}
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt
 coverage: test coverage.html

--- a/internal/namespace/configreload_test.go
+++ b/internal/namespace/configreload_test.go
@@ -446,10 +446,12 @@ func namespaceInitWaiter(t *testing.T, nmm *nmMocks, namespaces []string) *sync.
 	wg := &sync.WaitGroup{}
 	for _, ns := range namespaces {
 		_ns := ns
-		for _, mei := range nmm.mei {
+		count := len(nmm.mei)
+		for i, mei := range nmm.mei {
+			idx := i + 1
 			wg.Add(1)
 			mei.On("NamespaceRestarted", _ns, mock.Anything).Return().Run(func(args mock.Arguments) {
-				log.L(context.Background()).Infof("WAITER: Namespace started '%s'", _ns)
+				log.L(context.Background()).Infof("WAITER: Namespace started (cb=%d/%d) '%s'", idx, count, _ns)
 				wg.Done()
 			}).Once()
 		}

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -182,6 +182,10 @@ func NewNamespaceManager() Manager {
 }
 
 func (nm *namespaceManager) Init(ctx context.Context, cancelCtx context.CancelFunc, reset chan bool, reloadConfig func() error) (err error) {
+	// Hold the mutex throughout initial init, as we do not want to allow config reload to go yet
+	nm.nsMux.Lock()
+	defer nm.nsMux.Unlock()
+
 	nm.reset = reset               // channel to ask our parent to reload us
 	nm.reloadConfig = reloadConfig // function to cause our parent to call InitConfig on all components, including us
 	nm.ctx = ctx

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -303,7 +303,7 @@ func (nm *namespaceManager) namespaceStarter(ns *namespace) {
 		err = nm.initAndStartNamespace(ns)
 		// If we started successfully, then all is good
 		if err == nil {
-			log.L(nm.ctx).Infof("Namespace %s started", ns.Name)
+			log.L(nm.ctx).Infof("Namespace started '%s'", ns.Name)
 			nm.nsMux.Lock()
 			ns.started = true
 			ns.initError = ""
@@ -400,6 +400,7 @@ func (nm *namespaceManager) startNamespacesAndPlugins(namespacesToStart map[stri
 		// Note they will not be ready to process the events, and will error.
 		// That is fine as it will cause the plugin to push back the events,
 		// so they will not be rejected (or held in a retry loop).
+		log.L(nm.ctx).Infof("Initiating start of namespace '%s'", ns.Name)
 		if err := nm.preInitNamespace(ns); err != nil {
 			return err
 		}


### PR DESCRIPTION
Event after #1242 checked in, @awrichar saw an instance of #1250 in this test run, with slightly different symptoms https://github.com/hyperledger/firefly/actions/runs/4728313082/jobs/8389728445

~These are a nightmare to diagnose, as Go tests do not log start/end of tests (unless in full debug mode) so a `goroutine` bleading past the end of the test boundary is hard to debug. But with some staring, I believe the problem is that some tests was only waiting _once_ at the end for the reload, and because of that there's the possibility for timing to happen such that the reload is detected before the first initialization has completed.~

~This proposed change adds a wait in the middle~

> See additional diagnosis below
> - locking update to ensure state propagation issue due to a lack of locking between goroutines.
> - unit test file writing change to rename in, rather than write in place

```
panic: 
assert: mock: The method has been called over 1 times.
	Either do one more Mock.On("NamespaceRestarted").Return(...), or remove extra call.
	This call was unexpected:
		NamespaceRestarted(string,time.Time)
		0: "ns1"
		1: time.Date(2023, time.April, 18, 3, 40, 40, 19021351, time.Local)
	at: [/home/runner/work/firefly/firefly/internal/namespace/plugin.go:89 /home/runner/work/firefly/firefly/internal/namespace/manager.go:314 /home/runner/work/firefly/firefly/internal/namespace/retry.go:56 /home/runner/work/firefly/firefly/internal/namespace/manager.go:301 /home/runner/work/firefly/firefly/internal/namespace/asm_amd64.s:1571]
```