### PR TITLE
adding High/Critical severity vuln checks

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -16,9 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
 echo $@
 
- if [[ ! -x `which jq` ]]; then echo "Please install \"jq\" to continue"; exit 1; fi
+if [[ ! -x `which jq` ]]; then echo "Please install \"jq\" to continue"; exit 1; fi
 
 FIREFLY_BUILDER_TAG=$(cat manifest.json | jq -r '.build."firefly-builder".image')
 FABRIC_BUILDER_TAG=$(cat manifest.json | jq -r '.build."fabric-builder".image')


### PR DESCRIPTION
This Pull request:

1. updates the Dockerfile to check dependencies of this source code, and fail to build if high/critical severity vulnerabilities are detected
2. use `set -e` in `docker_build.sh` to ensure `make docker` has a non-zero exist code when the build fails

Both of the changes above are implemented with the help of Trivy, an open source scanning tool from Aquasec. Trivy is RedHat certified, and is being used as the default container scanner on GitLab (according [to this link](https://www.aquasec.com/products/trivy/))