### PR TITLE
Fixing protocol ID docs

### DIFF
--- a/doc-site/docs/reference/types/_includes/blockchainevent_description.md
+++ b/doc-site/docs/reference/types/_includes/blockchainevent_description.md
@@ -25,8 +25,8 @@ the blockchain plugins to try and create some consistency.
 An example `protocolId` string is: `000000000041/000020/000003`
 
 - `000000000041` - this is the block number
-- `000020` - this is the transaction index within that block
-- `000003` - this is the event (/log) index within that transaction
+- `000020` - this is the **transaction** index within that **block**
+- `000003` - this is the **event (/log)** index within that **block**
 
 The string is alphanumerically sortable as a plain string;
 


### PR DESCRIPTION
This PR corrects the documentation to reflect that the third segment of the `protocolId` represents the event (/log) index within the entire block, which aligns with the observed behavior and Ethereum's standards.
I referenced this [comment](https://github.com/hyperledger/firefly/issues/1455#issuecomment-1910275127) for the fix.

Resolves: #1455 