### PR TITLE
Add explicit github actions permissions

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fix 403 Forbidden on push to ghcr https://github.com/hyperledger/firefly/actions/runs/10421823597/job/28864918724

The same issue as https://github.com/hyperledger/firefly-helm-charts/pull/78 