### PR TITLE
FabConnect does not / can not set transactionIndex and eventIndex

### DIFF
--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -2033,8 +2033,6 @@ func TestHandleMessageContractEventOldSubscription(t *testing.T) {
 		"chaincodeId": "basic",
 		"blockNumber": 10,
 		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
-		"transactionIndex": 20,
-		"eventIndex": 30,
 		"eventName": "AssetCreated",
 		"payload": "eyJBcHByYWlzZWRWYWx1ZSI6MTAsIkNvbG9yIjoicmVkIiwiSUQiOiIxMjM0IiwiT3duZXIiOiJtZSIsIlNpemUiOjN9",
 		"subId": "sb-cb37cc07-e873-4f58-44ab-55add6bba320"
@@ -2059,7 +2057,7 @@ func TestHandleMessageContractEventOldSubscription(t *testing.T) {
 	em.On("BlockchainEventBatch", mock.MatchedBy(func(batch []*blockchain.EventToDispatch) bool {
 		return len(batch) == 1 &&
 			batch[0].Type == blockchain.EventTypeForListener &&
-			batch[0].ForListener.ProtocolID == "000000000010/000020/000030" &&
+			batch[0].ForListener.ProtocolID == "000000000010/4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d" &&
 			batch[0].ForListener.BlockchainTXID == "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d"
 	})).Return(nil)
 
@@ -2083,13 +2081,11 @@ func TestHandleMessageContractEventOldSubscription(t *testing.T) {
 	assert.Equal(t, outputs, ev.Event.Output)
 
 	info := fftypes.JSONObject{
-		"blockNumber":      float64(10),
-		"chaincodeId":      "basic",
-		"eventName":        "AssetCreated",
-		"subId":            "sb-cb37cc07-e873-4f58-44ab-55add6bba320",
-		"transactionId":    "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
-		"transactionIndex": float64(20),
-		"eventIndex":       float64(30),
+		"blockNumber":   float64(10),
+		"chaincodeId":   "basic",
+		"eventName":     "AssetCreated",
+		"subId":         "sb-cb37cc07-e873-4f58-44ab-55add6bba320",
+		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
 	}
 	assert.Equal(t, info, ev.Event.Info)
 
@@ -2103,8 +2099,6 @@ func TestHandleMessageContractEventNamespacedHandlers(t *testing.T) {
 		"chaincodeId": "basic",
 	  "blockNumber": 10,
 		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
-		"transactionIndex": 20,
-		"eventIndex": 30,
 		"eventName": "AssetCreated",
 		"payload": "eyJBcHByYWlzZWRWYWx1ZSI6MTAsIkNvbG9yIjoicmVkIiwiSUQiOiIxMjM0IiwiT3duZXIiOiJtZSIsIlNpemUiOjN9",
 		"subId": "sb-cb37cc07-e873-4f58-44ab-55add6bba320"
@@ -2113,8 +2107,6 @@ func TestHandleMessageContractEventNamespacedHandlers(t *testing.T) {
 		"chaincodeId": "basic",
 	  "blockNumber": 10,
 		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746f",
-		"transactionIndex": 20,
-		"eventIndex": 30,
 		"eventName": "AssetCreated",
 		"payload": "eyJBcHByYWlzZWRWYWx1ZSI6MTAsIkNvbG9yIjoicmVkIiwiSUQiOiIxMjM0IiwiT3duZXIiOiJtZSIsIlNpemUiOjN9",
 		"subId": "sb-cb37cc07-e873-4f58-44ab-55add6bba320"
@@ -2139,7 +2131,7 @@ func TestHandleMessageContractEventNamespacedHandlers(t *testing.T) {
 	em.On("BlockchainEventBatch", mock.MatchedBy(func(batch []*blockchain.EventToDispatch) bool {
 		return len(batch) == 2 &&
 			batch[0].Type == blockchain.EventTypeForListener &&
-			batch[0].ForListener.ProtocolID == "000000000010/000020/000030" &&
+			batch[0].ForListener.ProtocolID == "000000000010/4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d" &&
 			batch[0].ForListener.BlockchainTXID == "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d"
 	})).Return(nil)
 
@@ -2163,13 +2155,11 @@ func TestHandleMessageContractEventNamespacedHandlers(t *testing.T) {
 	assert.Equal(t, outputs, ev.Event.Output)
 
 	info := fftypes.JSONObject{
-		"blockNumber":      float64(10),
-		"chaincodeId":      "basic",
-		"eventName":        "AssetCreated",
-		"subId":            "sb-cb37cc07-e873-4f58-44ab-55add6bba320",
-		"transactionId":    "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
-		"transactionIndex": float64(20),
-		"eventIndex":       float64(30),
+		"blockNumber":   float64(10),
+		"chaincodeId":   "basic",
+		"eventName":     "AssetCreated",
+		"subId":         "sb-cb37cc07-e873-4f58-44ab-55add6bba320",
+		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
 	}
 	assert.Equal(t, info, ev.Event.Info)
 
@@ -2183,8 +2173,6 @@ func TestHandleMessageContractEventNoNamespacedHandlers(t *testing.T) {
 		"chaincodeId": "basic",
 	  "blockNumber": 10,
 		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
-		"transactionIndex": 20,
-		"eventIndex": 30,
 		"eventName": "AssetCreated",
 		"payload": "eyJBcHByYWlzZWRWYWx1ZSI6MTAsIkNvbG9yIjoicmVkIiwiSUQiOiIxMjM0IiwiT3duZXIiOiJtZSIsIlNpemUiOjN9",
 		"subId": "sb-cb37cc07-e873-4f58-44ab-55add6bba320"
@@ -2208,7 +2196,7 @@ func TestHandleMessageContractEventNoNamespacedHandlers(t *testing.T) {
 
 	em.On("BlockchainEvent", mock.MatchedBy(func(e *blockchain.EventForListener) bool {
 		assert.Equal(t, "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d", e.BlockchainTXID)
-		assert.Equal(t, "000000000010/000020/000030", e.Event.ProtocolID)
+		assert.Equal(t, "000000000010/4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d", e.Event.ProtocolID)
 		return true
 	})).Return(nil)
 
@@ -2227,8 +2215,6 @@ func TestHandleMessageContractEventNoPayload(t *testing.T) {
 		"chaincodeId": "basic",
 	  "blockNumber": 10,
 		"transactionId": "4763a0c50e3bba7cef1a7ba35dd3f9f3426bb04d0156f326e84ec99387c4746d",
-		"transactionIndex": 20,
-		"eventIndex": 30,
 		"eventName": "AssetCreated",
 		"subId": "sb-cb37cc07-e873-4f58-44ab-55add6bba320"
 	}
@@ -2829,8 +2815,6 @@ func TestHandleNetworkAction(t *testing.T) {
 		"chaincodeId": "firefly",
 		"blockNumber": 91,
 		"transactionId": "ce79343000e851a0c742f63a733ce19a5f8b9ce1c719b6cecd14f01bcf81fff2",
-		"transactionIndex": 2,
-		"eventIndex": 50,
 		"eventName": "BatchPin",
 		"payload": "eyJzaWduZXIiOiJ1MHZnd3U5czAwLXg1MDk6OkNOPXVzZXIyLE9VPWNsaWVudDo6Q049ZmFicmljLWNhLXNlcnZlciIsInRpbWVzdGFtcCI6eyJzZWNvbmRzIjoxNjMwMDMxNjY3LCJuYW5vcyI6NzkxNDk5MDAwfSwibmFtZXNwYWNlIjoiZmlyZWZseTp0ZXJtaW5hdGUiLCJ1dWlkcyI6IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMCIsImJhdGNoSGFzaCI6IiIsInBheWxvYWRSZWYiOiIiLCJjb250ZXh0cyI6W119",
 		"subId": "sb-0910f6a8-7bd6-4ced-453e-2db68149ce8e"
@@ -2873,8 +2857,6 @@ func TestHandleNetworkActionFail(t *testing.T) {
 		"chaincodeId": "firefly",
 		"blockNumber": 91,
 		"transactionId": "ce79343000e851a0c742f63a733ce19a5f8b9ce1c719b6cecd14f01bcf81fff2",
-		"transactionIndex": 2,
-		"eventIndex": 50,
 		"eventName": "BatchPin",
 		"payload": "eyJzaWduZXIiOiJ1MHZnd3U5czAwLXg1MDk6OkNOPXVzZXIyLE9VPWNsaWVudDo6Q049ZmFicmljLWNhLXNlcnZlciIsInRpbWVzdGFtcCI6eyJzZWNvbmRzIjoxNjMwMDMxNjY3LCJuYW5vcyI6NzkxNDk5MDAwfSwibmFtZXNwYWNlIjoiZmlyZWZseTp0ZXJtaW5hdGUiLCJ1dWlkcyI6IjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMCIsImJhdGNoSGFzaCI6IiIsInBheWxvYWRSZWYiOiIiLCJjb250ZXh0cyI6W119",
 		"subId": "sb-0910f6a8-7bd6-4ced-453e-2db68149ce8e"


### PR DESCRIPTION
Fabric chaincode events when dispatched to FabConnect by the Fabric SDK do not contain the index within the block:
https://github.com/hyperledger/fabric-sdk-go/blob/7af45cede6afa3939a9574bc9948cca9fb424257/pkg/common/providers/fab/eventservice.go#L43C1-L59

So the only information upon which to build a unique `ProtocolID` for the event is the block number, and the transaction index (noting Hyperledger Fabric has a restriction of one transaction per block).

Under load when multiple events are packed into a single block in Fabric, the FireFly Core code was de-duplicating them as a single event, because they all had the same `ProtocolID`, such as `000000000295/000000/000000` (where the second and third parts are always zeros).