### PR TITLE
fix: fabric check existence of listener

### DIFF
--- a/internal/blockchain/fabric/eventstream.go
+++ b/internal/blockchain/fabric/eventstream.go
@@ -156,39 +156,25 @@ func (s *streamManager) getSubscriptions(ctx context.Context) (subs []*subscript
 	return subs, nil
 }
 
-func (s *streamManager) getSubscription(ctx context.Context, subID string) (sub *subscription, err error) {
+func (s *streamManager) getSubscription(ctx context.Context, subID string, okNotFound bool) (sub *subscription, err error) {
 	res, err := s.client.R().
 		SetContext(ctx).
 		SetResult(&sub).
 		Get(fmt.Sprintf("/subscriptions/%s", subID))
 	if err != nil || !res.IsSuccess() {
+		if okNotFound && res.StatusCode() == 404 {
+			return nil, nil
+		}
 		return nil, ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgFabconnectRESTErr)
 	}
 	return sub, nil
 }
 
-func (s *streamManager) checkSubscriptionExistence(ctx context.Context, subID string) (found bool, err error) {
-	sub := &subscription{}
-	res, err := s.client.R().
-		SetContext(ctx).
-		SetResult(&sub).
-		Get(fmt.Sprintf("/subscriptions/%s", subID))
-
-	if err != nil || !res.IsSuccess() {
-		if res.StatusCode() == 404 {
-			return false, nil
-		}
-		return false, ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgFabconnectRESTErr)
-	}
-
-	return true, nil
-}
-
-func (s *streamManager) getSubscriptionName(ctx context.Context, subID string) (string, error) {
+func (s *streamManager) getSubscriptionName(ctx context.Context, subID string, okNotFound bool) (string, error) {
 	if cachedValue := s.cache.GetString("sub:" + subID); cachedValue != "" {
 		return cachedValue, nil
 	}
-	sub, err := s.getSubscription(ctx, subID)
+	sub, err := s.getSubscription(ctx, subID, okNotFound)
 	if err != nil {
 		return "", err
 	}

--- a/internal/blockchain/fabric/eventstream.go
+++ b/internal/blockchain/fabric/eventstream.go
@@ -167,6 +167,23 @@ func (s *streamManager) getSubscription(ctx context.Context, subID string) (sub 
 	return sub, nil
 }
 
+func (s *streamManager) checkSubscriptionExistence(ctx context.Context, subID string) (found bool, err error) {
+	sub := &subscription{}
+	res, err := s.client.R().
+		SetContext(ctx).
+		SetResult(&sub).
+		Get(fmt.Sprintf("/subscriptions/%s", subID))
+
+	if err != nil || !res.IsSuccess() {
+		if res.StatusCode() == 404 {
+			return false, nil
+		}
+		return false, ffresty.WrapRestErr(ctx, res, err, coremsgs.MsgFabconnectRESTErr)
+	}
+
+	return true, nil
+}
+
 func (s *streamManager) getSubscriptionName(ctx context.Context, subID string) (string, error) {
 	if cachedValue := s.cache.GetString("sub:" + subID); cachedValue != "" {
 		return cachedValue, nil

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -1000,11 +1000,7 @@ func (f *Fabric) GetContractListenerStatus(ctx context.Context, namespace, subID
 	// Fabconnect does not currently provide any additional status info for listener subscriptions.
 	// But we check for existence of the subscription
 	found, err := f.streams.checkSubscriptionExistence(ctx, subID)
-	if err != nil {
-		return found, nil, core.ContractListenerStatusUnknown, err
-	}
-
-	return found, nil, core.ContractListenerStatusUnknown, nil
+	return found, nil, core.ContractListenerStatusUnknown, err
 }
 
 func (f *Fabric) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -396,7 +396,7 @@ func (f *Fabric) buildEventLocationString(chaincode string) string {
 
 func (f *Fabric) processContractEvent(ctx context.Context, events common.EventsToDispatch, msgJSON fftypes.JSONObject) (err error) {
 	subID := msgJSON.GetString("subId")
-	subName, err := f.streams.getSubscriptionName(ctx, subID)
+	subName, err := f.streams.getSubscriptionName(ctx, subID, false)
 	if err != nil {
 		return err // this is a problem - we should be able to find the listener that dispatched this to us
 	}
@@ -999,8 +999,12 @@ func (f *Fabric) DeleteContractListener(ctx context.Context, subscription *core.
 func (f *Fabric) GetContractListenerStatus(ctx context.Context, namespace, subID string, okNotFound bool) (bool, interface{}, core.ContractListenerStatus, error) {
 	// Fabconnect does not currently provide any additional status info for listener subscriptions.
 	// But we check for existence of the subscription
-	found, err := f.streams.checkSubscriptionExistence(ctx, subID)
-	return found, nil, core.ContractListenerStatusUnknown, err
+	sub, err := f.streams.getSubscription(ctx, subID, okNotFound)
+	if err != nil || sub == nil {
+		return false, nil, core.ContractListenerStatusUnknown, err
+	}
+
+	return true, nil, core.ContractListenerStatusUnknown, err
 }
 
 func (f *Fabric) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -998,7 +998,13 @@ func (f *Fabric) DeleteContractListener(ctx context.Context, subscription *core.
 
 func (f *Fabric) GetContractListenerStatus(ctx context.Context, namespace, subID string, okNotFound bool) (bool, interface{}, core.ContractListenerStatus, error) {
 	// Fabconnect does not currently provide any additional status info for listener subscriptions.
-	return true, nil, core.ContractListenerStatusUnknown, nil
+	// But we check for existence of the subscription
+	found, err := f.streams.checkSubscriptionExistence(ctx, subID)
+	if err != nil {
+		return found, nil, core.ContractListenerStatusUnknown, err
+	}
+
+	return found, nil, core.ContractListenerStatusUnknown, nil
 }
 
 func (f *Fabric) GetFFIParamValidator(ctx context.Context) (fftypes.FFIParamValidator, error) {


### PR DESCRIPTION
As part of 1.3.1-rc1 testing, I realised that the Fabric listeners do not get recreated when migrating from v1.2.2 to v1.3.X. As far as I can see this was already an issue in v1.3.0. 

This checks for the existence of a Fabric subscription instead of just assuming true always so we recreate the listeners when recreating the event streams