### PR TITLE
Add name/version if not specified

### DIFF
--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -995,6 +995,12 @@ func (cm *contractManager) checkParamSchema(ctx context.Context, name string, in
 
 func (cm *contractManager) GenerateFFI(ctx context.Context, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
 	generationRequest.Namespace = cm.namespace
+	if generationRequest.Name == "" {
+		generationRequest.Name = "generated"
+	}
+	if generationRequest.Version == "" {
+		generationRequest.Version = "0.0.1"
+	}
 	ffi, err := cm.blockchain.GenerateFFI(ctx, generationRequest)
 	if err == nil {
 		err = cm.ResolveFFI(ctx, ffi)

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -3553,22 +3553,28 @@ func TestAddJSONSchemaExtension(t *testing.T) {
 func TestGenerateFFI(t *testing.T) {
 	cm := newTestContractManager()
 	mbi := cm.blockchain.(*blockchainmocks.Plugin)
-	mbi.On("GenerateFFI", mock.Anything, mock.Anything).Return(&fftypes.FFI{
-		Name:    "generated",
-		Version: "1.0",
-		Methods: []*fftypes.FFIMethod{
-			{
-				Name: "method1",
+	gfi := mbi.On("GenerateFFI", mock.Anything, mock.Anything)
+	gfi.Run(func(args mock.Arguments) {
+		gf := args[1].(*fftypes.FFIGenerationRequest)
+		gfi.Return(&fftypes.FFI{
+			Name:    gf.Name,
+			Version: gf.Version,
+			Methods: []*fftypes.FFIMethod{
+				{
+					Name: "method1",
+				},
+				{
+					Name: "method1",
+				},
 			},
-			{
-				Name: "method1",
-			},
-		},
-	}, nil)
+		}, nil)
+	})
+
 	ffi, err := cm.GenerateFFI(context.Background(), &fftypes.FFIGenerationRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, ffi)
 	assert.Equal(t, "generated", ffi.Name)
+	assert.Equal(t, "0.0.1", ffi.Version)
 	assert.Equal(t, "method1", ffi.Methods[0].Name)
 	assert.Equal(t, "method1", ffi.Methods[0].Pathname)
 	assert.Equal(t, "method1", ffi.Methods[1].Name)


### PR DESCRIPTION
In recent changes, the `name`/`version` of the FFI have become required, and this means that the API for `/generate` has changed behavior so it fails if these are not supplied