### PR TITLE
Updated to upload artifact v4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

Update upload artifact to v4 as v3 has been deprecated. Hoping it resolves this action error https://github.com/hyperledger/firefly/actions/runs/13115525724/job/36588780069


> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.


<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Dependency update
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generates no new warnings.

<hr>
