### PR TITLE
Handle large numbers when unmarshalling to an operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add make=4.4.1-r2 \
     gcc=13.2.1_git20231014-r0 \
     build-base=0.5-r3 \
     curl=8.9.1-r0 \
-    git=2.43.4-r0
+    git=2.43.5-r0
 WORKDIR /firefly
 RUN chgrp -R 0 /firefly \
     && chmod -R g+rwX /firefly \

--- a/internal/contracts/operations.go
+++ b/internal/contracts/operations.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/contracts/operations.go
+++ b/internal/contracts/operations.go
@@ -17,6 +17,7 @@
 package contracts
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 
@@ -38,7 +39,9 @@ type blockchainContractDeployData struct {
 func addBlockchainReqInputs(op *core.Operation, req interface{}) (err error) {
 	var reqJSON []byte
 	if reqJSON, err = json.Marshal(req); err == nil {
-		err = json.Unmarshal(reqJSON, &op.Input)
+		d := json.NewDecoder(bytes.NewReader(reqJSON))
+		d.UseNumber()
+		err = d.Decode(&op.Input)
 	}
 	return err
 }

--- a/internal/contracts/operations_test.go
+++ b/internal/contracts/operations_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/txcommon/contract_inputs.go
+++ b/internal/txcommon/contract_inputs.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/txcommon/contract_inputs.go
+++ b/internal/txcommon/contract_inputs.go
@@ -17,6 +17,7 @@
 package txcommon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 
@@ -39,7 +40,9 @@ type BlockchainInvokeData struct {
 func RetrieveBlockchainInvokeInputs(ctx context.Context, op *core.Operation) (*core.ContractCallRequest, error) {
 	var req core.ContractCallRequest
 	s := op.Input.String()
-	if err := json.Unmarshal([]byte(s), &req); err != nil {
+	d := json.NewDecoder(bytes.NewReader([]byte(s)))
+	d.UseNumber()
+	if err := d.Decode(&req); err != nil {
 		return nil, i18n.WrapError(ctx, err, i18n.MsgJSONObjectParseFailed, s)
 	}
 	return &req, nil


### PR DESCRIPTION
Relates to https://github.com/hyperledger/firefly/issues/1568

When unmarshalling contract invoke payloads to a Firefly `operation`, unmarshal numbers to `json.Number` instead of `float64`. This avoids unexpected (and silent) precision loss if a large number is included in the input payload.

I've tested this locally in a FF stack:

1. Submit a `curl` request to invoke a contract's setter function with a very large number:

```
curl -X 'POST' \
  'http://127.0.0.1:5000/api/v1/namespaces/default/apis/contract1/invoke/store?confirm=true' \
  -H 'accept: application/json' \
  -H 'Request-Timeout: 2m0s' \
  -H 'Content-Type: application/json' \
  -d '{
  "input": {
    "newMin": 1000000000000000000004
  }
}'
{"id":
```

2. The DB insert of the FF operation has the correct value:

```
[2024-09-17T10:51:51.702Z] TRACE SQL-> insert query: INSERT INTO operations (id,namespace,tx_id,optype,opstatus,plugin,created,updated,error,input,output,retry_id) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) (args: [f1aa8675-5018-446c-959e-06d4a7844e0a default 32c056ae-aa63-4042-8bea-9adfdd8982c3 blockchain_invoke Initialized ethereum 2024-09-17T10:51:51.697166508Z 2024-09-17T10:51:51.697166508Z  {"input":{"newMin":1000000000000000000004},"interface":"1875b0b2-e554-4155-9d4b-4bffcde877ad"
```

3. The `input` of the FF response matches the request:

```
{..."type":"blockchain_invoke","status":"Succeeded","plugin":"ethereum","input":{"input":{"newMin":1000000000000000000004},"interface":"1875b0b2-e554-4155-9d4b-4bffcde877ad","key"...}
```

4. The `event` from the blockchain comes back correctly:

```
[2024-09-17T10:51:53.037Z] TRACE WS ws://evmconnect_0:5008/ws read (mt=1): {"batchNumber":9,"events":[{"address":"0xcca8847223ac774e88686f84167060e501c78d0d","blockHash":"0x1ac1955c279c4f94daffcacba235cdeeb05d34ff6d6d958f83c519c5bd538bdd","blockNumber":"47","data":{"newValue":"1000000000000000000004"},"listenerId":"0191eb17-1651-4eb5-1e0b-0072d0621670"
```