### PR TITLE
Add httpOptions.proxyURL option to Subscription

### DIFF
--- a/docs/reference/types/subscription.md
+++ b/docs/reference/types/subscription.md
@@ -146,6 +146,7 @@ nav_order: 3
 
 | Field Name | Description | Type |
 |------------|-------------|------|
+| `proxyURL` | The max duration to hold a TLS handshake alive | `string` |
 | `tlsHandshakeTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `requestTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `maxIdleConns` | The max number of idle connections to hold pooled | `int` |

--- a/docs/reference/types/subscription.md
+++ b/docs/reference/types/subscription.md
@@ -146,7 +146,7 @@ nav_order: 3
 
 | Field Name | Description | Type |
 |------------|-------------|------|
-| `proxyURL` | The max duration to hold a TLS handshake alive | `string` |
+| `proxyURL` | HTTP proxy URL to use for outbound requests to the webhook | `string` |
 | `tlsHandshakeTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `requestTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `maxIdleConns` | The max number of idle connections to hold pooled | `int` |

--- a/docs/reference/types/wsstart.md
+++ b/docs/reference/types/wsstart.md
@@ -137,6 +137,7 @@ nav_order: 23
 
 | Field Name | Description | Type |
 |------------|-------------|------|
+| `proxyURL` | The max duration to hold a TLS handshake alive | `string` |
 | `tlsHandshakeTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `requestTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `maxIdleConns` | The max number of idle connections to hold pooled | `int` |

--- a/docs/reference/types/wsstart.md
+++ b/docs/reference/types/wsstart.md
@@ -137,7 +137,7 @@ nav_order: 23
 
 | Field Name | Description | Type |
 |------------|-------------|------|
