### PR TITLE
Correctly parse blockchain subscription name when delivering events

### DIFF
--- a/internal/blockchain/common/common.go
+++ b/internal/blockchain/common/common.go
@@ -332,13 +332,24 @@ func buildBatchPin(ctx context.Context, event *blockchain.Event, params *BatchPi
 }
 
 func GetNamespaceFromSubName(subName string) string {
-	var parts = strings.Split(subName, "-")
 	// Subscription names post version 1.1 are in the format `ff-sub-<namespace>-<listener ID>`
-	if len(parts) != 4 {
-		// Assume older subscription and return empty string
-		return ""
+	// Priot to that they had the format `ff-sub-<listener ID>`
+
+	// Strip the "ff-sub-" prefix from the beginning of the name
+	withoutPrefix := strings.TrimPrefix(subName, "ff-sub-")
+	if len(withoutPrefix) < len(subName) {
+		// Strip the listener ID from the end of the name
+		const UUIDLength = 36
+		if len(withoutPrefix) > UUIDLength {
+			uuidSplit := len(withoutPrefix) - UUIDLength - 1
+			namespace := withoutPrefix[:uuidSplit]
+			listenerID := withoutPrefix[uuidSplit:]
+			if strings.HasPrefix(listenerID, "-") {
+				return namespace
+			}
+		}
 	}
-	return parts[2]
+	return ""
 }
 
 func (s *subscriptions) AddSubscription(ctx context.Context, namespace *core.Namespace, version int, subID string, extra interface{}) {

--- a/internal/blockchain/common/common_test.go
+++ b/internal/blockchain/common/common_test.go
@@ -293,8 +293,14 @@ func TestBuildBatchPinErrors(t *testing.T) {
 }
 
 func TestGetNamespaceFromSubName(t *testing.T) {
-	ns := GetNamespaceFromSubName("ff-sub-ns1-123")
+	ns := GetNamespaceFromSubName("ff-sub-ns1-03071072-079b-4047-b192-a07186fc9db8")
 	assert.Equal(t, "ns1", ns)
+
+	ns = GetNamespaceFromSubName("ff-sub-03071072-079b-4047-b192-a07186fc9db8")
+	assert.Equal(t, "", ns)
+
+	ns = GetNamespaceFromSubName("ff-sub-ns1-123")
+	assert.Equal(t, "", ns)
 
 	ns = GetNamespaceFromSubName("BAD")
 	assert.Equal(t, "", ns)

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -2387,7 +2387,7 @@ func TestHandleMessageContractEventNoNamespaceHandlers(t *testing.T) {
 
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions/sub2",
 		httpmock.NewJsonResponderOrPanic(200, subscription{
-			ID: "sub2", Stream: "es12345", Name: "ff-sub-ns1-1132312312312",
+			ID: "sub2", Stream: "es12345", Name: "ff-sub-ns1-58113723-0cc3-411f-aa1b-948eca83b9cd",
 		}))
 
 	e.SetHandler("ns2", em)

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -2187,7 +2187,7 @@ func TestHandleMessageContractEventNoNamespacedHandlers(t *testing.T) {
 
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions/sb-cb37cc07-e873-4f58-44ab-55add6bba320",
 		httpmock.NewJsonResponderOrPanic(200, subscription{
-			ID: "sb-cb37cc07-e873-4f58-44ab-55add6bba320", Stream: "es12345", Name: "ff-sub-ns1-11232312312",
+			ID: "sb-cb37cc07-e873-4f58-44ab-55add6bba320", Stream: "es12345", Name: "ff-sub-ns1-58113723-0cc3-411f-aa1b-948eca83b9cd",
 		}))
 
 	e.streams = newTestStreamManager(e.client, e.signer)


### PR DESCRIPTION
This ensures the namespace can be accurately extracted.

Fixes https://github.com/hyperledger/firefly/issues/1374