### PR TITLE
Fix uniqueness check in InsertOrGetFFI to match indexes

### DIFF
--- a/internal/database/sqlcommon/ffi_sql.go
+++ b/internal/database/sqlcommon/ffi_sql.go
@@ -133,8 +133,8 @@ func (s *SQLCommon) InsertOrGetFFI(ctx context.Context, ffi *fftypes.FFI) (exist
 		sq.Eq{"namespace": ffi.Namespace},
 		sq.Or{
 			sq.Eq{"id": ffi.ID},
-			sq.Eq{"name": ffi.Name},
-			sq.Eq{"network_name": ffi.NetworkName},
+			sq.Eq{"name": ffi.Name, "version": ffi.Version},
+			sq.Eq{"network_name": ffi.NetworkName, "version": ffi.Version},
 		},
 	})
 	if queryErr != nil || existing != nil {


### PR DESCRIPTION
When guessing the reason for an insert conflict, the query needs to exactly match the configured database indexes. That means that the "name" and "networkName" queries need to both include "version" as well, otherwise we risk grabbing a row that isn't actually a conflict.

Fixes #1347 