### PR TITLE
Correct uniqueness lookup for nil location

### DIFF
--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -864,7 +864,7 @@ func (cm *contractManager) AddContractListener(ctx context.Context, listener *co
 		// of nil does not yield the right result, so we need to do an explicit nil query.
 		var locationLookup driver.Value = nil
 		if !listener.Location.IsNil() {
-			locationLookup = listener.Location
+			locationLookup = listener.Location.String()
 		}
 		fb := database.ContractListenerQueryFactory.NewFilter(ctx)
 		if existing, _, err := cm.database.GetContractListeners(ctx, cm.namespace, fb.And(

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -19,6 +19,7 @@ package contracts
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -857,14 +858,18 @@ func (cm *contractManager) AddContractListener(ctx context.Context, listener *co
 		}
 
 		// Namespace + Topic + Location + Signature must be unique
-		if len(strings.TrimSpace(listener.Location.String())) == 0 {
-			listener.Location = nil // consistently store nil
-		}
 		listener.Signature = cm.blockchain.GenerateEventSignature(ctx, &listener.Event.FFIEventDefinition)
+		// Above we only call NormalizeContractLocation if the listener is non-nil, and that means
+		// for an unset location we will have a nil value. Using an fftypes.JSONAny in a query
+		// of nil does not yield the right result, so we need to do an explicit nil query.
+		var locationLookup driver.Value = nil
+		if !listener.Location.IsNil() {
+			locationLookup = listener.Location
+		}
 		fb := database.ContractListenerQueryFactory.NewFilter(ctx)
 		if existing, _, err := cm.database.GetContractListeners(ctx, cm.namespace, fb.And(
 			fb.Eq("topic", listener.Topic),
-			fb.Eq("location", listener.Location), // we query nil
+			fb.Eq("location", locationLookup),
 			fb.Eq("signature", listener.Signature),
 		)); err != nil {
 			return err

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -861,7 +861,7 @@ func (cm *contractManager) AddContractListener(ctx context.Context, listener *co
 		fb := database.ContractListenerQueryFactory.NewFilter(ctx)
 		if existing, _, err := cm.database.GetContractListeners(ctx, cm.namespace, fb.And(
 			fb.Eq("topic", listener.Topic),
-			fb.Eq("location", listener.Location.String()),
+			fb.Eq("location", listener.Location),
 			fb.Eq("signature", listener.Signature),
 		)); err != nil {
 			return err

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -857,11 +857,14 @@ func (cm *contractManager) AddContractListener(ctx context.Context, listener *co
 		}
 
 		// Namespace + Topic + Location + Signature must be unique
+		if len(strings.TrimSpace(listener.Location.String())) == 0 {
+			listener.Location = nil // consistently store nil
+		}
 		listener.Signature = cm.blockchain.GenerateEventSignature(ctx, &listener.Event.FFIEventDefinition)
 		fb := database.ContractListenerQueryFactory.NewFilter(ctx)
 		if existing, _, err := cm.database.GetContractListeners(ctx, cm.namespace, fb.And(
 			fb.Eq("topic", listener.Topic),
-			fb.Eq("location", listener.Location),
+			fb.Eq("location", listener.Location), // we query nil
 			fb.Eq("signature", listener.Signature),
 		)); err != nil {
 			return err

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -788,14 +788,13 @@ func TestAddContractListenerInline(t *testing.T) {
 	mdi.AssertExpectations(t)
 }
 
-func TestAddContractListenerInlineEmptyString(t *testing.T) {
+func TestAddContractListenerInlineNilLocation(t *testing.T) {
 	cm := newTestContractManager()
 	mbi := cm.blockchain.(*blockchainmocks.Plugin)
 	mdi := cm.database.(*databasemocks.Plugin)
 
 	sub := &core.ContractListenerInput{
 		ContractListener: core.ContractListener{
-			Location: fftypes.JSONAnyPtr("   "),
 			Event: &core.FFISerializedEvent{
 				FFIEventDefinition: fftypes.FFIEventDefinition{
 					Name: "changed",
@@ -812,11 +811,11 @@ func TestAddContractListenerInlineEmptyString(t *testing.T) {
 		},
 	}
 
-	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeListener, sub.Location).Return(sub.Location, nil)
 	mbi.On("GenerateEventSignature", context.Background(), mock.Anything).Return("changed")
 	mdi.On("GetContractListeners", context.Background(), "ns1", mock.Anything).Return(nil, nil, nil)
 	mbi.On("AddContractListener", context.Background(), mock.MatchedBy(func(cl *core.ContractListener) bool {
-		return cl.Location == nil // converted from empty string
+		// Normalize is not called for this case
+		return cl.Location == nil
 	})).Return(nil)
 	mdi.On("InsertContractListener", context.Background(), &sub.ContractListener).Return(nil)
 

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -788,6 +788,47 @@ func TestAddContractListenerInline(t *testing.T) {
 	mdi.AssertExpectations(t)
 }
 
+func TestAddContractListenerInlineEmptyString(t *testing.T) {
+	cm := newTestContractManager()
+	mbi := cm.blockchain.(*blockchainmocks.Plugin)
+	mdi := cm.database.(*databasemocks.Plugin)
+
+	sub := &core.ContractListenerInput{
+		ContractListener: core.ContractListener{
+			Location: fftypes.JSONAnyPtr("   "),
+			Event: &core.FFISerializedEvent{
+				FFIEventDefinition: fftypes.FFIEventDefinition{
+					Name: "changed",
+					Params: fftypes.FFIParams{
+						{
+							Name:   "value",
+							Schema: fftypes.JSONAnyPtr(`{"type": "integer"}`),
+						},
+					},
+				},
+			},
+			Options: &core.ContractListenerOptions{},
+			Topic:   "test-topic",
+		},
+	}
+
+	mbi.On("NormalizeContractLocation", context.Background(), blockchain.NormalizeListener, sub.Location).Return(sub.Location, nil)
+	mbi.On("GenerateEventSignature", context.Background(), mock.Anything).Return("changed")
+	mdi.On("GetContractListeners", context.Background(), "ns1", mock.Anything).Return(nil, nil, nil)
+	mbi.On("AddContractListener", context.Background(), mock.MatchedBy(func(cl *core.ContractListener) bool {
+		return cl.Location == nil // converted from empty string
+	})).Return(nil)
+	mdi.On("InsertContractListener", context.Background(), &sub.ContractListener).Return(nil)
+
+	result, err := cm.AddContractListener(context.Background(), sub)
+	assert.NoError(t, err)
+	assert.NotNil(t, result.ID)
+	assert.NotNil(t, result.Event)
+
+	mbi.AssertExpectations(t)
+	mdi.AssertExpectations(t)
+}
+
 func TestAddContractListenerNoLocationOK(t *testing.T) {
 	cm := newTestContractManager()
 	mbi := cm.blockchain.(*blockchainmocks.Plugin)


### PR DESCRIPTION
It's extremely hard for an external client calling the `AddContractListener` REST API to determine whether the listener already exists, because the details are a factor of a complex FFI payload.

For this reason FireFly provides a uniqueness check for the:
- `namespace`
- `topic` - allows multiple listeners to the same event, for different apps
- `location` - can be nil, or a blockchain-specific location
- `signature` - generated _by FireFly_ in a protocol specific way from the supplied FFI signature

However, the code doing a lookup in the DB was not working for the nil check, due to a `.ToString()`

Annoyingly there's a weirdness with `fftypes.JSONAny.Value()` in the `nil` case, and for some reason passing a `(*fftypes.JSONAny)(nil)` into `fb.Eq()` is not generating an `IS NULL` SQL query.

So instead this code passes actual `nil` in the nil case, and this works.

> This is really an underlying issue in `firefly-common` for a `ffapi.JSONField` case, but that's too risky a change to do in isolation