### PR TITLE
Remove duplicates prior to adding unique index on contract API ID

### DIFF
--- a/db/migrations/postgres/000108_create_contractapis_id_index.up.sql
+++ b/db/migrations/postgres/000108_create_contractapis_id_index.up.sql
@@ -1,3 +1,5 @@
 BEGIN;
+DELETE FROM contractapis WHERE seq NOT IN (
+  SELECT MAX(seq) FROM contractapis GROUP BY namespace, id);
 CREATE UNIQUE INDEX contractapis_id ON contractapis(namespace,id);
 COMMIT;

--- a/db/migrations/sqlite/000108_create_contractapis_id_index.up.sql
+++ b/db/migrations/sqlite/000108_create_contractapis_id_index.up.sql
@@ -1,1 +1,3 @@
+DELETE FROM contractapis WHERE seq NOT IN (
+  SELECT MAX(seq) FROM contractapis GROUP BY namespace, id);
 CREATE UNIQUE INDEX contractapis_id ON contractapis(namespace,id);

--- a/internal/apiserver/route_post_new_contract_api.go
+++ b/internal/apiserver/route_post_new_contract_api.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -46,6 +46,7 @@ var postNewContractAPI = &ffapi.Route{
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)
 			api := r.Input.(*core.ContractAPI)
+			api.ID = nil
 			err = cr.or.DefinitionSender().DefineContractAPI(cr.ctx, cr.apiBaseURL, api, waitConfirm)
 			return api, err
 		},


### PR DESCRIPTION
Also ensure ID is always unset when creating a new API.

Follow-up to #1292, #1275