### PR TITLE
fix: Clean up manager creation to avoid NPEs during background start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ ARG UI_TAG
 ARG UI_RELEASE
 RUN apk add --update --no-cache \
     sqlite=3.44.2-r0 \
-    postgresql16-client=16.3-r0 \
+    postgresql16-client=16.4-r0 \
     curl=8.9.1-r0 \
     jq=1.7.1-r0
 WORKDIR /firefly

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -160,7 +160,12 @@ func NewContractManager(ctx context.Context, ns string, di database.Plugin, bi b
 	// cause recreation of all the listeners (noting that listeners that were specified to start
 	// from latest, will start from the new latest rather than replaying from the block they
 	// started from before they were deleted).
-	return cm, cm.verifyListeners(ctx)
+	err = cm.verifyListeners(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, nil
 }
 
 func (cm *contractManager) Name() string {

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/definitions/sender.go
+++ b/internal/definitions/sender.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/definitions/sender.go
+++ b/internal/definitions/sender.go
@@ -93,8 +93,12 @@ func NewDefinitionSender(ctx context.Context, ns *core.Namespace, multiparty boo
 		tokenBroadcastNames: tokenBroadcastNames,
 	}
 	dh, err := newDefinitionHandler(ctx, ns, multiparty, di, bi, dx, dm, im, am, cm, reverseMap(tokenBroadcastNames))
+	if err != nil {
+		return nil, nil, err
+	}
+
 	ds.handler = dh
-	return ds, dh, err
+	return ds, dh, nil
 }
 
 // reverseMap reverses the key/values of a given map

--- a/internal/definitions/sender_test.go
+++ b/internal/definitions/sender_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/definitions/sender_test.go
+++ b/internal/definitions/sender_test.go
@@ -105,6 +105,26 @@ func TestInitSenderFail(t *testing.T) {
 	assert.Regexp(t, "FF10128", err)
 }
 
+func TestNewDefinitionSenderHandlerThrows(t *testing.T) {
+	mdi := &databasemocks.Plugin{}
+	mbi := &blockchainmocks.Plugin{}
+	mdx := &dataexchangemocks.Plugin{}
+	mbm := &broadcastmocks.Manager{}
+	mim := &identitymanagermocks.Manager{}
+	mdm := &datamocks.Manager{}
+	mcm := &contractmocks.Manager{}
+
+	tokenBroadcastNames := make(map[string]string)
+	tokenBroadcastNames["connector1"] = "remote1"
+
+	ctx := context.Background()
+	ns := &core.Namespace{Name: "ns1", NetworkName: "ns1"}
+	ds, dh, err := NewDefinitionSender(ctx, ns, false, mdi, mbi, mdx, mbm, mim, mdm, nil, mcm, tokenBroadcastNames)
+	assert.Nil(t, ds)
+	assert.Nil(t, dh)
+	assert.NotNil(t, err)
+}
+
 func TestName(t *testing.T) {
 	ds := newTestDefinitionSender(t)
 	defer ds.cleanup(t)


### PR DESCRIPTION
ref: https://github.com/hyperledger/firefly/issues/1585#issuecomment-2361706076

Without this fix when calling to create a contract manager, it's possible for both the return value and the error value to be non-nil. This ensures that strictly one or the other is set.
https://github.com/hyperledger/firefly/blob/dc97c732e4b07c32b7c60978b79bb0dab98e7460/internal/orchestrator/orchestrator.go#L540

Need to test using the steps provided above to ensure the fix is good (also pending UT coverage).