### PR TITLE
Log full payload of critical EVMConnect actions at DEBUG level

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -42,6 +42,7 @@ import (
 	"github.com/hyperledger/firefly/internal/metrics"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/core"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -583,7 +584,15 @@ func (e *Ethereum) buildEthconnectRequestBody(ctx context.Context, messageType, 
 	if len(errors) > 0 {
 		body["errors"] = errors
 	}
-	return e.applyOptions(ctx, body, options)
+	finalBody, err := e.applyOptions(ctx, body, options)
+	if err != nil {
+		return nil, err
+	}
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		jsonBody, _ := json.Marshal(finalBody)
+		log.L(ctx).Debugf("EVMConnectorBody: %s", string(jsonBody))
+	}
+	return finalBody, nil
 }
 
 func (e *Ethereum) applyOptions(ctx context.Context, body, options map[string]interface{}) (map[string]interface{}, error) {

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/jarcoal/httpmock"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -2627,6 +2628,7 @@ func TestDeployContractError(t *testing.T) {
 }
 
 func TestInvokeContractOK(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
 	e, cancel := newTestEthereum()
 	defer cancel()
 	httpmock.ActivateNonDefault(e.client.GetClient())


### PR DESCRIPTION
The payloads that flow between `firefly-core` and `firefly-evmconnect` are a very important contract in FireFly, and there's complex translation that happens (FFI <-> ABI etc. and other things in the operation like the `from` address and `location`).
For debugging it's very important to be able to see the exact payload, and important enough you shouldn't need to enable `trace` level and take the cost of logging _every_ payload exchange between microservices to see it.