### PR TITLE
Address coverage gap, and issue with intent propagation found via it

### DIFF
--- a/internal/database/sqlcommon/nextpin_sql_test.go
+++ b/internal/database/sqlcommon/nextpin_sql_test.go
@@ -128,6 +128,15 @@ func TestGetNextPinsForContextReadMessageFail(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetNextPinsBadFilter(t *testing.T) {
+	s, mock := newMockProvider().init()
+	_, _, err := s.GetNextPins(context.Background(), "ns", database.NextPinQueryFactory.NewFilter(context.Background()).Eq(
+		"wrong", "bad",
+	))
+	assert.Regexp(t, "FF00142", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestGetNextPinQueryFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))

--- a/internal/events/event_poller_test.go
+++ b/internal/events/event_poller_test.go
@@ -312,8 +312,9 @@ func TestWaitForShoulderTapOrPollTimeoutTap(t *testing.T) {
 	mdi := &databasemocks.Plugin{}
 	ep, cancel := newTestEventPoller(t, mdi, nil, nil)
 	defer cancel()
+	ep.conf.eventPollTimeout = 10 * time.Second
 	ep.shoulderTap()
-	assert.True(t, ep.waitForShoulderTapOrPollTimeout(ep.conf.eventBatchSize))
+	assert.True(t, ep.waitForShoulderTapOrPollTimeout(0))
 }
 
 func TestDoubleTap(t *testing.T) {

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -615,7 +615,7 @@ func TestGetDefaultVerifierNoBlockchain(t *testing.T) {
 	im.blockchain = nil
 	im.defaultKey = "test"
 
-	verifier, err := im.getDefaultVerifier(ctx)
+	verifier, err := im.getDefaultVerifier(ctx, blockchain.ResolveKeyIntentSign)
 	assert.Regexp(t, "FF10417", err)
 	assert.Nil(t, verifier)
 }
@@ -649,6 +649,19 @@ func TestResolveInputSigningKeyDefaultNoBlockchainDefaultKeyFallback(t *testing.
 	mbi.On("ResolveSigningKey", ctx, "key123", blockchain.ResolveKeyIntentSign).Return("fullkey123", nil)
 
 	resolvedKey, err := im.ResolveInputSigningKey(ctx, "", KeyNormalizationBlockchainPlugin)
+	assert.NoError(t, err)
+	assert.Equal(t, "fullkey123", resolvedKey)
+}
+
+func TestResolveQuerySigningKeyDefaultNoBlockchainDefaultKeyFallback(t *testing.T) {
+	ctx, im := newTestIdentityManager(t)
+
+	im.defaultKey = "key123"
+
+	mbi := im.blockchain.(*blockchainmocks.Plugin)
+	mbi.On("ResolveSigningKey", ctx, "key123", blockchain.ResolveKeyIntentQuery).Return("fullkey123", nil)
+
+	resolvedKey, err := im.ResolveQuerySigningKey(ctx, "", KeyNormalizationBlockchainPlugin)
 	assert.NoError(t, err)
 	assert.Equal(t, "fullkey123", resolvedKey)
 }


### PR DESCRIPTION
In addressing all the coverage gaps I found in main (`internal/database`,`internal/events` and `internal/identity`) I found an issue with the new `ResolveQuerySigningKey` using the wrong intent on a default branch. The higher `sign` intent would have been used, rather than `query`.