### PR TITLE
Document support in v1.3.2 for large JSON numbers

### DIFF
--- a/doc-site/docs/reference/types/_includes/ffbigint_description.md
+++ b/doc-site/docs/reference/types/_includes/ffbigint_description.md
@@ -7,5 +7,49 @@ strings (with base 10).
 On input you can provide JSON string (string with an `0x` prefix are
 parsed at base 16), or a JSON number.
 
-Be careful when using JSON numbers, that the largest
-number that is safe to transfer using a JSON number is 2^53 - 1.
+## Maximum size of numbers in versions of FireFly up to `v1.3.1`
+
+In versions of FireFly up to and including `v1.3.1`, be careful when using large JSON numbers. The largest number that is safe to transfer using a JSON number is 2^53 - 1 and it is
+possible to receive errors from the transaction manager, or for precision to be silently lost when passing numeric parameters larger than that. It is recommended to pass large numbers as strings to avoid loss of precision.
+
+## Maximum size of numbers in versions of FireFly `v1.3.2` and higher
+
+In FireFly `v1.3.2` support was added for 256-bit precision JSON numbers. Some application frameworks automatically serialize large JSON numbers to a string which FireFly already supports, but there is no upper limit
+to the size of a number that can be represented in JSON. FireFly now supports much larger JSON numbers, up to 256-bit precision. For example the following input parameter to a contract constructor is now supported:
+
+```
+    ...
+    "definition": [{
+		"inputs": [
+			{
+				"internalType":" uint256",
+				"name": "x",
+				"type": "uint256"
+			}
+		],
+		"outputs":[],
+		"type":"constructor"
+	}],
+	"params": [ 10000000000000000000000000 ]
+    ...
+```
+
+Some application frameworks seralize large numbers in scientific notation e.g. `1e+25`. FireFly `v1.3.2` added supported for handling scientific numbers in parameters. This removes the need to change an application
+that uses this number format. For example the following input parameter to a contract constructor is now supported:
+
+```
+    ...
+    "definition": [{
+		"inputs": [
+			{
+				"internalType":" uint256",
+				"name": "x",
+				"type": "uint256"
+			}
+		],
+		"outputs":[],
+		"type":"constructor"
+	}],
+	"params": [ 1e+25 ]
+    ...
+```

--- a/doc-site/docs/releasenotes/index.md
+++ b/doc-site/docs/releasenotes/index.md
@@ -10,6 +10,10 @@ What's New:
 
 - Support for JSON numbers larger than `2^53-1`
     See [FFBigInt](../reference/types/simpletypes.md#ffbigint) 
+- Ability to install FireFly CLI with Brew for MacOS users
+    See [Brew](../) 
+- Miscellaneous bug fixes and minor improvements
+- FireFly has been upgraded to use Go 1.22
 
 ## [v1.3.1 - Aug 5, 2024](https://github.com/hyperledger/firefly/releases/tag/v1.3.1)
 

--- a/doc-site/docs/releasenotes/index.md
+++ b/doc-site/docs/releasenotes/index.md
@@ -4,6 +4,13 @@ title: Release Notes
 
 [Full release notes](https://github.com/hyperledger/firefly/releases)
 
+## [v1.3.2 - Sept 13, 2024](https://github.com/hyperledger/firefly/releases/tag/v1.3.2)
+
+What's New:
+
+- Support for JSON numbers larger than `2^53-1`
+    See [FFBigInt](../reference/types/simpletypes.md#ffbigint) 
+
 ## [v1.3.1 - Aug 5, 2024](https://github.com/hyperledger/firefly/releases/tag/v1.3.1)
 
 What's New:

--- a/doc-site/docs/releasenotes/index.md
+++ b/doc-site/docs/releasenotes/index.md
@@ -11,7 +11,7 @@ What's New:
 - Support for JSON numbers larger than `2^53-1`
     See [FFBigInt](../reference/types/simpletypes.md#ffbigint) 
 - Ability to install FireFly CLI with Brew for MacOS users
-    See [Brew](../) 
+    See [Brew](../gettingstarted/firefly_cli.md#install-via-homebrew-macOS) 
 - Miscellaneous bug fixes and minor improvements
 - FireFly has been upgraded to use Go 1.22
 


### PR DESCRIPTION
See issue https://github.com/hyperledger/firefly/issues/1568

This PR documents the new large-number support. For convenience, here's a preview of the updated topic:

![image](https://github.com/user-attachments/assets/9c037a86-8e5f-4eef-a12b-69d5cf0fe548)
