### PR TITLE
Handle duplicate pool locators properly

### DIFF
--- a/internal/database/sqlcommon/tokenpool_sql.go
+++ b/internal/database/sqlcommon/tokenpool_sql.go
@@ -71,9 +71,15 @@ func (s *SQLCommon) UpsertTokenPool(ctx context.Context, pool *core.TokenPool) (
 	rows, _, err := s.QueryTx(ctx, tokenpoolTable, tx,
 		sq.Select("id").
 			From(tokenpoolTable).
-			Where(sq.Eq{
-				"namespace": pool.Namespace,
-				"name":      pool.Name,
+			Where(sq.And{
+				sq.Eq{"namespace": pool.Namespace},
+				sq.Or{
+					sq.Eq{"name": pool.Name},
+					sq.Eq{
+						"connector": pool.Connector,
+						"locator":   pool.Locator,
+					},
+				},
 			}),
 	)
 	if err != nil {


### PR DESCRIPTION
Since there is a unique index on pool locators, it must be checked during token pool upsert.

This behavior will be changing again in #1261, but this is a more immediate fix without pulling in all of that.