### PR TITLE
fix metrics when recording length of confirmed event

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
As part of writing metrics to Prometheus, when a FF node submits an operation it records it and stores an in memory map of when that operation occurred. In the case of a multiparty setup where we receive messages that other participants have submitted we do not have a record of the submitted time and we provide Prometheus with an incorrect time. To be more precise, we provide it with seconds from time zero: `0001-01-01 00:00:00 +0000 UTC`.

This PR fixes that and verifies that we do not pass that incorrect time to Prometheus

