### PR TITLE
feat: Add metrics for messaging when performing a token transfer

### DIFF
--- a/internal/broadcast/message.go
+++ b/internal/broadcast/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,6 +34,9 @@ func (bm *broadcastManager) NewBroadcast(in *core.MessageInOut) syncasync.Sender
 		msg: &data.NewMessage{
 			Message: in,
 		},
+	}
+	if bm.metrics.IsMetricsEnabled() {
+		bm.metrics.MessageSubmitted(&in.Message)
 	}
 	broadcast.setDefaults()
 	return broadcast

--- a/internal/privatemessaging/message.go
+++ b/internal/privatemessaging/message.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,6 +34,9 @@ func (pm *privateMessaging) NewMessage(in *core.MessageInOut) syncasync.Sender {
 		msg: &data.NewMessage{
 			Message: in,
 		},
+	}
+	if pm.metrics.IsMetricsEnabled() {
+		pm.metrics.MessageSubmitted(&in.Message)
 	}
 	message.setDefaults()
 	return message


### PR DESCRIPTION
As part of performance testing for 1.3 rc1, I realised that the number of confirmed broadcast message compared to submitted was off. It turns out the FireFly performance CLI was performing mints with messages and the metrics for those message in the submitted part were not being counted. This fixes that!