### PR TITLE
Docs improvements

### DIFF
--- a/docs/gettingstarted/sandbox.md
+++ b/docs/gettingstarted/sandbox.md
@@ -47,7 +47,7 @@ The FireFly explorer is a part of FireFly Core itself. It is a view into the sys
 When you set up your FireFly stack in the previous section, it should have printed some URLs like the following. Open the link in a browser for the `Sandbox UI for member '0'. It should be: [http://127.0.0.1:5109](http://127.0.0.1:5109)
 
 ```
-ff start demo
+ff start dev
 this will take a few seconds longer since this is the first time you're running this stack...
 done
 
@@ -63,7 +63,7 @@ Sandbox UI for member '2': http://127.0.0.1:5309
 
 To see logs for your stack run:
 
-ff logs demo
+ff logs dev
 ```
 
 

--- a/docs/gettingstarted/setup_env.md
+++ b/docs/gettingstarted/setup_env.md
@@ -124,6 +124,8 @@ This may take a minute or two and in the background the FireFly CLI will do the 
 - Deploy an `ERC-1155` token smart contract
 - Register an identity for each member and node
 
+> **NOTE**: For macOS users, the default port (5000) is already in-use by `ControlCe` service (AirPlay Receiver). You can either [disable this service](https://support.apple.com/guide/mac-help/change-airdrop-handoff-settings-mchl6a407f99/13.0/mac/13.0) in your environment, or use a different port when creating your stack (e.g. `ff init dev -p 8000`)
+
 After your stack finishes starting it will print out the links to each member's UI and the Sandbox for that node:
 
 ```


### PR DESCRIPTION
Adding two improvements in docs:

- adding a note for macOS users (port 5000 already in use)
- updating the command to be consistent with previous page (created `dev` stack but next page started `demo`)