### PR TITLE
Surface message rejection reason to API

### DIFF
--- a/db/migrations/postgres/000114_add_message_reject_reason.down.sql
+++ b/db/migrations/postgres/000114_add_message_reject_reason.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE messages DROP COLUMN reject_reason;
+COMMIT;

--- a/db/migrations/postgres/000114_add_message_reject_reason.up.sql
+++ b/db/migrations/postgres/000114_add_message_reject_reason.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE messages ADD COLUMN reject_reason TEXT DEFAULT '';
+COMMIT;

--- a/db/migrations/sqlite/000114_add_message_reject_reason.down.sql
+++ b/db/migrations/sqlite/000114_add_message_reject_reason.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE messages DROP COLUMN reject_reason;

--- a/db/migrations/sqlite/000114_add_message_reject_reason.up.sql
+++ b/db/migrations/sqlite/000114_add_message_reject_reason.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE messages ADD COLUMN reject_reason TEXT DEFAULT '';

--- a/docs/reference/types/message.md
+++ b/docs/reference/types/message.md
@@ -63,6 +63,7 @@ nav_order: 16
 | `txid` | The ID of the transaction used to order/deliver this message | [`UUID`](simpletypes#uuid) |
 | `state` | The current state of the message | `FFEnum`:<br/>`"staged"`<br/>`"ready"`<br/>`"sent"`<br/>`"pending"`<br/>`"confirmed"`<br/>`"rejected"` |
 | `confirmed` | The timestamp of when the message was confirmed/rejected | [`FFTime`](simpletypes#fftime) |
+| `rejectReason` | If a message was rejected, provides details on the rejection reason | `string` |
 | `data` | The list of data elements attached to the message | [`DataRef[]`](#dataref) |
 | `pins` | For private messages, a unique pin hash:nonce is assigned for each topic | `string[]` |
 | `idempotencyKey` | An optional unique identifier for a message. Cannot be duplicated within a namespace, thus allowing idempotent submission of messages to the API. Local only - not transferred when the message is sent to other members of the network | `IdempotencyKey` |

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -6743,6 +6743,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: rejectreason
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: sequence
         schema:
           type: string
@@ -7020,6 +7025,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: rejectreason
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: sequence
         schema:
           type: string
@@ -7242,6 +7252,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -7340,6 +7354,11 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: pins
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: rejectreason
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -9542,6 +9561,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: rejectreason
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: sequence
         schema:
           type: string
@@ -9766,6 +9790,10 @@ paths:
                           is assigned for each topic
                         type: string
                       type: array
+                    rejectReason:
+                      description: If a message was rejected, provides details on
+                        the rejection reason
+                      type: string
                     state:
                       description: The current state of the message
                       enum:
@@ -10041,6 +10069,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -10677,6 +10709,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -10832,6 +10868,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -11158,6 +11198,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -11319,6 +11363,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -11726,6 +11774,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -19375,6 +19427,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: rejectreason
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: sequence
         schema:
           type: string
@@ -19666,6 +19723,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: rejectreason
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: sequence
         schema:
           type: string
@@ -19888,6 +19950,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -19993,6 +20059,11 @@ paths:
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
         name: pins
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
+        name: rejectreason
         schema:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
@@ -22314,6 +22385,11 @@ paths:
           type: string
       - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
         in: query
+        name: rejectreason
+        schema:
+          type: string
+      - description: 'Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^'
+        in: query
         name: sequence
         schema:
           type: string
@@ -22538,6 +22614,10 @@ paths:
                           is assigned for each topic
                         type: string
                       type: array
+                    rejectReason:
+                      description: If a message was rejected, provides details on
+                        the rejection reason
+                      type: string
                     state:
                       description: The current state of the message
                       enum:
@@ -22820,6 +22900,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -23528,6 +23612,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -23689,6 +23777,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -24022,6 +24114,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -24183,6 +24279,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:
@@ -24597,6 +24697,10 @@ paths:
                         assigned for each topic
                       type: string
                     type: array
+                  rejectReason:
+                    description: If a message was rejected, provides details on the
+                      rejection reason
+                    type: string
                   state:
                     description: The current state of the message
                     enum:

--- a/internal/coremsgs/en_error_messages.go
+++ b/internal/coremsgs/en_error_messages.go
@@ -288,4 +288,6 @@ var (
 	MsgCannotDeletePublished              = ffe("FF10449", "Cannot delete an item that has been published", 409)
 	MsgAlreadyPublished                   = ffe("FF10450", "Item has already been published", 409)
 	MsgContractInterfaceNotPublished      = ffe("FF10451", "Contract interface '%s' has not been published", 409)
+	MsgInvalidMessageSigner               = ffe("FF10452", "Invalid message '%s'. Key '%s' does not match the signer of the pin: %s")
+	MsgInvalidMessageIdentity             = ffe("FF10453", "Invalid message '%s'. Author '%s' does not match identity registered to %s: %s (%s)")
 )

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -67,6 +67,7 @@ var (
 	MessageBatchID        = ffm("Message.batch", "The UUID of the batch in which the message was pinned/transferred")
 	MessageState          = ffm("Message.state", "The current state of the message")
 	MessageConfirmed      = ffm("Message.confirmed", "The timestamp of when the message was confirmed/rejected")
+	MessageRejectReason   = ffm("Message.rejectReason", "If a message was rejected, provides details on the rejection reason")
 	MessageData           = ffm("Message.data", "The list of data elements attached to the message")
 	MessagePins           = ffm("Message.pins", "For private messages, a unique pin hash:nonce is assigned for each topic")
 	MessageTransactionID  = ffm("Message.txid", "The ID of the transaction used to order/deliver this message")

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -42,7 +42,7 @@ type Manager interface {
 	PeekMessageCache(ctx context.Context, id *fftypes.UUID, options ...CacheReadOption) (msg *core.Message, data core.DataArray)
 	UpdateMessageCache(msg *core.Message, data core.DataArray)
 	UpdateMessageIfCached(ctx context.Context, msg *core.Message)
-	UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state core.MessageState, confirmed *fftypes.FFTime)
+	UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state core.MessageState, confirmed *fftypes.FFTime, rejectReason string)
 	ResolveInlineData(ctx context.Context, msg *NewMessage) error
 	WriteNewMessage(ctx context.Context, newMsg *NewMessage) error
 	BlobsEnabled() bool
@@ -287,11 +287,12 @@ func (dm *dataManager) UpdateMessageIfCached(ctx context.Context, msg *core.Mess
 	}
 }
 
-func (dm *dataManager) UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state core.MessageState, confirmed *fftypes.FFTime) {
+func (dm *dataManager) UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state core.MessageState, confirmed *fftypes.FFTime, rejectReason string) {
 	mce := dm.queryMessageCache(ctx, id)
 	if mce != nil {
 		mce.msg.State = state
 		mce.msg.Confirmed = confirmed
+		mce.msg.RejectReason = rejectReason
 	}
 }
 

--- a/internal/data/data_manager_test.go
+++ b/internal/data/data_manager_test.go
@@ -1113,7 +1113,7 @@ func TestUpdateMessageCacheCRORequirePins(t *testing.T) {
 	}
 
 	now := fftypes.Now()
-	dm.UpdateMessageStateIfCached(ctx, msgWithPins.Header.ID, core.MessageStateConfirmed, now)
+	dm.UpdateMessageStateIfCached(ctx, msgWithPins.Header.ID, core.MessageStateConfirmed, now, "")
 	assert.Equal(t, core.MessageStateConfirmed, msgWithPins.State)
 	assert.Equal(t, now, msgWithPins.Confirmed)
 

--- a/internal/database/sqlcommon/message_sql.go
+++ b/internal/database/sqlcommon/message_sql.go
@@ -50,6 +50,7 @@ var (
 		"pins",
 		"state",
 		"confirmed",
+		"reject_reason",
 		"tx_type",
 		"tx_id",
 		"tx_parent_type",
@@ -66,6 +67,7 @@ var (
 		"batch":          "batch_id",
 		"group":          "group_hash",
 		"idempotencykey": "idempotency_key",
+		"rejectreason":   "reject_reason",
 	}
 )
 
@@ -95,6 +97,7 @@ func (s *SQLCommon) attemptMessageUpdate(ctx context.Context, tx *dbsql.TXWrappe
 			Set("pins", message.Pins).
 			Set("state", message.State).
 			Set("confirmed", message.Confirmed).
+			Set("reject_reason", message.RejectReason).
 			Set("tx_type", message.Header.TxType).
 			Set("tx_id", message.TransactionID).
 			Set("tx_parent_type", txParentType).
@@ -137,6 +140,7 @@ func (s *SQLCommon) setMessageInsertValues(query sq.InsertBuilder, message *core
 		message.Pins,
 		message.State,
 		message.Confirmed,
+		message.RejectReason,
 		message.Header.TxType,
 		message.TransactionID,
 		txParentType,
@@ -450,6 +454,7 @@ func (s *SQLCommon) msgResult(ctx context.Context, row *sql.Rows) (*core.Message
 		&msg.Pins,
 		&msg.State,
 		&msg.Confirmed,
+		&msg.RejectReason,
 		&msg.Header.TxType,
 		&msg.TransactionID,
 		&txParent.Type,

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -565,7 +565,7 @@ func TestGetMessageByIDLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "", nil, nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "", "pin", nil, "", nil, nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetMessageByID(context.Background(), "ns1", msgID)
 	assert.Regexp(t, "FF00176", err)
@@ -612,7 +612,7 @@ func TestGetMessagesLoadRefsFail(t *testing.T) {
 	cols := append([]string{}, msgColumns...)
 	cols = append(cols, "id()")
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows(cols).
-		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "pin", nil, "", nil, nil, "bob", 0))
+		AddRow(msgID.String(), nil, core.MessageTypeBroadcast, "author1", "0x12345", 0, "ns1", "ns1", "t1", "c1", nil, b32.String(), b32.String(), b32.String(), "confirmed", 0, "", "pin", nil, "", nil, nil, "bob", 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Gt("confirmed", "0")
 	_, _, err := s.GetMessages(context.Background(), "ns1", f)

--- a/internal/events/aggregator_batch_state_test.go
+++ b/internal/events/aggregator_batch_state_test.go
@@ -53,7 +53,7 @@ func TestFlushPinsFailUpdateMessages(t *testing.T) {
 
 	ag.mdi.On("UpdatePins", ag.ctx, "ns1", mock.Anything, mock.Anything).Return(nil)
 	ag.mdi.On("UpdateMessages", ag.ctx, "ns1", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
-	ag.mdm.On("UpdateMessageStateIfCached", ag.ctx, msgID, core.MessageStateConfirmed, mock.Anything).Return()
+	ag.mdm.On("UpdateMessageStateIfCached", ag.ctx, msgID, core.MessageStateConfirmed, mock.Anything, "").Return()
 
 	bs.markMessageDispatched(fftypes.NewUUID(), &core.Message{
 		Header: core.MessageHeader{

--- a/mocks/datamocks/manager.go
+++ b/mocks/datamocks/manager.go
@@ -278,9 +278,9 @@ func (_m *Manager) UpdateMessageIfCached(ctx context.Context, msg *core.Message)
 	_m.Called(ctx, msg)
 }
 
-// UpdateMessageStateIfCached provides a mock function with given fields: ctx, id, state, confirmed
-func (_m *Manager) UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state fftypes.FFEnum, confirmed *fftypes.FFTime) {
-	_m.Called(ctx, id, state, confirmed)
+// UpdateMessageStateIfCached provides a mock function with given fields: ctx, id, state, confirmed, rejectReason
+func (_m *Manager) UpdateMessageStateIfCached(ctx context.Context, id *fftypes.UUID, state fftypes.FFEnum, confirmed *fftypes.FFTime, rejectReason string) {
+	_m.Called(ctx, id, state, confirmed, rejectReason)
 }
 
 // UploadBlob provides a mock function with given fields: ctx, inData, blob, autoMeta

--- a/pkg/core/message.go
+++ b/pkg/core/message.go
@@ -98,6 +98,7 @@ type Message struct {
 	TransactionID  *fftypes.UUID         `ffstruct:"Message" json:"txid,omitempty" ffexcludeinput:"true"`
 	State          MessageState          `ffstruct:"Message" json:"state,omitempty" ffenum:"messagestate" ffexcludeinput:"true"`
 	Confirmed      *fftypes.FFTime       `ffstruct:"Message" json:"confirmed,omitempty" ffexcludeinput:"true"`
+	RejectReason   string                `ffstruct:"Message" json:"rejectReason,omitempty" ffexcludeinput:"true"`
 	Data           DataRefs              `ffstruct:"Message" json:"data" ffexcludeinput:"true"`
 	Pins           fftypes.FFStringArray `ffstruct:"Message" json:"pins,omitempty" ffexcludeinput:"true"`
 	IdempotencyKey IdempotencyKey        `ffstruct:"Message" json:"idempotencyKey,omitempty"`

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -741,6 +741,7 @@ var MessageQueryFactory = &ffapi.QueryFields{
 	"pins":           &ffapi.FFStringArrayField{},
 	"state":          &ffapi.StringField{},
 	"confirmed":      &ffapi.TimeField{},
+	"rejectreason":   &ffapi.StringField{},
 	"sequence":       &ffapi.Int64Field{},
 	"txtype":         &ffapi.StringField{},
 	"batch":          &ffapi.UUIDField{},


### PR DESCRIPTION
Proposal to add a "reject_reason" to messages (ie to database and API), which will be populated with the error text whenever a message is rejected. Previously this reason would only be logged, so the hope is that this assists in debugging when a message is rejected for an unexpected reason.