-| `proxyURL` | The max duration to hold a TLS handshake alive | `string` |
+| `proxyURL` | HTTP proxy URL to use for outbound requests to the webhook | `string` |
 | `tlsHandshakeTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `requestTimeout` | The max duration to hold a TLS handshake alive | `string` |
 | `maxIdleConns` | The max number of idle connections to hold pooled | `int` |

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -27749,6 +27749,10 @@ paths:
                               description: The max number of idle connections to hold
                                 pooled
                               type: integer
+                            proxyURL:
+                              description: The max duration to hold a TLS handshake
+                                alive
+                              type: string
                             requestTimeout:
                               description: The max duration to hold a TLS handshake
                                 alive
@@ -28033,6 +28037,9 @@ paths:
                           description: The max number of idle connections to hold
                             pooled
                           type: integer
+                        proxyURL:
+                          description: The max duration to hold a TLS handshake alive
+                          type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
                           type: string
@@ -28299,6 +28306,10 @@ paths:
                             description: The max number of idle connections to hold
                               pooled
                             type: integer
+                          proxyURL:
+                            description: The max duration to hold a TLS handshake
+                              alive
+                            type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
                               alive
@@ -28580,6 +28591,9 @@ paths:
                           description: The max number of idle connections to hold
                             pooled
                           type: integer
+                        proxyURL:
+                          description: The max duration to hold a TLS handshake alive
+                          type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
                           type: string
@@ -28846,6 +28860,10 @@ paths:
                             description: The max number of idle connections to hold
                               pooled
                             type: integer
+                          proxyURL:
+                            description: The max duration to hold a TLS handshake
+                              alive
+                            type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
                               alive
@@ -29189,6 +29207,10 @@ paths:
                             description: The max number of idle connections to hold
                               pooled
                             type: integer
+                          proxyURL:
+                            description: The max duration to hold a TLS handshake
+                              alive
+                            type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
                               alive
@@ -36670,6 +36692,10 @@ paths:
                               description: The max number of idle connections to hold
                                 pooled
                               type: integer
+                            proxyURL:
+                              description: The max duration to hold a TLS handshake
+                                alive
+                              type: string
                             requestTimeout:
                               description: The max duration to hold a TLS handshake
                                 alive
@@ -36947,6 +36973,9 @@ paths:
                           description: The max number of idle connections to hold
                             pooled
                           type: integer
+                        proxyURL:
+                          description: The max duration to hold a TLS handshake alive
+                          type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
                           type: string
@@ -37213,6 +37242,10 @@ paths:
                             description: The max number of idle connections to hold
                               pooled
                             type: integer
+                          proxyURL:
+                            description: The max duration to hold a TLS handshake
+                              alive
+                            type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
                               alive
@@ -37487,6 +37520,9 @@ paths:
                           description: The max number of idle connections to hold
                             pooled
                           type: integer
+                        proxyURL:
+                          description: The max duration to hold a TLS handshake alive
+                          type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
                           type: string
@@ -37753,6 +37789,10 @@ paths:
                             description: The max number of idle connections to hold
                               pooled
                             type: integer
+                          proxyURL:
+                            description: The max duration to hold a TLS handshake
+                              alive
+                            type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
                               alive
@@ -38082,6 +38122,10 @@ paths:
                             description: The max number of idle connections to hold
                               pooled
                             type: integer
+                          proxyURL:
+                            description: The max duration to hold a TLS handshake
+                              alive
+                            type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
                               alive

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -27750,8 +27750,8 @@ paths:
                                 pooled
                               type: integer
                             proxyURL:
-                              description: The max duration to hold a TLS handshake
-                                alive
+                              description: HTTP proxy URL to use for outbound requests
+                                to the webhook
                               type: string
                             requestTimeout:
                               description: The max duration to hold a TLS handshake
@@ -28038,7 +28038,8 @@ paths:
                             pooled
                           type: integer
                         proxyURL:
-                          description: The max duration to hold a TLS handshake alive
+                          description: HTTP proxy URL to use for outbound requests
+                            to the webhook
                           type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
@@ -28307,8 +28308,8 @@ paths:
                               pooled
                             type: integer
                           proxyURL:
-                            description: The max duration to hold a TLS handshake
-                              alive
+                            description: HTTP proxy URL to use for outbound requests
+                              to the webhook
                             type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
@@ -28592,7 +28593,8 @@ paths:
                             pooled
                           type: integer
                         proxyURL:
-                          description: The max duration to hold a TLS handshake alive
+                          description: HTTP proxy URL to use for outbound requests
+                            to the webhook
                           type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
@@ -28861,8 +28863,8 @@ paths:
                               pooled
                             type: integer
                           proxyURL:
-                            description: The max duration to hold a TLS handshake
-                              alive
+                            description: HTTP proxy URL to use for outbound requests
+                              to the webhook
                             type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
@@ -29208,8 +29210,8 @@ paths:
                               pooled
                             type: integer
                           proxyURL:
-                            description: The max duration to hold a TLS handshake
-                              alive
+                            description: HTTP proxy URL to use for outbound requests
+                              to the webhook
                             type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
@@ -36693,8 +36695,8 @@ paths:
                                 pooled
                               type: integer
                             proxyURL:
-                              description: The max duration to hold a TLS handshake
-                                alive
+                              description: HTTP proxy URL to use for outbound requests
+                                to the webhook
                               type: string
                             requestTimeout:
                               description: The max duration to hold a TLS handshake
@@ -36974,7 +36976,8 @@ paths:
                             pooled
                           type: integer
                         proxyURL:
-                          description: The max duration to hold a TLS handshake alive
+                          description: HTTP proxy URL to use for outbound requests
+                            to the webhook
                           type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
@@ -37243,8 +37246,8 @@ paths:
                               pooled
                             type: integer
                           proxyURL:
-                            description: The max duration to hold a TLS handshake
-                              alive
+                            description: HTTP proxy URL to use for outbound requests
+                              to the webhook
                             type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
@@ -37521,7 +37524,8 @@ paths:
                             pooled
                           type: integer
                         proxyURL:
-                          description: The max duration to hold a TLS handshake alive
+                          description: HTTP proxy URL to use for outbound requests
+                            to the webhook
                           type: string
                         requestTimeout:
                           description: The max duration to hold a TLS handshake alive
@@ -37790,8 +37794,8 @@ paths:
                               pooled
                             type: integer
                           proxyURL:
-                            description: The max duration to hold a TLS handshake
-                              alive
+                            description: HTTP proxy URL to use for outbound requests
+                              to the webhook
                             type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake
@@ -38123,8 +38127,8 @@ paths:
                               pooled
                             type: integer
                           proxyURL:
-                            description: The max duration to hold a TLS handshake
-                              alive
+                            description: HTTP proxy URL to use for outbound requests
+                              to the webhook
                             type: string
                           requestTimeout:
                             description: The max duration to hold a TLS handshake

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -711,6 +711,7 @@ var (
 	WebhookOptHTTPConnectionTimeout     = ffm("WebhookHTTPOptions.connectionTimeout", "The maximum amount of time that a connection is allowed to remain with no data transmitted.")
 	WebhookOptHTTPTLSHandshakeTimeout   = ffm("WebhookHTTPOptions.tlsHandshakeTimeout", "The max duration to hold a TLS handshake alive")
 	WebhookOptHTTPRequestTimeout        = ffm("WebhookHTTPOptions.requestTimeout", "The max duration to hold a TLS handshake alive")
+	WebhookOptHTTPProxyURL              = ffm("WebhookHTTPOptions.proxyURL", "The max duration to hold a TLS handshake alive")
 
 	// PublishInput field descriptions
 	PublishInputIdempotencyKey = ffm("PublishInput.idempotencyKey", "An optional identifier to allow idempotent submission of requests. Stored on the transaction uniquely within a namespace")

--- a/internal/coremsgs/en_struct_descriptions.go
+++ b/internal/coremsgs/en_struct_descriptions.go
@@ -711,7 +711,7 @@ var (
 	WebhookOptHTTPConnectionTimeout     = ffm("WebhookHTTPOptions.connectionTimeout", "The maximum amount of time that a connection is allowed to remain with no data transmitted.")
 	WebhookOptHTTPTLSHandshakeTimeout   = ffm("WebhookHTTPOptions.tlsHandshakeTimeout", "The max duration to hold a TLS handshake alive")
 	WebhookOptHTTPRequestTimeout        = ffm("WebhookHTTPOptions.requestTimeout", "The max duration to hold a TLS handshake alive")
-	WebhookOptHTTPProxyURL              = ffm("WebhookHTTPOptions.proxyURL", "The max duration to hold a TLS handshake alive")
+	WebhookOptHTTPProxyURL              = ffm("WebhookHTTPOptions.proxyURL", "HTTP proxy URL to use for outbound requests to the webhook")
 
 	// PublishInput field descriptions
 	PublishInputIdempotencyKey = ffm("PublishInput.idempotencyKey", "An optional identifier to allow idempotent submission of requests. Stored on the transaction uniquely within a namespace")

--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -341,11 +341,13 @@ func (wh *WebHooks) ValidateOptions(ctx context.Context, options *core.Subscript
 		newFFRestyConfig.HTTPTLSHandshakeTimeout = time.Duration(ffd)
 	}
 
+	if options.HTTPOptions.HTTPProxyURL != nil {
+		newFFRestyConfig.ProxyURL = *options.HTTPOptions.HTTPProxyURL
+	}
+
 	if options.TLSConfig != nil {
 		newFFRestyConfig.TLSClientConfig = options.TLSConfig
 	}
-
-	newFFRestyConfig.ProxyURL = options.HTTPOptions.HTTPProxyURL
 
 	// NOTE: this is the plugin context, as the context passed through can be terminated as part of a
 	// API call or anything else and we want to use this client later on!!

--- a/internal/events/webhooks/webhooks.go
+++ b/internal/events/webhooks/webhooks.go
@@ -345,6 +345,8 @@ func (wh *WebHooks) ValidateOptions(ctx context.Context, options *core.Subscript
 		newFFRestyConfig.TLSClientConfig = options.TLSConfig
 	}
 
+	newFFRestyConfig.ProxyURL = options.HTTPOptions.HTTPProxyURL
+
 	// NOTE: this is the plugin context, as the context passed through can be terminated as part of a
 	// API call or anything else and we want to use this client later on!!
 	// So these clients should live as long as the plugin exists

--- a/internal/events/webhooks/webhooks_test.go
+++ b/internal/events/webhooks/webhooks_test.go
@@ -255,6 +255,7 @@ func TestValidateOptionsExtraFields(t *testing.T) {
 		MaximumDelay: "2s",
 	}
 
+	proxyURL := "http://myproxy.example.com:8888"
 	opts.HTTPOptions = core.WebhookHTTPOptions{
 		HTTPMaxIdleConns:          2,
 		HTTPTLSHandshakeTimeout:   "2s",
@@ -262,6 +263,7 @@ func TestValidateOptionsExtraFields(t *testing.T) {
 		HTTPIdleConnTimeout:       "2s",
 		HTTPConnectionTimeout:     "2s",
 		HTTPExpectContinueTimeout: "2s",
+		HTTPProxyURL:              &proxyURL,
 	}
 
 	opts.TLSConfig = &tls.Config{}
@@ -283,6 +285,11 @@ func TestValidateOptionsExtraFields(t *testing.T) {
 	assert.Equal(t, transport.TLSHandshakeTimeout, expectedDuration)
 	assert.Equal(t, transport.MaxIdleConns, 2)
 	assert.NotNil(t, transport.TLSClientConfig)
+
+	req := httptest.NewRequest(http.MethodGet, "http://testany.example.com", nil)
+	u, err := transport.Proxy(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://myproxy.example.com:8888", u.String())
 }
 
 func TestRequestWithBodyReplyEndToEnd(t *testing.T) {

--- a/pkg/core/webhooks.go
+++ b/pkg/core/webhooks.go
@@ -48,13 +48,13 @@ type WebhookRetryOptions struct {
 }
 
 type WebhookHTTPOptions struct {
-	HTTPProxyURL              string `ffstruct:"WebhookHTTPOptions" json:"proxyURL,omitempty"`
-	HTTPTLSHandshakeTimeout   string `ffstruct:"WebhookHTTPOptions" json:"tlsHandshakeTimeout,omitempty"`
-	HTTPRequestTimeout        string `ffstruct:"WebhookHTTPOptions" json:"requestTimeout,omitempty"`
-	HTTPMaxIdleConns          int    `ffstruct:"WebhookHTTPOptions" json:"maxIdleConns,omitempty"`
-	HTTPIdleConnTimeout       string `ffstruct:"WebhookHTTPOptions" json:"idleTimeout,omitempty"`
-	HTTPConnectionTimeout     string `ffstruct:"WebhookHTTPOptions" json:"connectionTimeout,omitempty"`
-	HTTPExpectContinueTimeout string `ffstruct:"WebhookHTTPOptions" json:"expectContinueTimeout,omitempty"`
+	HTTPProxyURL              *string `ffstruct:"WebhookHTTPOptions" json:"proxyURL,omitempty"`
+	HTTPTLSHandshakeTimeout   string  `ffstruct:"WebhookHTTPOptions" json:"tlsHandshakeTimeout,omitempty"`
+	HTTPRequestTimeout        string  `ffstruct:"WebhookHTTPOptions" json:"requestTimeout,omitempty"`
+	HTTPMaxIdleConns          int     `ffstruct:"WebhookHTTPOptions" json:"maxIdleConns,omitempty"`
+	HTTPIdleConnTimeout       string  `ffstruct:"WebhookHTTPOptions" json:"idleTimeout,omitempty"`
+	HTTPConnectionTimeout     string  `ffstruct:"WebhookHTTPOptions" json:"connectionTimeout,omitempty"`
+	HTTPExpectContinueTimeout string  `ffstruct:"WebhookHTTPOptions" json:"expectContinueTimeout,omitempty"`
 }
 
 type WebhookInputOptions struct {

--- a/pkg/core/webhooks.go
+++ b/pkg/core/webhooks.go
@@ -48,6 +48,7 @@ type WebhookRetryOptions struct {
 }
 
 type WebhookHTTPOptions struct {
+	HTTPProxyURL              string `ffstruct:"WebhookHTTPOptions" json:"proxyURL,omitempty"`
 	HTTPTLSHandshakeTimeout   string `ffstruct:"WebhookHTTPOptions" json:"tlsHandshakeTimeout,omitempty"`
 	HTTPRequestTimeout        string `ffstruct:"WebhookHTTPOptions" json:"requestTimeout,omitempty"`
 	HTTPMaxIdleConns          int    `ffstruct:"WebhookHTTPOptions" json:"maxIdleConns,omitempty"`


### PR DESCRIPTION
So that you can configure the HTTP Proxy on a per-subscription setting, like you can with the mTLS certificates, or the other HTTP options