### PR TITLE
fix: DB write of upsert pins in run as group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ containerlogs
 .vscode/*.log
 .idea
 doc-site/site
+doc-site/venv


### PR DESCRIPTION
In the case where FireFly is restarted and the listener for BatchPin events is recreated in the blockchain connector, FireFly will re-index all the events into the system. The Pins table has an index for uniqueness of `batch_id+hash+namespace` so it will not allow inserting a duplicate record. In this case, the code falls back to upsetting the batch which is correct but this code is run in the context of DB TX which will never succeed as the previous insert fails.

You get the error `current transaction is aborted, commands ignored until end of transaction block`, explanation at 
https://stackoverflow.com/questions/10399727/psqlexception-current-transaction-is-aborted-commands-ignored-until-end-of-tra why you get this error.

So there are two options:
- When we insert we ignore on conflict, so don't error and we always upsert 
- We upsert using a different DB TX. In this case I achieve this by using a different context

