### PR TITLE
Retry tokens events consistent with FFDX, as we cannot push back nack

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -950,7 +950,10 @@ nav_order: 2
 |---|-----------|----|-------------|
 |count|The maximum number of times to retry|`int`|`5`
 |enabled|Enables retries|`boolean`|`false`
+|factor|The retry backoff factor|`float32`|`2`
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
+|initialDelay|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`50ms`
+|maxDelay|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 
 ## plugins.tokens[].fftokens.ws

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -795,6 +795,14 @@ nav_order: 2
 |password|Password|`string`|`<nil>`
 |username|Username|`string`|`<nil>`
 
+## plugins.dataexchange[].ffdx.eventRetry
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|factor|The retry backoff factor, for event processing|`float32`|`2`
+|initialDelay|The initial retry delay, for event processing|[`time.Duration`](https://pkg.go.dev/time#Duration)|`50ms`
+|maxDelay|The maximum retry delay, for event processing|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
+
 ## plugins.dataexchange[].ffdx.proxy
 
 |Key|Description|Type|Default Value|
@@ -807,10 +815,7 @@ nav_order: 2
 |---|-----------|----|-------------|
 |count|The maximum number of times to retry|`int`|`5`
 |enabled|Enables retries|`boolean`|`false`
-|factor|The retry backoff factor|`float32`|`2`
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
-|initialDelay|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`50ms`
-|maxDelay|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 
 ## plugins.dataexchange[].ffdx.ws
@@ -938,6 +943,14 @@ nav_order: 2
 |password|Password|`string`|`<nil>`
 |username|Username|`string`|`<nil>`
 
+## plugins.tokens[].fftokens.eventRetry
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|factor|The retry backoff factor, for event processing|`float32`|`2`
+|initialDelay|The initial retry delay, for event processing|[`time.Duration`](https://pkg.go.dev/time#Duration)|`50ms`
+|maxDelay|The maximum retry delay, for event processing|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
+
 ## plugins.tokens[].fftokens.proxy
 
 |Key|Description|Type|Default Value|
@@ -950,10 +963,7 @@ nav_order: 2
 |---|-----------|----|-------------|
 |count|The maximum number of times to retry|`int`|`5`
 |enabled|Enables retries|`boolean`|`false`
-|factor|The retry backoff factor|`float32`|`2`
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`
-|initialDelay|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`50ms`
-|maxDelay|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |maxWaitTime|The maximum retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 
 ## plugins.tokens[].fftokens.ws

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -31,6 +31,10 @@ var (
 	ConfigGlobalMigrationsDirectory = ffc("config.global.migrations.directory", "The directory containing the numerically ordered migration DDL files to apply to the database", i18n.StringType)
 	ConfigGlobalShutdownTimeout     = ffc("config.global.shutdownTimeout", "The maximum amount of time to wait for any open HTTP requests to finish before shutting down the HTTP server", i18n.TimeDurationType)
 
+	ConfigEventRetryFactor       = ffc("config.global.eventRetry.factor", "The retry backoff factor, for event processing", i18n.FloatType)
+	ConfigEventRetryInitialDelay = ffc("config.global.eventRetry.initialDelay", "The initial retry delay, for event processing", i18n.TimeDurationType)
+	ConfigEventRetryMaxDelay     = ffc("config.global.eventRetry.maxDelay", "The maximum retry delay, for event processing", i18n.TimeDurationType)
+
 	ConfigConfigAutoReload = ffc("config.config.autoReload", "Monitor the configuration file for changes, and automatically add/remove/reload namespaces and plugins", i18n.BooleanType)
 
 	ConfigLegacyAdmin     = ffc("config.admin.enabled", "Deprecated - use spi.enabled instead", i18n.BooleanType)

--- a/internal/dataexchange/ffdx/config.go
+++ b/internal/dataexchange/ffdx/config.go
@@ -29,16 +29,16 @@ const (
 	// DataExchangeInitEnabled instructs FireFly to always post all current nodes to the /init API before connecting or reconnecting to the connector
 	DataExchangeInitEnabled = "initEnabled"
 
-	DataExchangeRetryInitialDelay = "retry.initialDelay"
-	DataExchangeRetryMaxDelay     = "retry.maxDelay"
-	DataExchangeRetryFactor       = "retry.factor"
+	DataExchangeEventRetryInitialDelay = "eventRetry.initialDelay"
+	DataExchangeEventRetryMaxDelay     = "eventRetry.maxDelay"
+	DataExchangeEventRetryFactor       = "eventRetry.factor"
 )
 
 func (h *FFDX) InitConfig(config config.Section) {
 	wsclient.InitConfig(config)
 	config.AddKnownKey(DataExchangeManifestEnabled, false)
 	config.AddKnownKey(DataExchangeInitEnabled, false)
-	config.AddKnownKey(DataExchangeRetryInitialDelay, 50*time.Millisecond)
-	config.AddKnownKey(DataExchangeRetryMaxDelay, 30*time.Second)
-	config.AddKnownKey(DataExchangeRetryFactor, 2.0)
+	config.AddKnownKey(DataExchangeEventRetryInitialDelay, 50*time.Millisecond)
+	config.AddKnownKey(DataExchangeEventRetryMaxDelay, 30*time.Second)
+	config.AddKnownKey(DataExchangeEventRetryFactor, 2.0)
 }

--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -187,9 +187,9 @@ func (h *FFDX) Init(ctx context.Context, cancelCtx context.CancelFunc, config co
 		Manifest: config.GetBool(DataExchangeManifestEnabled),
 	}
 	h.retry = &retry.Retry{
-		InitialDelay: config.GetDuration(DataExchangeRetryInitialDelay),
-		MaximumDelay: config.GetDuration(DataExchangeRetryMaxDelay),
-		Factor:       config.GetFloat64(DataExchangeRetryFactor),
+		InitialDelay: config.GetDuration(DataExchangeEventRetryInitialDelay),
+		MaximumDelay: config.GetDuration(DataExchangeEventRetryMaxDelay),
+		Factor:       config.GetFloat64(DataExchangeEventRetryFactor),
 	}
 
 	wsConfig := wsclient.GenerateConfig(config)

--- a/internal/tokens/fftokens/config.go
+++ b/internal/tokens/fftokens/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -17,10 +17,22 @@
 package fftokens
 
 import (
+	"time"
+
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/wsclient"
 )
 
+const (
+	FFTRetryInitialDelay = "retry.initialDelay"
+	FFTRetryMaxDelay     = "retry.maxDelay"
+	FFTRetryFactor       = "retry.factor"
+)
+
 func (ft *FFTokens) InitConfig(config config.KeySet) {
 	wsclient.InitConfig(config)
+
+	config.AddKnownKey(FFTRetryInitialDelay, 50*time.Millisecond)
+	config.AddKnownKey(FFTRetryMaxDelay, 30*time.Second)
+	config.AddKnownKey(FFTRetryFactor, 2.0)
 }

--- a/internal/tokens/fftokens/config.go
+++ b/internal/tokens/fftokens/config.go
@@ -24,15 +24,15 @@ import (
 )
 
 const (
-	FFTRetryInitialDelay = "retry.initialDelay"
-	FFTRetryMaxDelay     = "retry.maxDelay"
-	FFTRetryFactor       = "retry.factor"
+	FFTEventRetryInitialDelay = "eventRetry.initialDelay"
+	FFTEventRetryMaxDelay     = "eventRetry.maxDelay"
+	FFTEventRetryFactor       = "eventRetry.factor"
 )
 
 func (ft *FFTokens) InitConfig(config config.KeySet) {
 	wsclient.InitConfig(config)
 
-	config.AddKnownKey(FFTRetryInitialDelay, 50*time.Millisecond)
-	config.AddKnownKey(FFTRetryMaxDelay, 30*time.Second)
-	config.AddKnownKey(FFTRetryFactor, 2.0)
+	config.AddKnownKey(FFTEventRetryInitialDelay, 50*time.Millisecond)
+	config.AddKnownKey(FFTEventRetryMaxDelay, 30*time.Second)
+	config.AddKnownKey(FFTEventRetryFactor, 2.0)
 }

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -354,12 +354,15 @@ func (ft *FFTokens) handleTokenPoolCreate(ctx context.Context, data fftypes.JSON
 	blockchainEvent := data.GetObject("blockchain")
 
 	poolDataString := data.GetString("data")
-	if poolData == nil && poolDataString != "" {
-		// We want to process all events, even those not initiated by FireFly.
-		// The "data" argument is optional, so it's important not to fail if it's missing or malformed.
-		if err = json.Unmarshal([]byte(poolDataString), &poolData); err != nil {
-			log.L(ctx).Warnf("TokenPool event data could not be parsed - continuing anyway (%s): %+v", err, data)
-			poolData = &tokenData{}
+	if poolData == nil {
+		poolData = &tokenData{}
+		if poolDataString != "" {
+			// We want to process all events, even those not initiated by FireFly.
+			// The "data" argument is optional, so it's important not to fail if it's missing or malformed.
+			if err = json.Unmarshal([]byte(poolDataString), &poolData); err != nil {
+				log.L(ctx).Warnf("TokenPool event data could not be parsed - continuing anyway (%s): %+v", err, data)
+				poolData = &tokenData{}
+			}
 		}
 	}
 
@@ -519,60 +522,60 @@ func (ft *FFTokens) handleTokenApproval(ctx context.Context, data fftypes.JSONOb
 	return ft.callbacks.TokensApproved(ctx, namespace, approval)
 }
 
-func (ft *FFTokens) handleEventWithRetry(parentCtx context.Context, msg *wsEvent) error {
-	log.L(parentCtx).Debugf("Received %s event %s", msg.Event, msg.ID)
-	eventCtx, done := context.WithCancel(parentCtx)
-	defer done()
-	return ft.retry.Do(eventCtx, "fftokens event", func(attempt int) (retry bool, err error) {
-		switch msg.Event {
-		case messageReceipt:
-			ft.handleReceipt(eventCtx, msg.Data)
-		case messageBatch:
-			for _, msg := range msg.Data.GetObjectArray("events") {
-				if err = ft.handleMessage(eventCtx, []byte(msg.String())); err != nil {
-					break
-				}
-			}
-		case messageTokenPool:
-			err = ft.handleTokenPoolCreate(eventCtx, msg.Data, nil /* need to extract poolData from event */)
-		case messageTokenMint:
-			err = ft.handleTokenTransfer(eventCtx, core.TokenTransferTypeMint, msg.Data)
-		case messageTokenBurn:
-			err = ft.handleTokenTransfer(eventCtx, core.TokenTransferTypeBurn, msg.Data)
-		case messageTokenTransfer:
-			err = ft.handleTokenTransfer(eventCtx, core.TokenTransferTypeTransfer, msg.Data)
-		case messageTokenApproval:
-			err = ft.handleTokenApproval(eventCtx, msg.Data)
-		default:
-			log.L(eventCtx).Errorf("Message unexpected: %s", msg.Event)
-			// do not set error here - we will never be able to process this message so log+swallow it.
-		}
-		return true, err // We keep retrying on error until the context ends
-	})
-}
-
-func (ft *FFTokens) handleMessage(ctx context.Context, msgBytes []byte) (err error) {
-	l := log.L(ctx)
-
+func (ft *FFTokens) handleMessage(ctx context.Context, msgBytes []byte) (retry bool, err error) {
 	var msg *wsEvent
 	if err = json.Unmarshal(msgBytes, &msg); err != nil {
-		l.Errorf("Message cannot be parsed as JSON: %s\n%s", err, string(msgBytes))
-		return nil // Swallow this and move on
+		log.L(ctx).Errorf("Message cannot be parsed as JSON: %s\n%s", err, string(msgBytes))
+		return false, nil // Swallow this and move on
 	}
-
-	err = ft.handleEventWithRetry(ctx, msg)
-	if err == nil && msg.Event != messageReceipt && msg.ID != "" {
-		l.Debugf("Sending ack %s", msg.ID)
+	log.L(ctx).Debugf("Received %s event %s", msg.Event, msg.ID)
+	switch msg.Event {
+	case messageReceipt:
+		ft.handleReceipt(ctx, msg.Data)
+	case messageBatch:
+		for _, msg := range msg.Data.GetObjectArray("events") {
+			if retry, err = ft.handleMessage(ctx, []byte(msg.String())); err != nil {
+				return retry, err
+			}
+		}
+	case messageTokenPool:
+		err = ft.handleTokenPoolCreate(ctx, msg.Data, nil /* need to extract poolData from event */)
+	case messageTokenMint:
+		err = ft.handleTokenTransfer(ctx, core.TokenTransferTypeMint, msg.Data)
+	case messageTokenBurn:
+		err = ft.handleTokenTransfer(ctx, core.TokenTransferTypeBurn, msg.Data)
+	case messageTokenTransfer:
+		err = ft.handleTokenTransfer(ctx, core.TokenTransferTypeTransfer, msg.Data)
+	case messageTokenApproval:
+		err = ft.handleTokenApproval(ctx, msg.Data)
+	default:
+		log.L(ctx).Errorf("Message unexpected: %s", msg.Event)
+		// do not set error here - we will never be able to process this message so log+swallow it.
+	}
+	if err != nil {
+		// All errors above are retryable
+		return true, err
+	}
+	if msg.Event != messageReceipt && msg.ID != "" {
+		log.L(ctx).Debugf("Sending ack %s", msg.ID)
 		ack, _ := json.Marshal(fftypes.JSONObject{
 			"event": "ack",
 			"data": fftypes.JSONObject{
 				"id": msg.ID,
 			},
 		})
-		err = ft.wsconn.Send(ctx, ack)
+		// Do not retry this
+		return false, ft.wsconn.Send(ctx, ack)
 	}
+	return false, nil
+}
 
-	return err
+func (ft *FFTokens) handleMessageRetry(ctx context.Context, msgBytes []byte) (err error) {
+	eventCtx, done := context.WithCancel(ctx)
+	defer done()
+	return ft.retry.Do(eventCtx, "fftokens event", func(attempt int) (retry bool, err error) {
+		return ft.handleMessage(eventCtx, msgBytes) // We keep retrying on error until the context ends
+	})
 }
 
 func (ft *FFTokens) eventLoop() {
@@ -590,7 +593,7 @@ func (ft *FFTokens) eventLoop() {
 				ft.cancelCtx()
 				return
 			}
-			if err := ft.handleMessage(ctx, msgBytes); err != nil {
+			if err := ft.handleMessageRetry(ctx, msgBytes); err != nil {
 				l.Errorf("Event loop exiting (%s). Terminating server!", err)
 				ft.cancelCtx()
 				return

--- a/internal/tokens/fftokens/fftokens.go
+++ b/internal/tokens/fftokens/fftokens.go
@@ -252,9 +252,9 @@ func (ft *FFTokens) Init(ctx context.Context, cancelCtx context.CancelFunc, name
 	}
 
 	ft.retry = &retry.Retry{
-		InitialDelay: config.GetDuration(FFTRetryInitialDelay),
-		MaximumDelay: config.GetDuration(FFTRetryMaxDelay),
-		Factor:       config.GetFloat64(FFTRetryFactor),
+		InitialDelay: config.GetDuration(FFTEventRetryInitialDelay),
+		MaximumDelay: config.GetDuration(FFTEventRetryMaxDelay),
+		Factor:       config.GetFloat64(FFTEventRetryFactor),
 	}
 
 	go ft.eventLoop()

--- a/internal/tokens/fftokens/fftokens_test.go
+++ b/internal/tokens/fftokens/fftokens_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/ffresty"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly-common/pkg/retry"
 	"github.com/hyperledger/firefly-common/pkg/wsclient"
 	"github.com/hyperledger/firefly/internal/coreconfig"
 	"github.com/hyperledger/firefly/mocks/coremocks"
@@ -1422,6 +1423,7 @@ func TestEventLoopSendClosed(t *testing.T) {
 		ctx:       context.Background(),
 		cancelCtx: func() { called = true },
 		wsconn:    wsm,
+		retry:     &retry.Retry{},
 	}
 	r := make(chan []byte, 1)
 	r <- []byte(`{"id":"1"}`) // ignored but acked
@@ -1439,6 +1441,7 @@ func TestEventLoopClosedContext(t *testing.T) {
 	h := &FFTokens{
 		ctx:    ctx,
 		wsconn: wsm,
+		retry:  &retry.Retry{},
 	}
 	r := make(chan []byte, 1)
 	wsm.On("Close").Return()


### PR DESCRIPTION
Make this consistent with what we did for FFDX, and prevents a scenario on startup as seen in the integration test where a token event comes in before the namespace is started:

```
firefly_core_0_1  | [2023-04-30T00:35:08.431Z] DEBUG Calling TokenPoolCreated callback. Locator='address=0x8875e026c26cedc2ab9880ac56d31e328428db73&schema=ERC20WithData&type=fungible' TX=token_pool/66fffabe-5b11-4118-abc2-50b95877654d pid=1 proto=fftokens role=event-loop
firefly_core_0_1  | [2023-04-30T00:35:08.431Z] ERROR Event loop exiting (FF10446: Namespace 'default' is not started). Terminating server! pid=1 proto=fftokens role=event-loop
```

Also made a change to both FFDX and FFTokens to split `eventRetry` out from `retry` in the config, as I realized looking at this PR that the config was overlapping with the `ffresty` config for request retry.