### PR TITLE
fix: doc site release action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
               https://api.github.com/repos/${{ github.repository }}/releases/latest \
               | jq -r '.tag_name'
           )
-          IS_LATEST=${{ env.LATEST_TAG == github.event.release.tag_name }}
+          IS_LATEST=${{ $LATEST_TAG == github.event.release.tag_name }}
           echo This release is: "${{ github.event.release.tag_name }}"
           echo The latest release is: "$LATEST_TAG"
           echo "IS_LATEST_RELEASE=$IS_LATEST" >> "$GITHUB_ENV"


### PR DESCRIPTION
This should fix the release GitHub action that did not set the version as latest for the v1.3.1 release. Unfortunately this only gets triggered on release, so a manual step will be needed to fix the version this time around