### PR TITLE
fix: Merge ID into PATCH calls for identity if one is not provided

### DIFF
--- a/internal/networkmap/update_identity.go
+++ b/internal/networkmap/update_identity.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -42,6 +42,12 @@ func (nm *networkMap) updateIdentityID(ctx context.Context, id *fftypes.UUID, dt
 	}
 	if identity == nil || identity.Namespace != nm.namespace {
 		return nil, i18n.NewError(ctx, coremsgs.Msg404NoResult)
+	}
+
+	// We can't sparse merge the generic JSON fields, but we need to propagate the ID
+	if dto.IdentityProfile.Profile.GetString("id") == "" {
+		existingID := identity.IdentityProfile.Profile.GetString("id")
+		dto.IdentityProfile.Profile["id"] = existingID
 	}
 
 	var updateSigner *core.SignerRef


### PR DESCRIPTION
ref: https://github.com/hyperledger/firefly/issues/1450

When calling the PATCH identity API, if an ID is not provided, we grab the ID from the existing identity and use this. This effectively means that a PATCH operation should always have an ID in the payload, which should stop the downstream DX connectors from crashing when they attempt to peer on a restart.