### PR TITLE
Upgrade to Go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Build and Test
         run: make
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Build Docker image
         run: make docker
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Download Docker image
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Update manifest to latest commit for every service
         run: ./manifestgen.sh head
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Update manifest to latest commit for every service
         run: ./manifestgen.sh head

--- a/doc-site/docs/contributors/dev_environment_setup.md
+++ b/doc-site/docs/contributors/dev_environment_setup.md
@@ -12,7 +12,7 @@ This guide will walk you through setting up your machine for contributing to Fir
 
 You will need a few prerequisites set up on your machine before you can build FireFly from source. We recommend doing development on macOS, Linux, or WSL 2.0.
 
-- [Go 1.21](https://golang.org/dl/)
+- [Go 1.22](https://golang.org/dl/)
 - make
 - GCC
 - openssl

--- a/doc-site/docs/releasenotes/1.3_migration_guide.md
+++ b/doc-site/docs/releasenotes/1.3_migration_guide.md
@@ -103,4 +103,4 @@ Prior to FireFly v1.3.0, when the FabConnect client indexed events submitted by 
 
 ### Go version upgrade
 
-FireFly v1.3.0 now uses Go 1.21 across all modules.
+FireFly v1.3.2 now uses Go 1.22 across all modules.

--- a/doc-site/docs/releasenotes/1.3_migration_guide.md
+++ b/doc-site/docs/releasenotes/1.3_migration_guide.md
@@ -103,4 +103,4 @@ Prior to FireFly v1.3.0, when the FabConnect client indexed events submitted by 
 
 ### Go version upgrade
 
-FireFly v1.3.2 now uses Go 1.22 across all modules.
+FireFly v1.3.0 now uses Go 1.21 across all modules.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hyperledger/firefly
 
-go 1.21
+go 1.22
+
+toolchain go1.22.7
 
 require (
 	blockwatch.cc/tzgo v1.17.1
@@ -15,8 +17,8 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.17.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
-	github.com/hyperledger/firefly-common v1.4.9
-	github.com/hyperledger/firefly-signer v1.1.14
+	github.com/hyperledger/firefly-common v1.4.10
+	github.com/hyperledger/firefly-signer v1.1.15
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.19

--- a/go.sum
+++ b/go.sum
@@ -77,10 +77,10 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hyperledger/firefly-common v1.4.9 h1:PfPZ73FN8WUoPl8iF8ud00B8476+jmqXHHi94w0Krbc=
-github.com/hyperledger/firefly-common v1.4.9/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
-github.com/hyperledger/firefly-signer v1.1.14 h1:gSGwdBHTLPchGlmLOKk2Y2nawfMhlH2CDm2owt0lIUE=
-github.com/hyperledger/firefly-signer v1.1.14/go.mod h1:Xj2PF6y8Ce26jX38ch0KasNnnZCSyzcwyLSv8NN+7JA=
+github.com/hyperledger/firefly-common v1.4.10 h1:NgUYorxZF3tNkL7bBqe3PlwA42pPAYlj0wStnUsjN9Y=
+github.com/hyperledger/firefly-common v1.4.10/go.mod h1:E7w/RxNtVnX52WXLQW9f2xVAgZnW70voZeE9sZrx/q0=
+github.com/hyperledger/firefly-signer v1.1.15 h1:oJXrX1ziDIxzSbRX+risVEmprx3McD1yi0S1S5La4zc=
+github.com/hyperledger/firefly-signer v1.1.15/go.mod h1:E/TO0Koi4BqSr8hRhKJVTxiynwX/EQYjqqKrlnsQK7o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=

--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.21
+go 1.22
+
+toolchain go1.22.7
 
 use (
 	.

--- a/go.work.sum
+++ b/go.work.sum
@@ -253,6 +253,7 @@ github.com/hashicorp/go-memdb v1.3.3/go.mod h1:uBTr1oQbtuMgd1SSGoR8YV27eT3sBHbYi
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
+github.com/hyperledger/firefly-common v1.4.10 h1:NgUYorxZF3tNkL7bBqe3PlwA42pPAYlj0wStnUsjN9Y=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/pgconn v1.14.0/go.mod h1:9mBNlny0UvkgJdCDvdVHYSjI+8tD2rnKK69Wz8ti++E=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=

--- a/manifest.json
+++ b/manifest.json
@@ -41,10 +41,10 @@
   },
   "build": {
     "firefly-builder": {
-      "image": "golang:1.21-alpine3.19"
+      "image": "golang:1.22-alpine3.19"
     },
     "fabric-builder": {
-      "image": "golang:1.21",
+      "image": "golang:1.22",
       "platform": "linux/x86_64"
     },
     "solidity-builder": {

--- a/smart_contracts/fabric/custompin-sample/go.mod
+++ b/smart_contracts/fabric/custompin-sample/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/firefly/custompin_sample
 
-go 1.21
+go 1.22
 
 require (
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20240124143825-7dec3c7e7d45

--- a/smart_contracts/fabric/firefly-go/go.mod
+++ b/smart_contracts/fabric/firefly-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/firefly/chaincode-go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/golang/protobuf v1.5.3

--- a/test/data/contracts/assetcreator/go.mod
+++ b/test/data/contracts/assetcreator/go.mod
@@ -1,8 +1,8 @@
 module github.com/hyperledger/firefly/test/data/assetcreator
 
-go 1.21
+go 1.22
 
-toolchain go1.21.0
+toolchain go1.22.0
 
 require github.com/hyperledger/fabric-contract-api-go v1.2.2
 


### PR DESCRIPTION
All FireFly Go modules are being upgraded to Go 1.22. This PR updates Firefly itself, along with miscellaneous docs references.