### PR TITLE
Process batch of events from Blockchain connector, in a single DB TX

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -428,7 +428,7 @@ func (e *Ethereum) handleMessageBatch(ctx context.Context, batchID int64, messag
 		signature := msgJSON.GetString("signature")
 		sub := msgJSON.GetString("subId")
 		logger := log.L(ctx)
-		logger.Infof("[EVM:%d:%d/%d]: '%s' on '%s'", batchID, i, count, signature, sub)
+		logger.Infof("[EVM:%d:%d/%d]: '%s' on '%s'", batchID, i+1, count, signature, sub)
 		logger.Tracef("Message: %+v", msgJSON)
 
 		// Matches one of the active FireFly BatchPin subscriptions

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -356,10 +356,10 @@ func (e *Ethereum) parseBlockchainEvent(ctx context.Context, msgJSON fftypes.JSO
 	}
 }
 
-func (e *Ethereum) handleBatchPinEvent(ctx context.Context, location *fftypes.JSONAny, subInfo *common.SubscriptionInfo, msgJSON fftypes.JSONObject) (err error) {
+func (e *Ethereum) processBatchPinEvent(ctx context.Context, events common.EventsToDispatch, location *fftypes.JSONAny, subInfo *common.SubscriptionInfo, msgJSON fftypes.JSONObject) {
 	event := e.parseBlockchainEvent(ctx, msgJSON)
 	if event == nil {
-		return nil // move on
+		return // move on
 	}
 
 	authorAddress := event.Output.GetString("author")
@@ -378,41 +378,45 @@ func (e *Ethereum) handleBatchPinEvent(ctx context.Context, location *fftypes.JS
 
 	// Validate the ethereum address - it must already be a valid address, we do not
 	// engage the address resolve on this blockchain-driven path.
-	authorAddress, err = formatEthAddress(ctx, authorAddress)
+	authorAddress, err := formatEthAddress(ctx, authorAddress)
 	if err != nil {
 		log.L(ctx).Errorf("BatchPin event is not valid - bad from address (%s): %+v", err, msgJSON)
-		return nil // move on
+		return // move on
 	}
 	verifier := &core.VerifierRef{
 		Type:  core.VerifierTypeEthAddress,
 		Value: authorAddress,
 	}
 
-	return e.callbacks.BatchPinOrNetworkAction(ctx, subInfo, location, event, verifier, params)
+	e.callbacks.PrepareBatchPinOrNetworkAction(ctx, events, subInfo, location, event, verifier, params)
 }
 
-func (e *Ethereum) handleContractEvent(ctx context.Context, msgJSON fftypes.JSONObject) (err error) {
-	subName, err := e.streams.getSubscriptionName(ctx, msgJSON.GetString("subId"))
+func (e *Ethereum) processContractEvent(ctx context.Context, events common.EventsToDispatch, msgJSON fftypes.JSONObject) error {
+	subID := msgJSON.GetString("subId")
+	subName, err := e.streams.getSubscriptionName(ctx, subID)
 	if err != nil {
-		return err
+		return err // this is a problem - we should be able to find the listener that dispatched this to us
 	}
 
 	namespace := common.GetNamespaceFromSubName(subName)
 	event := e.parseBlockchainEvent(ctx, msgJSON)
 	if event != nil {
-		err = e.callbacks.BlockchainEvent(ctx, namespace, &blockchain.EventWithSubscription{
-			Event:        *event,
-			Subscription: msgJSON.GetString("subId"),
+		e.callbacks.PrepareBlockchainEvent(ctx, events, namespace, &blockchain.EventForListener{
+			Event:      event,
+			ListenerID: subID,
 		})
 	}
-	return err
+	return nil
 }
 
 func (e *Ethereum) buildEventLocationString(msgJSON fftypes.JSONObject) string {
 	return fmt.Sprintf("address=%s", msgJSON.GetString("address"))
 }
 
-func (e *Ethereum) handleMessageBatch(ctx context.Context, messages []interface{}) error {
+func (e *Ethereum) handleMessageBatch(ctx context.Context, batchID int64, messages []interface{}) error {
+	// Build the set of events that need handling
+	events := make(common.EventsToDispatch)
+	count := len(messages)
 	for i, msgI := range messages {
 		msgMap, ok := msgI.(map[string]interface{})
 		if !ok {
@@ -421,12 +425,10 @@ func (e *Ethereum) handleMessageBatch(ctx context.Context, messages []interface{
 		}
 		msgJSON := fftypes.JSONObject(msgMap)
 
-		logger := log.L(ctx).WithField("ethmsgidx", i)
-		eventCtx, done := context.WithCancel(log.WithLogger(ctx, logger))
-
 		signature := msgJSON.GetString("signature")
 		sub := msgJSON.GetString("subId")
-		logger.Infof("Received '%s' message on '%s'", signature, sub)
+		logger := log.L(ctx)
+		logger.Infof("[EVM:%d:%d/%d]: '%s' on '%s'", batchID, i, count, signature, sub)
 		logger.Tracef("Message: %+v", msgJSON)
 
 		// Matches one of the active FireFly BatchPin subscriptions
@@ -435,7 +437,6 @@ func (e *Ethereum) handleMessageBatch(ctx context.Context, messages []interface{
 				Address: msgJSON.GetString("address"),
 			})
 			if err != nil {
-				done()
 				return err
 			}
 
@@ -445,25 +446,21 @@ func (e *Ethereum) handleMessageBatch(ctx context.Context, messages []interface{
 			}
 			switch signature {
 			case broadcastBatchEventSignature:
-				if err := e.handleBatchPinEvent(eventCtx, location, subInfo, msgJSON); err != nil {
-					done()
-					return err
-				}
+				e.processBatchPinEvent(ctx, events, location, subInfo, msgJSON)
 			default:
 				log.L(ctx).Infof("Ignoring event with unknown signature: %s", signature)
 			}
 		} else {
 			// Subscription not recognized - assume it's from a custom contract listener
 			// (event manager will reject it if it's not)
-			if err := e.handleContractEvent(eventCtx, msgJSON); err != nil {
-				done()
+			if err := e.processContractEvent(ctx, events, msgJSON); err != nil {
 				return err
 			}
 		}
-		done()
 	}
-
-	return nil
+	// Dispatch all the events from this patch that were successfully parsed and routed to namespaces
+	// (could be zero - that's ok)
+	return e.callbacks.DispatchBlockchainEvents(ctx, events)
 }
 
 func (e *Ethereum) eventLoop() {
@@ -491,7 +488,7 @@ func (e *Ethereum) eventLoop() {
 			}
 			switch msgTyped := msgParsed.(type) {
 			case []interface{}:
-				err = e.handleMessageBatch(ctx, msgTyped)
+				err = e.handleMessageBatch(ctx, 0, msgTyped)
 				if err == nil {
 					ack, _ := json.Marshal(&ethWSCommandPayload{
 						Type:  "ack",
@@ -505,7 +502,7 @@ func (e *Ethereum) eventLoop() {
 					if events, ok := msgTyped["events"].([]interface{}); ok {
 						// FFTM delivery with a batch number to use in the ack
 						isBatch = true
-						err = e.handleMessageBatch(ctx, events)
+						err = e.handleMessageBatch(ctx, (int64)(batchNumber), events)
 						// Errors processing messages are converted into nacks
 						ackOrNack := &ethWSCommandPayload{
 							Topic:       e.topic,

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -475,7 +475,7 @@ func (f *Fabric) handleMessageBatch(ctx context.Context, messages []interface{})
 		eventName := msgJSON.GetString("eventName")
 		sub := msgJSON.GetString("subId")
 		logger := log.L(ctx)
-		logger.Infof("[Fabric:%d/%d]: '%s' on '%s'", i, count, eventName, sub)
+		logger.Infof("[Fabric:%d/%d]: '%s' on '%s'", i+1, count, eventName, sub)
 		logger.Tracef("Message: %+v", msgJSON)
 
 		// Matches one of the active FireFly BatchPin subscriptions

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -377,10 +377,10 @@ func (f *Fabric) parseBlockchainEvent(ctx context.Context, msgJSON fftypes.JSONO
 	}
 }
 
-func (f *Fabric) handleBatchPinEvent(ctx context.Context, location *fftypes.JSONAny, subInfo *common.SubscriptionInfo, msgJSON fftypes.JSONObject) (err error) {
+func (f *Fabric) processBatchPinEvent(ctx context.Context, events common.EventsToDispatch, location *fftypes.JSONAny, subInfo *common.SubscriptionInfo, msgJSON fftypes.JSONObject) {
 	event := f.parseBlockchainEvent(ctx, msgJSON)
 	if event == nil {
-		return nil // move on
+		return // move on
 	}
 
 	signer := event.Output.GetString("signer")
@@ -398,27 +398,28 @@ func (f *Fabric) handleBatchPinEvent(ctx context.Context, location *fftypes.JSON
 		Value: signer,
 	}
 
-	return f.callbacks.BatchPinOrNetworkAction(ctx, subInfo, location, event, verifier, params)
+	f.callbacks.PrepareBatchPinOrNetworkAction(ctx, events, subInfo, location, event, verifier, params)
 }
 
 func (f *Fabric) buildEventLocationString(chaincode string) string {
 	return fmt.Sprintf("chaincode=%s", chaincode)
 }
 
-func (f *Fabric) handleContractEvent(ctx context.Context, msgJSON fftypes.JSONObject) (err error) {
-	subName, err := f.streams.getSubscriptionName(ctx, msgJSON.GetString("subId"))
+func (f *Fabric) processContractEvent(ctx context.Context, events common.EventsToDispatch, msgJSON fftypes.JSONObject) (err error) {
+	subID := msgJSON.GetString("subId")
+	subName, err := f.streams.getSubscriptionName(ctx, subID)
 	if err != nil {
-		return err
+		return err // this is a problem - we should be able to find the listener that dispatched this to us
 	}
 	namespace := common.GetNamespaceFromSubName(subName)
 	event := f.parseBlockchainEvent(ctx, msgJSON)
-	if event == nil {
-		return nil // move on
+	if event != nil {
+		f.callbacks.PrepareBlockchainEvent(ctx, events, namespace, &blockchain.EventForListener{
+			Event:      event,
+			ListenerID: subID,
+		})
 	}
-	return f.callbacks.BlockchainEvent(ctx, namespace, &blockchain.EventWithSubscription{
-		Event:        *event,
-		Subscription: msgJSON.GetString("subId"),
-	})
+	return nil
 }
 
 func (f *Fabric) AddFireflySubscription(ctx context.Context, namespace *core.Namespace, contract *blockchain.MultipartyContract) (string, error) {
@@ -460,6 +461,9 @@ func (f *Fabric) RemoveFireflySubscription(ctx context.Context, subID string) {
 }
 
 func (f *Fabric) handleMessageBatch(ctx context.Context, messages []interface{}) error {
+	// Build the set of events that need handling
+	events := make(common.EventsToDispatch)
+	count := len(messages)
 	for i, msgI := range messages {
 		msgMap, ok := msgI.(map[string]interface{})
 		if !ok {
@@ -468,12 +472,10 @@ func (f *Fabric) handleMessageBatch(ctx context.Context, messages []interface{})
 		}
 		msgJSON := fftypes.JSONObject(msgMap)
 
-		logger := log.L(ctx).WithField("fabmsgidx", i)
-		eventCtx, done := context.WithCancel(log.WithLogger(ctx, logger))
-
 		eventName := msgJSON.GetString("eventName")
 		sub := msgJSON.GetString("subId")
-		logger.Infof("Received '%s' message on '%s'", eventName, sub)
+		logger := log.L(ctx)
+		logger.Infof("[Fabric:%d/%d]: '%s' on '%s'", i, count, eventName, sub)
 		logger.Tracef("Message: %+v", msgJSON)
 
 		// Matches one of the active FireFly BatchPin subscriptions
@@ -483,31 +485,26 @@ func (f *Fabric) handleMessageBatch(ctx context.Context, messages []interface{})
 				Channel:   subInfo.Extra.(string),
 			})
 			if err != nil {
-				done()
 				return err
 			}
 
 			switch eventName {
 			case broadcastBatchEventName:
-				if err := f.handleBatchPinEvent(eventCtx, location, subInfo, msgJSON); err != nil {
-					done()
-					return err
-				}
+				f.processBatchPinEvent(ctx, events, location, subInfo, msgJSON)
 			default:
 				log.L(ctx).Infof("Ignoring event with unknown name: %s", eventName)
 			}
 		} else {
 			// Subscription not recognized - assume it's from a custom contract listener
 			// (event manager will reject it if it's not)
-			if err := f.handleContractEvent(ctx, msgJSON); err != nil {
-				done()
+			if err := f.processContractEvent(ctx, events, msgJSON); err != nil {
 				return err
 			}
 		}
-		done()
 	}
-
-	return nil
+	// Dispatch all the events from this patch that were successfully parsed and routed to namespaces
+	// (could be zero - that's ok)
+	return f.callbacks.DispatchBlockchainEvents(ctx, events)
 }
 
 func (f *Fabric) eventLoop() {

--- a/internal/events/batch_pin_complete.go
+++ b/internal/events/batch_pin_complete.go
@@ -35,15 +35,15 @@ func (em *eventManager) handleBlockchainBatchPinEvent(ctx context.Context, event
 	batchPin := event.Batch
 
 	if em.multiparty == nil {
-		log.L(em.ctx).Errorf("Ignoring batch pin from non-multiparty network!")
+		log.L(ctx).Errorf("Ignoring batch pin from non-multiparty network!")
 		return nil
 	}
 	if batchPin.TransactionID == nil {
-		log.L(em.ctx).Errorf("Invalid BatchPin transaction - ID is nil")
+		log.L(ctx).Errorf("Invalid BatchPin transaction - ID is nil")
 		return nil // move on
 	}
 	if event.Namespace != em.namespace.Name {
-		log.L(em.ctx).Debugf("Ignoring batch pin from different namespace '%s'", event.Namespace)
+		log.L(ctx).Debugf("Ignoring batch pin from different namespace '%s'", event.Namespace)
 		return nil // move on
 	}
 
@@ -51,11 +51,11 @@ func (em *eventManager) handleBlockchainBatchPinEvent(ctx context.Context, event
 		batchPin.TransactionType = core.TransactionTypeBatchPin
 	}
 
-	log.L(em.ctx).Infof("-> BatchPinComplete batch=%s txn=%s signingIdentity=%s", batchPin.BatchID, batchPin.Event.ProtocolID, event.SigningKey.Value)
+	log.L(ctx).Infof("-> BatchPinComplete batch=%s txn=%s signingIdentity=%s", batchPin.BatchID, batchPin.Event.ProtocolID, event.SigningKey.Value)
 	defer func() {
-		log.L(em.ctx).Infof("<- BatchPinComplete batch=%s txn=%s signingIdentity=%s", batchPin.BatchID, batchPin.Event.ProtocolID, event.SigningKey.Value)
+		log.L(ctx).Infof("<- BatchPinComplete batch=%s txn=%s signingIdentity=%s", batchPin.BatchID, batchPin.Event.ProtocolID, event.SigningKey.Value)
 	}()
-	log.L(em.ctx).Tracef("BatchPinComplete batch=%s info: %+v", batchPin.BatchID, batchPin.Event.Info)
+	log.L(ctx).Tracef("BatchPinComplete batch=%s info: %+v", batchPin.BatchID, batchPin.Event.Info)
 
 	if err := em.persistBatchTransaction(ctx, batchPin); err != nil {
 		return err

--- a/internal/events/batch_pin_complete_test.go
+++ b/internal/events/batch_pin_complete_test.go
@@ -131,9 +131,18 @@ func TestBatchPinCompleteOkBroadcast(t *testing.T) {
 	em.mdi.On("GetBatchByID", mock.Anything, "ns1", mock.Anything).Return(nil, nil)
 	em.msd.On("InitiateDownloadBatch", mock.Anything, batchPin.TransactionID, batchPin.BatchPayloadRef).Return(nil)
 
-	err := em.BatchPinComplete("ns1", batchPin, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0x12345",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batchPin,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0x12345",
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 
@@ -194,9 +203,18 @@ func TestBatchPinCompleteOkBroadcastExistingBatch(t *testing.T) {
 	em.mdi.On("InsertPins", mock.Anything, mock.Anything).Return(nil).Once()
 	em.mdi.On("GetBatchByID", mock.Anything, "ns1", mock.Anything).Return(batchPersisted, nil)
 
-	err := em.BatchPinComplete("ns1", batchPin, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0x12345",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batchPin,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0x12345",
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 
@@ -225,9 +243,18 @@ func TestBatchPinCompleteOkPrivate(t *testing.T) {
 	em.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	em.mdi.On("GetBatchByID", mock.Anything, "ns1", mock.Anything).Return(nil, nil)
 
-	err := em.BatchPinComplete("ns1", batchPin, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0xffffeeee",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batchPin,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0xffffeeee",
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 
@@ -262,9 +289,18 @@ func TestBatchPinCompleteInsertPinsFail(t *testing.T) {
 	em.mth.On("InsertOrGetBlockchainEvent", mock.Anything, mock.Anything).Return(nil, nil)
 	em.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 
-	err := em.BatchPinComplete("ns1", batchPin, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0xffffeeee",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batchPin,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0xffffeeee",
+				},
+			},
+		},
 	})
 	assert.Regexp(t, "FF00154", err)
 
@@ -293,9 +329,18 @@ func TestBatchPinCompleteGetBatchByIDFails(t *testing.T) {
 	em.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	em.mdi.On("GetBatchByID", mock.Anything, "ns1", mock.Anything).Return(nil, fmt.Errorf("batch lookup failed"))
 
-	err := em.BatchPinComplete("ns1", batchPin, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0xffffeeee",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batchPin,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0xffffeeee",
+				},
+			},
+		},
 	})
 	assert.Regexp(t, "FF00154", err)
 
@@ -326,9 +371,18 @@ func TestSequencedBroadcastInitiateDownloadFail(t *testing.T) {
 	em.mdi.On("GetBatchByID", mock.Anything, "ns1", mock.Anything).Return(nil, nil)
 	em.msd.On("InitiateDownloadBatch", mock.Anything, batchPin.TransactionID, batchPin.BatchPayloadRef).Return(fmt.Errorf("pop"))
 
-	err := em.BatchPinComplete("ns1", batchPin, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0xffffeeee",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batchPin,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0xffffeeee",
+				},
+			},
+		},
 	})
 	assert.Regexp(t, "FF00154", err)
 }
@@ -339,9 +393,18 @@ func TestBatchPinCompleteNoTX(t *testing.T) {
 
 	batch := &blockchain.BatchPin{}
 
-	err := em.BatchPinComplete("ns1", batch, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0x12345",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batch,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0x12345",
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 }
@@ -357,9 +420,18 @@ func TestBatchPinCompleteWrongNamespace(t *testing.T) {
 		},
 	}
 
-	err := em.BatchPinComplete("ns2", batch, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0x12345",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns2",
+				Batch:     batch,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0xffffeeee",
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 }
@@ -376,9 +448,18 @@ func TestBatchPinCompleteNonMultiparty(t *testing.T) {
 		},
 	}
 
-	err := em.BatchPinComplete("ns1", batch, &core.VerifierRef{
-		Type:  core.VerifierTypeEthAddress,
-		Value: "0x12345",
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeBatchPinComplete,
+			BatchPinComplete: &blockchain.BatchPinCompleteEvent{
+				Namespace: "ns1",
+				Batch:     batch,
+				SigningKey: &core.VerifierRef{
+					Type:  core.VerifierTypeEthAddress,
+					Value: "0x12345",
+				},
+			},
+		},
 	})
 	assert.NoError(t, err)
 }

--- a/internal/events/blockchain_event.go
+++ b/internal/events/blockchain_event.go
@@ -133,7 +133,7 @@ func (em *eventManager) handleBlockchainEventForListener(ctx context.Context, ev
 		return nil // no retry
 	}
 	if listener.Namespace != em.namespace.Name {
-		log.L(em.ctx).Debugf("Ignoring blockchain event from different namespace '%s'", listener.Namespace)
+		log.L(ctx).Debugf("Ignoring blockchain event from different namespace '%s'", listener.Namespace)
 		return nil
 	}
 	listener.Namespace = em.namespace.Name

--- a/internal/events/blockchain_event.go
+++ b/internal/events/blockchain_event.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -99,32 +99,51 @@ func (em *eventManager) emitBlockchainEventMetric(event *blockchain.Event) {
 	}
 }
 
-func (em *eventManager) BlockchainEvent(event *blockchain.EventWithSubscription) error {
+func (em *eventManager) BlockchainEventBatch(batch []*blockchain.EventToDispatch) error {
 	return em.retry.Do(em.ctx, "persist blockchain event", func(attempt int) (bool, error) {
-		err := em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
-			listener, err := em.getChainListenerByProtocolIDCached(ctx, event.Subscription)
-			if err != nil {
-				return err
+		return true, em.database.RunAsGroup(em.ctx, func(ctx context.Context) error {
+			for _, event := range batch {
+				switch event.Type {
+				case blockchain.EventTypeForListener:
+					if err := em.handleBlockchainEventForListener(ctx, event.ForListener); err != nil {
+						return err
+					}
+				case blockchain.EventTypeBatchPinComplete:
+					if err := em.handleBlockchainBatchPinEvent(ctx, event.BatchPinComplete); err != nil {
+						return err
+					}
+				case blockchain.EventTypeNetworkAction:
+					if err := em.handleBlockchainNetworkAction(ctx, event.NetworkAction); err != nil {
+						return err
+					}
+				}
 			}
-			if listener == nil {
-				log.L(ctx).Warnf("Event received from unknown subscription %s", event.Subscription)
-				return nil // no retry
-			}
-			if listener.Namespace != em.namespace.Name {
-				log.L(em.ctx).Debugf("Ignoring blockchain event from different namespace '%s'", listener.Namespace)
-				return nil
-			}
-			listener.Namespace = em.namespace.Name
-
-			chainEvent := buildBlockchainEvent(listener.Namespace, listener.ID, &event.Event, &core.BlockchainTransactionRef{
-				BlockchainID: event.BlockchainTXID,
-			})
-			if err := em.maybePersistBlockchainEvent(ctx, chainEvent, listener); err != nil {
-				return err
-			}
-			em.emitBlockchainEventMetric(&event.Event)
 			return nil
 		})
-		return err != nil, err
 	})
+}
+
+func (em *eventManager) handleBlockchainEventForListener(ctx context.Context, event *blockchain.EventForListener) error {
+	listener, err := em.getChainListenerByProtocolIDCached(ctx, event.ListenerID)
+	if err != nil {
+		return err
+	}
+	if listener == nil {
+		log.L(ctx).Warnf("Event received from unknown subscription %s", event.ListenerID)
+		return nil // no retry
+	}
+	if listener.Namespace != em.namespace.Name {
+		log.L(em.ctx).Debugf("Ignoring blockchain event from different namespace '%s'", listener.Namespace)
+		return nil
+	}
+	listener.Namespace = em.namespace.Name
+
+	chainEvent := buildBlockchainEvent(listener.Namespace, listener.ID, event.Event, &core.BlockchainTransactionRef{
+		BlockchainID: event.BlockchainTXID,
+	})
+	if err := em.maybePersistBlockchainEvent(ctx, chainEvent, listener); err != nil {
+		return err
+	}
+	em.emitBlockchainEventMetric(event.Event)
+	return nil
 }

--- a/internal/events/blockchain_event_test.go
+++ b/internal/events/blockchain_event_test.go
@@ -31,9 +31,9 @@ func TestContractEventWithRetries(t *testing.T) {
 	em := newTestEventManager(t)
 	defer em.cleanup(t)
 
-	ev := &blockchain.EventWithSubscription{
-		Subscription: "sb-1",
-		Event: blockchain.Event{
+	ev := &blockchain.EventForListener{
+		ListenerID: "sb-1",
+		Event: &blockchain.Event{
 			BlockchainTXID: "0xabcd1234",
 			ProtocolID:     "10/20/30",
 			Name:           "Changed",
@@ -64,7 +64,12 @@ func TestContractEventWithRetries(t *testing.T) {
 		return e.Type == core.EventTypeBlockchainEventReceived && e.Reference != nil && e.Reference == eventID && e.Topic == "topic1"
 	})).Return(nil).Once()
 
-	err := em.BlockchainEvent(ev)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type:        blockchain.EventTypeForListener,
+			ForListener: ev,
+		},
+	})
 	assert.NoError(t, err)
 
 }
@@ -73,9 +78,9 @@ func TestContractEventUnknownSubscription(t *testing.T) {
 	em := newTestEventManager(t)
 	defer em.cleanup(t)
 
-	ev := &blockchain.EventWithSubscription{
-		Subscription: "sb-1",
-		Event: blockchain.Event{
+	ev := &blockchain.EventForListener{
+		ListenerID: "sb-1",
+		Event: &blockchain.Event{
 			BlockchainTXID: "0xabcd1234",
 			Name:           "Changed",
 			Output: fftypes.JSONObject{
@@ -89,7 +94,12 @@ func TestContractEventUnknownSubscription(t *testing.T) {
 
 	em.mdi.On("GetContractListenerByBackendID", mock.Anything, "ns1", "sb-1").Return(nil, nil)
 
-	err := em.BlockchainEvent(ev)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type:        blockchain.EventTypeForListener,
+			ForListener: ev,
+		},
+	})
 	assert.NoError(t, err)
 
 }
@@ -98,9 +108,9 @@ func TestContractEventWrongNS(t *testing.T) {
 	em := newTestEventManager(t)
 	defer em.cleanup(t)
 
-	ev := &blockchain.EventWithSubscription{
-		Subscription: "sb-1",
-		Event: blockchain.Event{
+	ev := &blockchain.EventForListener{
+		ListenerID: "sb-1",
+		Event: &blockchain.Event{
 			BlockchainTXID: "0xabcd1234",
 			Name:           "Changed",
 			Output: fftypes.JSONObject{
@@ -119,7 +129,12 @@ func TestContractEventWrongNS(t *testing.T) {
 
 	em.mdi.On("GetContractListenerByBackendID", mock.Anything, "ns1", "sb-1").Return(sub, nil)
 
-	err := em.BlockchainEvent(ev)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type:        blockchain.EventTypeForListener,
+			ForListener: ev,
+		},
+	})
 	assert.NoError(t, err)
 
 }

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -66,9 +66,7 @@ type EventManager interface {
 	WaitStop()
 
 	// Bound blockchain callbacks
-	BatchPinComplete(namespace string, batch *blockchain.BatchPin, signingKey *core.VerifierRef) error
-	BlockchainEvent(event *blockchain.EventWithSubscription) error
-	BlockchainNetworkAction(action string, location *fftypes.JSONAny, event *blockchain.Event, signingKey *core.VerifierRef) error
+	BlockchainEventBatch(batch []*blockchain.EventToDispatch) error
 
 	// Bound dataexchange callbacks
 	DXEvent(plugin dataexchange.Plugin, event dataexchange.DXEvent) error

--- a/internal/events/network_action.go
+++ b/internal/events/network_action.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -17,6 +17,8 @@
 package events
 
 import (
+	"context"
+
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly/pkg/blockchain"
@@ -27,40 +29,38 @@ func (em *eventManager) actionTerminate(location *fftypes.JSONAny, event *blockc
 	return em.multiparty.TerminateContract(em.ctx, location, event)
 }
 
-func (em *eventManager) BlockchainNetworkAction(action string, location *fftypes.JSONAny, event *blockchain.Event, signingKey *core.VerifierRef) error {
+func (em *eventManager) handleBlockchainNetworkAction(ctx context.Context, event *blockchain.NetworkActionEvent) error {
 	if em.multiparty == nil {
 		log.L(em.ctx).Errorf("Ignoring network action from non-multiparty network!")
 		return nil
 	}
 
-	return em.retry.Do(em.ctx, "handle network action", func(attempt int) (retry bool, err error) {
-		// Verify that the action came from a registered root org
-		resolvedAuthor, err := em.identity.FindIdentityForVerifier(em.ctx, []core.IdentityType{core.IdentityTypeOrg}, signingKey)
-		if err != nil {
-			return true, err
-		}
-		if resolvedAuthor == nil {
-			log.L(em.ctx).Errorf("Ignoring network action %s from unknown identity %s", action, signingKey.Value)
-			return false, nil
-		}
-		if resolvedAuthor.Parent != nil {
-			log.L(em.ctx).Errorf("Ignoring network action %s from non-root identity %s", action, signingKey.Value)
-			return false, nil
-		}
+	// Verify that the action came from a registered root org
+	resolvedAuthor, err := em.identity.FindIdentityForVerifier(em.ctx, []core.IdentityType{core.IdentityTypeOrg}, event.SigningKey)
+	if err != nil {
+		return err
+	}
+	if resolvedAuthor == nil {
+		log.L(em.ctx).Errorf("Ignoring network action %s from unknown identity %s", event.Action, event.SigningKey.Value)
+		return nil
+	}
+	if resolvedAuthor.Parent != nil {
+		log.L(em.ctx).Errorf("Ignoring network action %s from non-root identity %s", event.Action, event.SigningKey.Value)
+		return nil
+	}
 
-		if action == core.NetworkActionTerminate.String() {
-			err = em.actionTerminate(location, event)
-		} else {
-			log.L(em.ctx).Errorf("Ignoring unrecognized network action: %s", action)
-			return false, nil
-		}
+	if event.Action == core.NetworkActionTerminate.String() {
+		err = em.actionTerminate(event.Location, event.Event)
+	} else {
+		log.L(em.ctx).Errorf("Ignoring unrecognized network action: %s", event.Action)
+		return nil
+	}
 
-		if err == nil {
-			chainEvent := buildBlockchainEvent(em.namespace.Name, nil, event, &core.BlockchainTransactionRef{
-				BlockchainID: event.BlockchainTXID,
-			})
-			err = em.maybePersistBlockchainEvent(em.ctx, chainEvent, nil)
-		}
-		return true, err
-	})
+	if err == nil {
+		chainEvent := buildBlockchainEvent(em.namespace.Name, nil, event.Event, &core.BlockchainTransactionRef{
+			BlockchainID: event.Event.BlockchainTXID,
+		})
+		err = em.maybePersistBlockchainEvent(em.ctx, chainEvent, nil)
+	}
+	return err
 }

--- a/internal/events/network_action_test.go
+++ b/internal/events/network_action_test.go
@@ -175,6 +175,6 @@ func TestActionTerminateFail(t *testing.T) {
 
 	em.mmp.On("TerminateContract", em.ctx, location, mock.AnythingOfType("*blockchain.Event")).Return(fmt.Errorf("pop"))
 
-	err := em.actionTerminate(location, &blockchain.Event{})
+	err := em.actionTerminate(em.ctx, location, &blockchain.Event{})
 	assert.EqualError(t, err, "pop")
 }

--- a/internal/events/network_action_test.go
+++ b/internal/events/network_action_test.go
@@ -45,7 +45,17 @@ func TestNetworkAction(t *testing.T) {
 	em.mdi.On("InsertEvent", em.ctx, mock.Anything).Return(nil)
 	em.mmp.On("TerminateContract", em.ctx, location, mock.AnythingOfType("*blockchain.Event")).Return(nil)
 
-	err := em.BlockchainNetworkAction("terminate", location, event, verifier)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeNetworkAction,
+			NetworkAction: &blockchain.NetworkActionEvent{
+				Action:     "terminate",
+				Location:   location,
+				Event:      event,
+				SigningKey: verifier,
+			},
+		},
+	})
 	assert.NoError(t, err)
 }
 
@@ -62,7 +72,17 @@ func TestNetworkActionUnknownIdentity(t *testing.T) {
 	em.mim.On("FindIdentityForVerifier", em.ctx, []core.IdentityType{core.IdentityTypeOrg}, verifier).Return(nil, fmt.Errorf("pop")).Once()
 	em.mim.On("FindIdentityForVerifier", em.ctx, []core.IdentityType{core.IdentityTypeOrg}, verifier).Return(nil, nil).Once()
 
-	err := em.BlockchainNetworkAction("terminate", location, &blockchain.Event{}, verifier)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeNetworkAction,
+			NetworkAction: &blockchain.NetworkActionEvent{
+				Action:     "terminate",
+				Location:   location,
+				Event:      &blockchain.Event{},
+				SigningKey: verifier,
+			},
+		},
+	})
 	assert.NoError(t, err)
 }
 
@@ -82,7 +102,17 @@ func TestNetworkActionNonRootIdentity(t *testing.T) {
 		},
 	}, nil)
 
-	err := em.BlockchainNetworkAction("terminate", location, &blockchain.Event{}, verifier)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeNetworkAction,
+			NetworkAction: &blockchain.NetworkActionEvent{
+				Action:     "terminate",
+				Location:   location,
+				Event:      &blockchain.Event{},
+				SigningKey: verifier,
+			},
+		},
+	})
 	assert.NoError(t, err)
 }
 
@@ -97,7 +127,17 @@ func TestNetworkActionNonMultiparty(t *testing.T) {
 		Value: "0x1234",
 	}
 
-	err := em.BlockchainNetworkAction("terminate", location, &blockchain.Event{}, verifier)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeNetworkAction,
+			NetworkAction: &blockchain.NetworkActionEvent{
+				Action:     "terminate",
+				Location:   location,
+				Event:      &blockchain.Event{},
+				SigningKey: verifier,
+			},
+		},
+	})
 	assert.NoError(t, err)
 }
 
@@ -113,7 +153,17 @@ func TestNetworkActionUnknown(t *testing.T) {
 
 	em.mim.On("FindIdentityForVerifier", em.ctx, []core.IdentityType{core.IdentityTypeOrg}, verifier).Return(&core.Identity{}, nil)
 
-	err := em.BlockchainNetworkAction("bad", location, &blockchain.Event{}, verifier)
+	err := em.BlockchainEventBatch([]*blockchain.EventToDispatch{
+		{
+			Type: blockchain.EventTypeNetworkAction,
+			NetworkAction: &blockchain.NetworkActionEvent{
+				Action:     "bad",
+				Location:   location,
+				Event:      &blockchain.Event{},
+				SigningKey: verifier,
+			},
+		},
+	})
 	assert.NoError(t, err)
 }
 

--- a/internal/orchestrator/bound_callbacks.go
+++ b/internal/orchestrator/bound_callbacks.go
@@ -59,25 +59,11 @@ func (bc *boundCallbacks) SharedStorageBlobDownloaded(hash fftypes.Bytes32, size
 	return bc.o.events.SharedStorageBlobDownloaded(bc.o.sharedstorage(), hash, size, payloadRef, dataID)
 }
 
-func (bc *boundCallbacks) BatchPinComplete(namespace string, batch *blockchain.BatchPin, signingKey *core.VerifierRef) error {
+func (bc *boundCallbacks) BlockchainEventBatch(batch []*blockchain.EventToDispatch) error {
 	if err := bc.checkStopped(); err != nil {
 		return err
 	}
-	return bc.o.events.BatchPinComplete(namespace, batch, signingKey)
-}
-
-func (bc *boundCallbacks) BlockchainNetworkAction(action string, location *fftypes.JSONAny, event *blockchain.Event, signingKey *core.VerifierRef) error {
-	if err := bc.checkStopped(); err != nil {
-		return err
-	}
-	return bc.o.events.BlockchainNetworkAction(action, location, event, signingKey)
-}
-
-func (bc *boundCallbacks) BlockchainEvent(event *blockchain.EventWithSubscription) error {
-	if err := bc.checkStopped(); err != nil {
-		return err
-	}
-	return bc.o.events.BlockchainEvent(event)
+	return bc.o.events.BlockchainEventBatch(batch)
 }
 
 func (bc *boundCallbacks) DXEvent(plugin dataexchange.Plugin, event dataexchange.DXEvent) error {

--- a/internal/orchestrator/bound_callbacks_test.go
+++ b/internal/orchestrator/bound_callbacks_test.go
@@ -86,16 +86,8 @@ func TestBoundCallbacks(t *testing.T) {
 	err = bc.SharedStorageBlobDownloaded(*hash, 12345, "payload1", dataID)
 	assert.NoError(t, err)
 
-	mei.On("BatchPinComplete", "ns1", &blockchain.BatchPin{}, &core.VerifierRef{}).Return(nil)
-	err = bc.BatchPinComplete("ns1", &blockchain.BatchPin{}, &core.VerifierRef{})
-	assert.NoError(t, err)
-
-	mei.On("BlockchainNetworkAction", "action", fftypes.JSONAnyPtr("{}"), &blockchain.Event{}, &core.VerifierRef{}).Return(nil)
-	err = bc.BlockchainNetworkAction("action", fftypes.JSONAnyPtr("{}"), &blockchain.Event{}, &core.VerifierRef{})
-	assert.NoError(t, err)
-
-	mei.On("BlockchainEvent", &blockchain.EventWithSubscription{}).Return(nil)
-	err = bc.BlockchainEvent(&blockchain.EventWithSubscription{})
+	mei.On("BlockchainEventBatch", []*blockchain.EventToDispatch{{Type: blockchain.EventTypeBatchPinComplete}}).Return(nil)
+	err = bc.BlockchainEventBatch([]*blockchain.EventToDispatch{{Type: blockchain.EventTypeBatchPinComplete}})
 	assert.NoError(t, err)
 
 	mei.On("DXEvent", mdx, &dataexchangemocks.DXEvent{}).Return(nil)
@@ -130,13 +122,7 @@ func TestBoundCallbacksStopped(t *testing.T) {
 	err = bc.SharedStorageBlobDownloaded(*fftypes.NewRandB32(), 12345, "payload1", nil)
 	assert.Regexp(t, "FF10446", err)
 
-	err = bc.BatchPinComplete("ns1", &blockchain.BatchPin{}, &core.VerifierRef{})
-	assert.Regexp(t, "FF10446", err)
-
-	err = bc.BlockchainNetworkAction("action", fftypes.JSONAnyPtr("{}"), &blockchain.Event{}, &core.VerifierRef{})
-	assert.Regexp(t, "FF10446", err)
-
-	err = bc.BlockchainEvent(&blockchain.EventWithSubscription{})
+	err = bc.BlockchainEventBatch([]*blockchain.EventToDispatch{})
 	assert.Regexp(t, "FF10446", err)
 
 	err = bc.DXEvent(nil, &dataexchangemocks.DXEvent{})

--- a/mocks/blockchainmocks/callbacks.go
+++ b/mocks/blockchainmocks/callbacks.go
@@ -4,10 +4,6 @@ package blockchainmocks
 
 import (
 	blockchain "github.com/hyperledger/firefly/pkg/blockchain"
-	core "github.com/hyperledger/firefly/pkg/core"
-
-	fftypes "github.com/hyperledger/firefly-common/pkg/fftypes"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -16,41 +12,13 @@ type Callbacks struct {
 	mock.Mock
 }
 
-// BatchPinComplete provides a mock function with given fields: namespace, batch, signingKey
-func (_m *Callbacks) BatchPinComplete(namespace string, batch *blockchain.BatchPin, signingKey *core.VerifierRef) error {
-	ret := _m.Called(namespace, batch, signingKey)
+// BlockchainEventBatch provides a mock function with given fields: batch
+func (_m *Callbacks) BlockchainEventBatch(batch []*blockchain.EventToDispatch) error {
+	ret := _m.Called(batch)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *blockchain.BatchPin, *core.VerifierRef) error); ok {
-		r0 = rf(namespace, batch, signingKey)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// BlockchainEvent provides a mock function with given fields: event
-func (_m *Callbacks) BlockchainEvent(event *blockchain.EventWithSubscription) error {
-	ret := _m.Called(event)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*blockchain.EventWithSubscription) error); ok {
-		r0 = rf(event)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// BlockchainNetworkAction provides a mock function with given fields: action, location, event, signingKey
-func (_m *Callbacks) BlockchainNetworkAction(action string, location *fftypes.JSONAny, event *blockchain.Event, signingKey *core.VerifierRef) error {
-	ret := _m.Called(action, location, event, signingKey)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *fftypes.JSONAny, *blockchain.Event, *core.VerifierRef) error); ok {
-		r0 = rf(action, location, event, signingKey)
+	if rf, ok := ret.Get(0).(func([]*blockchain.EventToDispatch) error); ok {
+		r0 = rf(batch)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/eventmocks/event_manager.go
+++ b/mocks/eventmocks/event_manager.go
@@ -41,41 +41,13 @@ func (_m *EventManager) AddSystemEventListener(ns string, el system.EventListene
 	return r0
 }
 
-// BatchPinComplete provides a mock function with given fields: namespace, batch, signingKey
-func (_m *EventManager) BatchPinComplete(namespace string, batch *blockchain.BatchPin, signingKey *core.VerifierRef) error {
-	ret := _m.Called(namespace, batch, signingKey)
+// BlockchainEventBatch provides a mock function with given fields: batch
+func (_m *EventManager) BlockchainEventBatch(batch []*blockchain.EventToDispatch) error {
+	ret := _m.Called(batch)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *blockchain.BatchPin, *core.VerifierRef) error); ok {
-		r0 = rf(namespace, batch, signingKey)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// BlockchainEvent provides a mock function with given fields: event
-func (_m *EventManager) BlockchainEvent(event *blockchain.EventWithSubscription) error {
-	ret := _m.Called(event)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*blockchain.EventWithSubscription) error); ok {
-		r0 = rf(event)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// BlockchainNetworkAction provides a mock function with given fields: action, location, event, signingKey
-func (_m *EventManager) BlockchainNetworkAction(action string, location *fftypes.JSONAny, event *blockchain.Event, signingKey *core.VerifierRef) error {
-	ret := _m.Called(action, location, event, signingKey)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *fftypes.JSONAny, *blockchain.Event, *core.VerifierRef) error); ok {
-		r0 = rf(action, location, event, signingKey)
+	if rf, ok := ret.Get(0).(func([]*blockchain.EventToDispatch) error); ok {
+		r0 = rf(batch)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
One of the outstanding observations from the performance testing in V1.2 was that we are performing a DB commit for each Blockchain event.

These are sequential on the single logical delivery thread from the blockchain connector (which currently is server-wide, although that should itself become namespace-wide).

This PR proposes that instead we update all the internal callback interfaces, to propagate the batch of events that come in over the wire from the connector, through to the event processor.

This means a few things handled in this PR:
1. Handling a batch that contains events of multiple types -  Batch Pin, Network Action, or custom Blockchain Event Listener
2. Handling a batch that needs different events dispatching to different namespaces
3. Continuing to handle old events that didn't come with a namespace at all (these are dispatched to all registered namespaces)