### PR TITLE
Confirm group init messages during dispatch

### DIFF
--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -624,7 +624,8 @@ func (ag *aggregator) readyForDispatch(ctx context.Context, msg *core.Message, d
 		action = handlerResult.Action
 
 	case msg.Header.Type == core.MessageTypeGroupInit:
-		// Already handled as part of resolving the context - do nothing.
+		// Already handled as part of resolving the context
+		action = core.ActionConfirm
 
 	case len(msg.Data) > 0:
 		var valid bool

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -1980,7 +1980,7 @@ func TestReadyForDispatchGroupInit(t *testing.T) {
 	bs := newBatchState(&ag.aggregator)
 	org1 := newTestOrg("org1")
 
-	_, _, err := ag.readyForDispatch(ag.ctx, &core.Message{
+	action, _, err := ag.readyForDispatch(ag.ctx, &core.Message{
 		Header: core.MessageHeader{
 			ID:        fftypes.NewUUID(),
 			Type:      core.MessageTypeGroupInit,
@@ -1988,6 +1988,7 @@ func TestReadyForDispatchGroupInit(t *testing.T) {
 		},
 	}, nil, nil, bs, &core.Pin{Signer: "0x12345"})
 	assert.NoError(t, err)
+	assert.Equal(t, core.ActionConfirm, action)
 
 }
 


### PR DESCRIPTION
It is not possible for a group init message to fail at this phase. If it fails, it must fail earlier. If it makes it to dispatch, it should flow through to confirm.

Fixes #1308