### PR TITLE
check enabled for organization creation in non-multiparty system

### DIFF
--- a/internal/apiserver/route_post_new_organization.go
+++ b/internal/apiserver/route_post_new_organization.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/apiserver/route_post_new_organization.go
+++ b/internal/apiserver/route_post_new_organization.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly/internal/coremsgs"
+	"github.com/hyperledger/firefly/internal/orchestrator"
 	"github.com/hyperledger/firefly/pkg/core"
 )
 
@@ -38,6 +39,9 @@ var postNewOrganization = &ffapi.Route{
 	JSONOutputValue: func() interface{} { return &core.Identity{} },
 	JSONOutputCodes: []int{http.StatusAccepted, http.StatusOK},
 	Extensions: &coreExtensions{
+		EnabledIf: func(or orchestrator.Orchestrator) bool {
+			return or.MultiParty() != nil
+		},
 		CoreJSONHandler: func(r *ffapi.APIRequest, cr *coreRequest) (output interface{}, err error) {
 			waitConfirm := strings.EqualFold(r.QP["confirm"], "true")
 			r.SuccessStatus = syncRetcode(waitConfirm)

--- a/internal/apiserver/route_post_new_organization_test.go
+++ b/internal/apiserver/route_post_new_organization_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hyperledger/firefly/mocks/multipartymocks"
 	"github.com/hyperledger/firefly/mocks/networkmapmocks"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,7 @@ func TestNewOrganization(t *testing.T) {
 	o.On("Authorize", mock.Anything, mock.Anything).Return(nil)
 	mnm := &networkmapmocks.Manager{}
 	o.On("NetworkMap").Return(mnm)
+	o.On("MultiParty").Return(&multipartymocks.Manager{})
 	input := core.Identity{}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(&input)

--- a/internal/apiserver/route_post_new_organization_test.go
+++ b/internal/apiserver/route_post_new_organization_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
Fix for #1404 

Added checks on `/firefly/internal/apiserver/route_post_new_organization.go`
Updated the test file `/firefly/internal/apiserver/route_post_new_organization_test.go`

Test result: 
```
Running tool: /usr/local/go/bin/go test -timeout 10s -run ^TestNewOrganization$ github.com/hyperledger/firefly/internal/apiserver

=== RUN   TestNewOrganization
time="2023-09-21T22:20:26+05:30" level=info msg="--> POST /api/v1/network/organizations" httpreq=ZlrSSWSy
time="2023-09-21T22:20:26+05:30" level=info msg="<-- POST /api/v1/network/organizations [202] (1.67ms)" httpreq=ZlrSSWSy
--- PASS: TestNewOrganization (0.25s)
PASS
ok      github.com/hyperledger/firefly/internal/apiserver       0.493s
```