### PR TITLE
Refactor `maybePersistBlockchainEvent` to Return a Boolean Indicating Event Creation Status

### DIFF
--- a/internal/events/blockchain_event.go
+++ b/internal/events/blockchain_event.go
@@ -71,7 +71,7 @@ func (em *eventManager) getChainListenerByProtocolIDCached(ctx context.Context, 
 	return l, nil
 }
 
-// handleBlockchainBatchPinEvent handles a blockchain event, returning true if the event was created, false if it was a duplicate
+// handleBlockchainBatchPinEvent handles a blockchain event, returning true if the event was created, false if it was a duplicate along with an error if any failures occur
 func (em *eventManager) maybePersistBlockchainEvent(ctx context.Context, chainEvent *core.BlockchainEvent, listener *core.ContractListener) (bool, error) {
 	existing, err := em.txHelper.InsertOrGetBlockchainEvent(ctx, chainEvent)
 	if err != nil {

--- a/internal/events/blockchain_event_test.go
+++ b/internal/events/blockchain_event_test.go
@@ -151,54 +151,34 @@ func TestContractEventWrongNS(t *testing.T) {
 
 }
 
+// TODO: Add test case for event not existing
 func TestPersistBlockchainEventDuplicate(t *testing.T) {
-	type testCase struct {
-		name            string
-		event           *core.BlockchainEvent
-		existingID      *fftypes.UUID
-		expectedID      *fftypes.UUID
-		expectedError   error
-		expectedCreated bool
-	}
+	em := newTestEventManager(t)
+	defer em.cleanup(t)
 
-	testCases := []testCase{
-		{
-			name: "Event already exists",
-			event: &core.BlockchainEvent{
-				ID:         fftypes.NewUUID(),
-				Name:       "Changed",
-				Namespace:  "ns1",
-				ProtocolID: "10/20/30",
-				Output: fftypes.JSONObject{
-					"value": "1",
-				},
-				Info: fftypes.JSONObject{
-					"blockNumber": "10",
-				},
-				Listener: fftypes.NewUUID(),
-			},
-			existingID:      fftypes.NewUUID(),
-			expectedID:      fftypes.NewUUID(),
-			expectedError:   nil,
-			expectedCreated: false,
+	ev := &core.BlockchainEvent{
+		ID:         fftypes.NewUUID(),
+		Name:       "Changed",
+		Namespace:  "ns1",
+		ProtocolID: "10/20/30",
+		Output: fftypes.JSONObject{
+			"value": "1",
 		},
-		// TODO: Add test case for event not existing
+		Info: fftypes.JSONObject{
+			"blockNumber": "10",
+		},
+		Listener: fftypes.NewUUID(),
 	}
+	existingID := fftypes.NewUUID()
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			em := newTestEventManager(t)
-			defer em.cleanup(t)
+	em.mth.On("InsertOrGetBlockchainEvent", mock.Anything, ev).
+		Return(&core.BlockchainEvent{ID: existingID}, nil)
 
-			em.mth.On("InsertOrGetBlockchainEvent", mock.Anything, tc.event).
-				Return(&core.BlockchainEvent{ID: tc.existingID}, tc.expectedError)
+	created, err := em.maybePersistBlockchainEvent(em.ctx, ev, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, existingID, ev.ID)
+	assert.False(t, created)
 
-			created, err := em.maybePersistBlockchainEvent(em.ctx, tc.event, nil)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.existingID, tc.event.ID)
-			assert.Equal(t, tc.expectedCreated, created)
-		})
-	}
 }
 
 func TestGetTopicForChainListenerFallback(t *testing.T) {

--- a/internal/events/event_manager_test.go
+++ b/internal/events/event_manager_test.go
@@ -681,7 +681,7 @@ func TestEventFilterOnSubscriptionMatchesEventType(t *testing.T) {
 	filteredEvents, _ = em.FilterHistoricalEventsOnSubscription(context.Background(), events, subscription)
 	assert.NotNil(t, filteredEvents)
 	assert.Equal(t, 1, len(filteredEvents))
-	
+
 	listenerUuid := fftypes.NewUUID()
 
 	events[0].Event.Topic = ""

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -62,10 +62,13 @@ func (em *eventManager) confirmPool(ctx context.Context, pool *core.TokenPool, e
 			Type:         pool.TX.Type,
 			BlockchainID: blockchainID,
 		})
-		if err := em.maybePersistBlockchainEvent(ctx, chainEvent, nil); err != nil {
+		created, err := em.maybePersistBlockchainEvent(ctx, chainEvent, nil)
+		if err != nil {
 			return err
 		}
-		em.emitBlockchainEventMetric(ev)
+		if created {
+			em.emitBlockchainEventMetric(ev)
+		}
 	}
 	if _, err := em.txHelper.PersistTransaction(ctx, pool.TX.ID, pool.TX.Type, blockchainID); err != nil {
 		return err

--- a/internal/events/tokens_approved.go
+++ b/internal/events/tokens_approved.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/events/tokens_approved.go
+++ b/internal/events/tokens_approved.go
@@ -97,10 +97,13 @@ func (em *eventManager) persistTokenApproval(ctx context.Context, approval *toke
 		Type:         approval.TX.Type,
 		BlockchainID: approval.Event.BlockchainTXID,
 	})
-	if err := em.maybePersistBlockchainEvent(ctx, chainEvent, nil); err != nil {
+	created, err := em.maybePersistBlockchainEvent(ctx, chainEvent, nil)
+	if err != nil {
 		return false, err
 	}
-	em.emitBlockchainEventMetric(approval.Event)
+	if created {
+		em.emitBlockchainEventMetric(approval.Event)
+	}
 	approval.BlockchainEvent = chainEvent.ID
 
 	fb := database.TokenApprovalQueryFactory.NewFilter(ctx)

--- a/internal/events/tokens_transferred.go
+++ b/internal/events/tokens_transferred.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/events/tokens_transferred.go
+++ b/internal/events/tokens_transferred.go
@@ -89,10 +89,13 @@ func (em *eventManager) persistTokenTransfer(ctx context.Context, transfer *toke
 		Type:         transfer.TX.Type,
 		BlockchainID: transfer.Event.BlockchainTXID,
 	})
-	if err := em.maybePersistBlockchainEvent(ctx, chainEvent, nil); err != nil {
+	created, err := em.maybePersistBlockchainEvent(ctx, chainEvent, nil)
+	if err != nil {
 		return false, err
 	}
-	em.emitBlockchainEventMetric(transfer.Event)
+	if created {
+		em.emitBlockchainEventMetric(transfer.Event)
+	}
 	transfer.BlockchainEvent = chainEvent.ID
 
 	// This is a no-op if we've already persisted this token transfer


### PR DESCRIPTION
# Overview

This PR refactors the `maybePersistBlockchainEvent()` function to return a boolean indicating whether a blockchain event was newly created. This change prevents the double-counting of metrics by ensuring that `emitBlockchainEventMetric()` is only called for new events. 

Fixes #1294.