### PR TITLE
Correctly parse blockchain subscription name when delivering events

### DIFF
--- a/internal/blockchain/common/common.go
+++ b/internal/blockchain/common/common.go
@@ -334,7 +334,7 @@ func buildBatchPin(ctx context.Context, event *blockchain.Event, params *BatchPi
 func GetNamespaceFromSubName(subName string) string {
 	var parts = strings.Split(subName, "-")
 	// Subscription names post version 1.1 are in the format `ff-sub-<namespace>-<listener ID>`
-	if len(parts) != 4 {
+	if len(parts) < 4 {
 		// Assume older subscription and return empty string
 		return ""
 	}

--- a/internal/blockchain/common/common_test.go
+++ b/internal/blockchain/common/common_test.go
@@ -293,7 +293,7 @@ func TestBuildBatchPinErrors(t *testing.T) {
 }
 
 func TestGetNamespaceFromSubName(t *testing.T) {
-	ns := GetNamespaceFromSubName("ff-sub-ns1-123")
+	ns := GetNamespaceFromSubName("ff-sub-ns1-03071072-079b-4047-b192-a07186fc9db8")
 	assert.Equal(t, "ns1", ns)
 
 	ns = GetNamespaceFromSubName("BAD")


### PR DESCRIPTION
This ensures the namespace can be accurately extracted.

Fixes #1374