### PR TITLE
Accept private groupinit messages from any signing key

### DIFF
--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -192,7 +192,6 @@ var (
 	MsgAddressResolveBadStatus            = ffe("FF10340", "Failed to resolve signing key string '%s' [%d]: %s", 500)
 	MsgAddressResolveBadResData           = ffe("FF10341", "Failed to resolve signing key string '%s' - invalid address returned '%s': %s", 500)
 	MsgDXNotInitialized                   = ffe("FF10342", "Data exchange is initializing")
-	MsgGroupRequired                      = ffe("FF10344", "Group must be set", 400)
 	MsgDBLockFailed                       = ffe("FF10345", "Database lock failed")
 	MsgFFIGenerationFailed                = ffe("FF10346", "Error generating smart contract interface: %s", 400)
 	MsgFFIGenerationUnsupported           = ffe("FF10347", "Smart contract interface generation is not supported by this blockchain plugin", 400)

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -419,7 +419,7 @@ func (ag *aggregator) checkOnchainConsistency(ctx context.Context, msg *core.Mes
 		return core.ActionReject, nil // This is not retryable. Reject this message
 	}
 
-	// Verify that we can resolve the signing key back to the identity that is claimed in the batch.
+	// Verify that we can resolve the signing key back to the identity that is claimed in the batch
 	resolvedAuthor, err := ag.identity.FindIdentityForVerifier(ctx, []core.IdentityType{
 		core.IdentityTypeOrg,
 		core.IdentityTypeCustom,
@@ -427,22 +427,32 @@ func (ag *aggregator) checkOnchainConsistency(ctx context.Context, msg *core.Mes
 	if err != nil {
 		return core.ActionRetry, err
 	}
+
 	if resolvedAuthor == nil {
-		if msg.Header.Type == core.MessageTypeDefinition &&
-			(msg.Header.Tag == core.SystemTagIdentityClaim || msg.Header.Tag == core.DeprecatedSystemTagDefineNode || msg.Header.Tag == core.DeprecatedSystemTagDefineOrganization) {
-			// We defer detailed checking of this identity to the system handler
+		switch {
+		case msg.Header.Type == core.MessageTypeDefinition &&
+			(msg.Header.Tag == core.SystemTagIdentityClaim ||
+				msg.Header.Tag == core.DeprecatedSystemTagDefineNode ||
+				msg.Header.Tag == core.DeprecatedSystemTagDefineOrganization):
+			// Identity claims can have an unregistered identity at this point
+			// We defer detailed checking of the identity to the system handler
 			return core.ActionConfirm, nil
-		} else if msg.Header.Type != core.MessageTypePrivate {
-			// Only private messages, or root org broadcasts can have an unregistered identity
+
+		case msg.Header.Type == core.MessageTypePrivate || msg.Header.Type == core.MessageTypeGroupInit:
+			// Private messages (and their associated group init) can always use an unregistered verifier
+			return core.ActionConfirm, nil
+
+		default:
+			// Everything else (broadcasts, non-identity definitions) will not be processed from an unregistered identity
 			l.Warnf("Skipping message '%s'. Author '%s' could not be resolved: %s", msg.Header.ID, msg.Header.Author, err)
 			return core.ActionWait, nil // Wait in case the identity is resolved later
 		}
-	} else if msg.Header.Author == "" || resolvedAuthor.DID != msg.Header.Author {
+	}
+	if msg.Header.Author == "" || resolvedAuthor.DID != msg.Header.Author {
 		l.Errorf("Invalid message '%s'. Author '%s' does not match identity registered to %s: %s (%s)", msg.Header.ID, msg.Header.Author, verifierRef.Value, resolvedAuthor.DID, resolvedAuthor.ID)
 		return core.ActionReject, nil // This is not retryable. Reject this message
 
 	}
-
 	return core.ActionConfirm, nil
 }
 

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -1930,6 +1930,21 @@ func TestDefinitionBroadcastActionWait(t *testing.T) {
 
 }
 
+func TestPrivateMessageUnregisteredSigner(t *testing.T) {
+	ag := newTestAggregator()
+	defer ag.cleanup(t)
+
+	msg1, _, _, _ := newTestManifest(core.MessageTypePrivate, nil)
+	msg1.Header.Tag = core.SystemTagIdentityClaim
+
+	ag.mim.On("FindIdentityForVerifier", ag.ctx, mock.Anything, mock.Anything).Return(nil, nil)
+
+	action, err := ag.checkOnchainConsistency(ag.ctx, msg1, &core.Pin{Signer: "0x12345"})
+	assert.NoError(t, err)
+	assert.Equal(t, core.ActionConfirm, action)
+
+}
+
 func TestCompleteDispatchEventFail(t *testing.T) {
 	ag := newTestAggregator()
 	defer ag.cleanup(t)

--- a/internal/privatemessaging/groupmanager.go
+++ b/internal/privatemessaging/groupmanager.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -52,20 +52,12 @@ type groupHashEntry struct {
 	nodes []*core.Identity
 }
 
+// EnsureLocalGroup is called for unpinned messages, which carry the full group definition next to the message batch.
+// The group simply needs to be validated and stored (or loaded if it exists already).
 func (gm *groupManager) EnsureLocalGroup(ctx context.Context, group *core.Group, creator *core.Member) (ok bool, err error) {
-	if group == nil {
-		return false, i18n.NewError(ctx, coremsgs.MsgGroupRequired)
-	}
-
-	// In the case that we've received a private message for a group, it's possible (likely actually)
-	// that the private message using the group will arrive before the group init message confirming
-	// the group via the blockchain.
-	// So this method checks if a group exists, and if it doesn't inserts it.
-	// We do assume the other side has sent the batch init of the group (rather than generating a second one)
 	if g, err := gm.database.GetGroupByHash(ctx, gm.namespace.Name, group.Hash); err != nil {
 		return false, err
 	} else if g != nil {
-		// The group already exists
 		return true, nil
 	}
 

--- a/internal/privatemessaging/groupmanager_test.go
+++ b/internal/privatemessaging/groupmanager_test.go
@@ -714,15 +714,6 @@ func TestEnsureLocalGroupNewOk(t *testing.T) {
 	mdi.AssertExpectations(t)
 }
 
-func TestEnsureLocalGroupNil(t *testing.T) {
-	pm, cancel := newTestPrivateMessaging(t)
-	defer cancel()
-
-	ok, err := pm.EnsureLocalGroup(pm.ctx, nil, &core.Member{})
-	assert.Regexp(t, "FF10344", err)
-	assert.False(t, ok)
-}
-
 func TestEnsureLocalGroupExistingOk(t *testing.T) {
 	pm, cancel := newTestPrivateMessaging(t)
 	defer cancel()


### PR DESCRIPTION
Since we allow private messages to originate from an unregistered blockchain signing key,
we must also accept groupinit messages from the same (since the first private message
to a group will trigger group creation as a side-effect).

Fixes #1247