### PR TITLE
fix: Status call returns properly when node is not registered but organisation is

### DIFF
--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -105,13 +105,12 @@ func ParseKeyNormalizationConfig(strConfigVal string) int {
 
 func (im *identityManager) GetLocalNode(ctx context.Context) (node *core.Identity, err error) {
 	nodeName := im.multiparty.LocalNode().Name
-	nodeDID := fmt.Sprintf("%s%s", core.FireFlyNodeDIDPrefix, nodeName)
-	node, _, err = im.CachedIdentityLookupNilOK(ctx, nodeDID)
-
-	if nodeName == "" && node == nil {
+	if nodeName == "" {
 		return nil, i18n.NewError(ctx, coremsgs.MsgLocalNodeNotSet)
 	}
 
+	nodeDID := fmt.Sprintf("%s%s", core.FireFlyNodeDIDPrefix, nodeName)
+	node, _, err = im.CachedIdentityLookupNilOK(ctx, nodeDID)
 	return node, err
 }
 

--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -105,13 +105,13 @@ func ParseKeyNormalizationConfig(strConfigVal string) int {
 
 func (im *identityManager) GetLocalNode(ctx context.Context) (node *core.Identity, err error) {
 	nodeName := im.multiparty.LocalNode().Name
-	if nodeName != "" {
-		nodeDID := fmt.Sprintf("%s%s", core.FireFlyNodeDIDPrefix, nodeName)
-		node, _, err = im.CachedIdentityLookupNilOK(ctx, nodeDID)
-	}
-	if err == nil && node == nil {
+	nodeDID := fmt.Sprintf("%s%s", core.FireFlyNodeDIDPrefix, nodeName)
+	node, _, err = im.CachedIdentityLookupNilOK(ctx, nodeDID)
+
+	if nodeName == "" && node == nil {
 		return nil, i18n.NewError(ctx, coremsgs.MsgLocalNodeNotSet)
 	}
+
 	return node, err
 }
 

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -1436,8 +1436,11 @@ func TestGetLocalNode(t *testing.T) {
 func TestGetLocalNodeNotSet(t *testing.T) {
 	ctx, im := newTestIdentityManager(t)
 	mmp := im.multiparty.(*multipartymocks.Manager)
+	mdi := im.database.(*databasemocks.Plugin)
 
 	mmp.On("LocalNode").Return(multiparty.LocalNode{})
+	mdi.On("GetIdentityByDID", ctx, "ns1", "did:firefly:node/").Return(nil, nil).Once()
+	mmp.On("GetNetworkVersion").Return(2)
 
 	_, err := im.GetLocalNode(ctx)
 	assert.Regexp(t, "FF10225", err)

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -1436,11 +1436,8 @@ func TestGetLocalNode(t *testing.T) {
 func TestGetLocalNodeNotSet(t *testing.T) {
 	ctx, im := newTestIdentityManager(t)
 	mmp := im.multiparty.(*multipartymocks.Manager)
-	mdi := im.database.(*databasemocks.Plugin)
 
 	mmp.On("LocalNode").Return(multiparty.LocalNode{})
-	mdi.On("GetIdentityByDID", ctx, "ns1", "did:firefly:node/").Return(nil, nil).Once()
-	mmp.On("GetNetworkVersion").Return(2)
 
 	_, err := im.GetLocalNode(ctx)
 	assert.Regexp(t, "FF10225", err)


### PR DESCRIPTION
ref: https://github.com/hyperledger/firefly/issues/1453 and [this change](https://github.com/hyperledger/firefly/commit/4696ad1c82194580c3c8bf01632c020db86a74e7#diff-e097a0bac30f72e5cc6978dc4e6336e1377310f01235622293baf87758df9302R111)

When a namespace is registered to the organisation but the node has not been registered, if the name has not been set (i.e. it's `""`) then we throw an error. If a name _is_ set, then we return `nil` because while there is no information on the node (as it's not registered) it is possible for the node to be registered.

Side note: getting an environment in which to test this was a colossal pain and largely undocumented, so I'm going to put a comment below with how I got a testing configuration in place to test this out.



