### PR TITLE
Two functions with the same param types, but different names, cannot share a cache entry

### DIFF
--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -650,6 +650,8 @@ func (cm *contractManager) validateFFIMethod(ctx context.Context, method *fftype
 			return nil, nil, err
 		}
 		paramSchemas[param.Name] = schema
+		// The input parsing is dependent on the parameter name, so it's important those are included in the hash
+		paramUniqueHash.Write([]byte(param.Name))
 		paramUniqueHash.Write([]byte(paramSchemaHash))
 	}
 	for _, param := range method.Returns {
@@ -657,6 +659,7 @@ func (cm *contractManager) validateFFIMethod(ctx context.Context, method *fftype
 		if err != nil {
 			return nil, nil, err
 		}
+		paramUniqueHash.Write([]byte(param.Name))
 		paramUniqueHash.Write([]byte(returnHash))
 	}
 	return paramUniqueHash, paramSchemas, nil

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -708,6 +708,7 @@ func (cm *contractManager) validateFFIError(ctx context.Context, errorDef *fftyp
 		if err != nil {
 			return "", err
 		}
+		cacheKeyBuff.WriteString(param.Name)
 		cacheKeyBuff.WriteString(paramCacheKey)
 	}
 	return cacheKeyBuff.String(), nil


### PR DESCRIPTION
### Issue

If you invoke a Method FFI to FireFly with one set of parameter names like:

- `myfunc(uint256 var1, address var2)`

Then you invoke another function with an identical ABI, but different parameter names like:

- `myfunc(uint256 _var1, address _var2)`

Then you will see the following error from EVMConnect, with valid inputs:

`FF10111: Error from ethereum connector: FF22034: Unable to parse input of type <nil>`

This is because the cache we use to avoid expensive JSON Schema compilation, uses a cache key that does not factor in the names of the parameters.

However, when we look at the input JSON Object to extract the parameters in order to pass them into EVMConnect, we need to know the exact parameter names.

### Fix

This PR proposes including all parameter names from the FFI in the calculation of the cache key.