### PR TITLE
Update Fabric chaincode Dockerfile

### DIFF
--- a/smart_contracts/fabric/firefly-go/Dockerfile
+++ b/smart_contracts/fabric/firefly-go/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.18
 WORKDIR /app
 COPY  firefly.go go.mod go.sum ./
 COPY chaincode/ ./chaincode/
+COPY batchpin/ ./batchpin/
 RUN ls -la ./ \
     && GO111MODULE=on GOOS=linux CGO_ENABLED=0 go build -o firefly.bin firefly.go
 


### PR DESCRIPTION
Building with this Dockerfile currently breaks because the batchpin folder isn't being copied


```#10 2.414 go: downloading golang.org/x/text v0.3.2
#10 5.161 chaincode/contract.go:8:2: no required module provides package github.com/hyperledger/firefly/chaincode-go/batchpin; to add it:
#10 5.161       go get github.com/hyperledger/firefly/chaincode-go/batchpin
------
executor failed running [/bin/sh -c ls -la ./     && GO111MODULE=on GOOS=linux CGO_ENABLED=0 go build -o firefly.bin firefly.go]: exit code: 1```