### PR TITLE
Ignore release candidate tags when determining latest tag for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get the latest tag
         run: |
           git fetch --tags
-          latest_tag=$(git tag -l | sort -V | tail -n 1)
+          latest_tag=$(git tag -l | sort -V | grep -v "rc" | tail -n 1)
           echo "latest tag: $latest_tag"
           echo "LATEST_TAG=$latest_tag" >> $GITHUB_ENV
 


### PR DESCRIPTION
The latests docs release picked up the wrong tag because it took into consideration release candidate versions... https://github.com/hyperledger/firefly/actions/runs/11163270495/job/31029806304 


`grep -v` removes lines with `rc` in them