### PR TITLE
Broken Swagger links in documentation

### DIFF
--- a/doc-site/docs/reference/firefly_interface_format.md
+++ b/doc-site/docs/reference/firefly_interface_format.md
@@ -98,7 +98,7 @@ For example, the Ethereum plugin always needs to know what Solidity type the fie
 
 ## Automated generation of FireFly Interfaces
 
-A convenience endpoint exists on the API to facilitate converting from native blockchain interface formats such as an Ethereum ABI to the FireFly Interface format. For details, please see the <a href="../swagger/swagger.html#/Default%20Namespace/postGenerateContractInterface" data-proofer-ignore>API documentation for the contract interface generation endpoint</a>.
+A convenience endpoint exists on the API to facilitate converting from native blockchain interface formats such as an Ethereum ABI to the FireFly Interface format. For details, please see the <a href="/swagger/#/Default%20Namespace/postGenerateContractInterface" data-proofer-ignore>API documentation for the contract interface generation endpoint</a>.
 
 For an example of using this endpoint with a specific Ethereum contract, please see the [Tutorial to Work with custom smart contracts](../tutorials/custom_contracts/index.md).
 

--- a/doc-site/docs/tutorials/broadcast_data.md
+++ b/doc-site/docs/tutorials/broadcast_data.md
@@ -20,7 +20,7 @@ title: Broadcast data
 ## Additional info
 
 - Key Concepts: [Broadcast / shared data](../overview/multiparty/broadcast.md)
-- Swagger Reference: <a href="../swagger/swagger.html#/Default%20Namespace/postNewMessageBroadcast" data-proofer-ignore>POST /api/v1/namespaces/{ns}/messages/broadcast</a>
+- Swagger Reference: <a href="/swagger/#/Default%20Namespace/postNewMessageBroadcast" data-proofer-ignore>POST /api/v1/namespaces/{ns}/messages/broadcast</a>
 
 ## Example 1: Inline string data
 

--- a/doc-site/docs/tutorials/create_custom_identity.md
+++ b/doc-site/docs/tutorials/create_custom_identity.md
@@ -11,7 +11,7 @@ Out of the box, a FireFly Supernode contains both an `org` and a `node` identity
 ## Additional info
 
 - Reference: [Identities](../reference/identities.md)
-- Swagger: <a href="../swagger/swagger.html#/Default%20Namespace/postNewIdentity" data-proofer-ignore>POST /api/v1/identities</a>
+- Swagger: <a href="/swagger/#/Default%20Namespace/postNewIdentity" data-proofer-ignore>POST /api/v1/identities</a>
 
 ## Previous steps: Start your environment
 

--- a/doc-site/docs/tutorials/define_datatype.md
+++ b/doc-site/docs/tutorials/define_datatype.md
@@ -20,7 +20,7 @@ of datatypes, as is used to broadcast the data itself.
 ## Additional info
 
 - Key Concepts: [Broadcast / shared data](../overview/multiparty/broadcast.md)
-- Swagger: <a href="../swagger/swagger.html#/Default%20Namespace/postNewDatatype" data-proofer-ignore>POST /api/v1/namespaces/{ns}/datatypes</a>
+- Swagger: <a href="/swagger/#/Default%20Namespace/postNewDatatype" data-proofer-ignore>POST /api/v1/namespaces/{ns}/datatypes</a>
 
 ### Example 1: Broadcast new datatype
 

--- a/doc-site/docs/tutorials/private_send.md
+++ b/doc-site/docs/tutorials/private_send.md
@@ -37,7 +37,7 @@ title: Privately send data
 ## Additional info
 
 - Key Concepts: [Private data exchange](../overview/multiparty/data_exchange.md)
-- Swagger: <a href="../swagger/swagger.html#/Default%20Namespace/postNewMessagePrivate" data-proofer-ignore>POST /api/v1/namespaces/{ns}/messages/private</a>
+- Swagger: <a href="/swagger/#/Default%20Namespace/postNewMessagePrivate" data-proofer-ignore>POST /api/v1/namespaces/{ns}/messages/private</a>
 
 ## Example 1: Pinned private send of in-line string data
 

--- a/doc-site/docs/tutorials/query_messages.md
+++ b/doc-site/docs/tutorials/query_messages.md
@@ -17,7 +17,7 @@ This builds on the APIs to query and filter messages, described below
 ## Additional info
 
 - Reference: [API Query Syntax](../reference/api_query_syntax.md)
-- Swagger: <a href="../swagger/swagger.html#/Default%20Namespace/getMsgs" data-proofer-ignore>GET /api/v1/namespaces/{ns}/messages</a>
+- Swagger: <a href="/swagger/#/Default%20Namespace/getMsgs" data-proofer-ignore>GET /api/v1/namespaces/{ns}/messages</a>
 
 ### Example 1: Query confirmed messages
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

Updated the Swagger link structure to omit the `swagger.html` portion and to switch away from using the relative path

e.g. From `https://hyperledger.github.io/firefly/latest/reference/swagger/swagger.html#/Default%20Namespace/postGenerateContractInterface` to `https://hyperledger.github.io/firefly/latest/swagger/#/Default%20Namespace/postGenerateContractInterface`

Fixes #1619 

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix 
- [ ] New feature added
- [x] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] My Pull Request title is in format <code>< issue name ></code> eg <code>Added links in the documentation</code>.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
