### PR TITLE
Fix build tag in release GitHub action

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set build tag
         id: build_tag_generator
         run: |
-          RELEASE_TAG=$(curl https://api.github.com/repos/${{ github.repository }}/releases/latest -s | jq .tag_name -r)
+          RELEASE_TAG=${{ github.ref_name }}
           BUILD_TAG=$RELEASE_TAG-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "BUILD_TAG=$BUILD_TAG" >> $GITHUB_OUTPUT
@@ -76,7 +76,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           platforms: linux/amd64
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }},ghcr.io/${{ github.repository }}:head,${{ env.DOCKER_TAGS }}
+          tags: ghcr.io/${{ github.repository }}:${{ steps.build_tag_generator.outputs.RELEASE_TAG }},ghcr.io/${{ github.repository }}:head,${{ env.DOCKER_TAGS }}
           labels: |
             commit=${{ github.sha }}
             build_date=${{ steps.build_tag_generator.outputs.BUILD_DATE }}


### PR DESCRIPTION
In testing `v1.3.0-rc.1` I noticed an issue with the version information. This resulted in the wrong version being displayed:

- When the application starts up, in its log file
- In the Docker image labels

An example of an incorrectly labeled image is here: https://github.com/hyperledger/firefly/pkgs/container/firefly/186598190?tag=v1.3.0-rc.1

Despite the _label_ being incorrect on this image, the _tag_ was correct. This PR sets them to the same thing.