### PR TITLE
feature: changes to support upgrade to Fabric v2.5 TLS in Firefly CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN curl -fsSL "https://golang.org/dl/go$GO_VERSION.linux-$ARCH.tar.gz" | tar -C
 ENV PATH="/usr/local/go/bin:$PATH"
 WORKDIR /firefly/smart_contracts/fabric/firefly-go
 ADD smart_contracts/fabric/firefly-go .
-ENV GO111MODULE=on
 RUN GO111MODULE=on go mod vendor
 WORKDIR /tmp/fabric
 RUN wget https://github.com/hyperledger/fabric/releases/download/v2.5.4/hyperledger-fabric-linux-amd64-2.5.4.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,25 @@ ADD . .
 RUN make build
 
 FROM --platform=$FABRIC_BUILDER_PLATFORM $FABRIC_BUILDER_TAG AS fabric-builder
-RUN apk add libc6-compat
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    wget \
+    sudo \
+    curl \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+# Install Go
+ARG GO_VERSION=1.20
+ARG ARCH=amd64
+RUN curl -fsSL "https://golang.org/dl/go$GO_VERSION.linux-$ARCH.tar.gz" | tar -C /usr/local -xzf -
+ENV PATH="/usr/local/go/bin:$PATH"
 WORKDIR /firefly/smart_contracts/fabric/firefly-go
 ADD smart_contracts/fabric/firefly-go .
+ENV GO111MODULE=on
 RUN GO111MODULE=on go mod vendor
 WORKDIR /tmp/fabric
-RUN wget https://github.com/hyperledger/fabric/releases/download/v2.3.2/hyperledger-fabric-linux-amd64-2.3.2.tar.gz
-RUN tar -zxf hyperledger-fabric-linux-amd64-2.3.2.tar.gz
+RUN wget https://github.com/hyperledger/fabric/releases/download/v2.5.4/hyperledger-fabric-linux-amd64-2.5.4.tar.gz
+RUN tar -zxf hyperledger-fabric-linux-amd64-2.5.4.tar.gz
 RUN touch core.yaml
 RUN ./bin/peer lifecycle chaincode package /firefly/smart_contracts/fabric/firefly-go/firefly_fabric.tar.gz --path /firefly/smart_contracts/fabric/firefly-go --lang golang --label firefly_1.0
 

--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,7 @@
       "image": "golang:1.19-alpine3.16"
     },
     "fabric-builder": {
-      "image": "golang:1.19-alpine3.16",
+      "image": "ubuntu:22.04",
       "platform": "linux/x86_64"
     },
     "solidity-builder": {


### PR DESCRIPTION
 Updated GO to version 1.20 (Fabric 2.5 compatibility) and Ubuntu as the base instead of Alpine.
 
 Fixes this Issue: #1414 
 
 Related to the Firefly CLI change here: #https://github.com/hyperledger/firefly-cli/issues/268
 
 E2E test passed:
 
 --- PASS: TestFabricMultipartyE2ESuite (137.02s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EBroadcast (3.97s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EBroadcastBlob (34.51s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EPrivate (3.74s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EPrivateBlobDatatypeTagged (3.71s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EWebhookExchange (7.61s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EWebhookRequestReplyNoTx (4.78s)
    --- PASS: TestFabricMultipartyE2ESuite/TestStrongDatatypesBroadcast (7.58s)
    --- PASS: TestFabricMultipartyE2ESuite/TestStrongDatatypesPrivate (7.29s)
    --- PASS: TestFabricMultipartyE2ESuite/TestCustomChildIdentityBroadcasts (7.88s)
    --- PASS: TestFabricMultipartyE2ESuite/TestCustomChildIdentityPrivate (11.26s)
    --- PASS: TestFabricMultipartyE2ESuite/TestInvalidIdentityAlreadyRegistered (9.39s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EContractEvents (2.69s)
PASS
ok  	github.com/hyperledger/firefly/test/e2e/runners	137.028s