### PR TITLE
Update log level in config auto reload

### DIFF
--- a/internal/namespace/configreload.go
+++ b/internal/namespace/configreload.go
@@ -61,6 +61,8 @@ func (nm *namespaceManager) configFileChanged() {
 }
 
 func (nm *namespaceManager) configReloaded(ctx context.Context) {
+	// Always make sure log level is up to date
+	log.SetLevel(config.GetString(config.LogLevel))
 
 	// Get Viper to dump the whole new config, with everything resolved across env vars
 	// and the config file etc.


### PR DESCRIPTION
Partially resolves https://github.com/hyperledger/firefly/issues/1421

This solves the log level getting set, which is arguably the most important for operating a production system where you may need to temporarily change the log level while the system is running to test something.