### PR TITLE
break out of infinite retry for submitted ops

### DIFF
--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -636,6 +636,7 @@ func (bp *batchProcessor) dispatchBatch(payload *DispatchPayload) error {
 				conflictErr, conflictTestOk := err.(operations.ConflictError)
 				if conflictTestOk && conflictErr.IsConflictError() {
 					// We know that the connector has received our batch, so we shouldn't need to retry
+					payload.addMessageUpdate(payload.Messages, core.MessageStateReady, core.MessageStateSent)
 					return true, nil
 				}
 			} else {

--- a/internal/batch/batch_processor.go
+++ b/internal/batch/batch_processor.go
@@ -633,6 +633,11 @@ func (bp *batchProcessor) dispatchBatch(payload *DispatchPayload) error {
 						}
 					}
 				}
+				conflictErr, conflictTestOk := err.(operations.ConflictError)
+				if conflictTestOk && conflictErr.IsConflictError() {
+					// We know that the connector has received our batch, so we shouldn't need to retry
+					return true, nil
+				}
 			} else {
 				if core.IsPinned(payload.Batch.TX.Type) {
 					payload.addMessageUpdate(payload.Messages, core.MessageStateReady, core.MessageStateSent)


### PR DESCRIPTION
Fix for https://github.com/hyperledger/firefly/issues/1594

I've noticed that if there's an error (timeout/disconnect/connection loss) during a BatchPin submission to the blockchain connector (EVMConnect in my case), it's possible for EVMConnect to successfully process the transaction but the FireFly operation will be Failed. Then, the batch processor resubmits the batch but EVMConnect returns a 409, which causes the processor to indefinitely retry and prevent new batches from occurring.

Example error message:

`FF10458: Conflict from blockchain connector: FF21065: ID 'default:f5296ba7-1b23-4c7f-8612-620dafc0e40a' is not unique d=pinned_broadcast ns=default opcache=1UGYM3mn p=did:firefly:org/org_5452a6| pid=61421 role=batchmgr
Currently, the only way to fix this is restarting FireFly.`


Instead, I propose we break the retry loop by having the batch processor not retry on conflict errors. 