### PR TITLE
Rename metrics to monitoring to support additional routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ ARG UI_TAG
 ARG UI_RELEASE
 RUN apk add --update --no-cache \
   sqlite=3.44.2-r0 \
-  postgresql16-client=16.6-r0 \
+  postgresql16-client=16.8-r0 \
   curl=8.12.1-r0 \
   jq=1.7.1-r0
 WORKDIR /firefly

--- a/doc-site/docs/reference/config.md
+++ b/doc-site/docs/reference/config.md
@@ -409,14 +409,14 @@ title: Configuration Reference
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
-|address|The IP address on which the metrics HTTP API should listen|`int`|`127.0.0.1`
-|enabled|Enables the metrics API|`boolean`|`true`
-|path|The path from which to serve the Prometheus metrics|`string`|`/metrics`
-|port|The port on which the metrics HTTP API should listen|`int`|`6000`
-|publicURL|The fully qualified public URL for the metrics API. This is used for building URLs in HTTP responses and in OpenAPI Spec generation|URL `string`|`<nil>`
-|readTimeout|The maximum time to wait when reading from an HTTP connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
+|address|Deprecated - use monitoring.address instead|`int`|`127.0.0.1`
+|enabled|Deprecated - use monitoring.enabled instead|`boolean`|`true`
+|path|Deprecated - use monitoring.metricsPath instead|`string`|`/metrics`
+|port|Deprecated - use monitoring.port instead|`int`|`6000`
+|publicURL|Deprecated - use monitoring.publicURL instead|URL `string`|`<nil>`
+|readTimeout|Deprecated - use monitoring.readTimeout instead|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
 |shutdownTimeout|The maximum amount of time to wait for any open HTTP requests to finish before shutting down the HTTP server|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
-|writeTimeout|The maximum time to wait when writing to an HTTP connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
+|writeTimeout|Deprecated - use monitoring.writeTimeout instead|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
 
 ## metrics.auth
 
@@ -431,6 +431,46 @@ title: Configuration Reference
 |passwordfile|The path to a .htpasswd file to use for authenticating requests. Passwords should be hashed with bcrypt.|`string`|`<nil>`
 
 ## metrics.tls
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|ca|The TLS certificate authority in PEM format (this option is ignored if caFile is also set)|`string`|`<nil>`
+|caFile|The path to the CA file for TLS on this API|`string`|`<nil>`
+|cert|The TLS certificate in PEM format (this option is ignored if certFile is also set)|`string`|`<nil>`
+|certFile|The path to the certificate file for TLS on this API|`string`|`<nil>`
+|clientAuth|Enables or disables client auth for TLS on this API|`string`|`<nil>`
+|enabled|Enables or disables TLS on this API|`boolean`|`false`
+|insecureSkipHostVerify|When to true in unit test development environments to disable TLS verification. Use with extreme caution|`boolean`|`<nil>`
+|key|The TLS certificate key in PEM format (this option is ignored if keyFile is also set)|`string`|`<nil>`
+|keyFile|The path to the private key file for TLS on this API|`string`|`<nil>`
+|requiredDNAttributes|A set of required subject DN attributes. Each entry is a regular expression, and the subject certificate must have a matching attribute of the specified type (CN, C, O, OU, ST, L, STREET, POSTALCODE, SERIALNUMBER are valid attributes)|`map[string]string`|`<nil>`
+
+## monitoring
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|address|The IP address on which the metrics HTTP API should listen|`int`|`127.0.0.1`
+|enabled|Enables the metrics API|`boolean`|`true`
+|metricsPath|The path from which to serve the Prometheus metrics|`string`|`/metrics`
+|port|The port on which the metrics HTTP API should listen|`int`|`6000`
+|publicURL|The fully qualified public URL for the metrics API. This is used for building URLs in HTTP responses and in OpenAPI Spec generation|URL `string`|`<nil>`
+|readTimeout|The maximum time to wait when reading from an HTTP connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
+|shutdownTimeout|The maximum amount of time to wait for any open HTTP requests to finish before shutting down the HTTP server|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
+|writeTimeout|The maximum time to wait when writing to an HTTP connection|[`time.Duration`](https://pkg.go.dev/time#Duration)|`15s`
+
+## monitoring.auth
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|type|The auth plugin to use for server side authentication of requests|`string`|`<nil>`
+
+## monitoring.auth.basic
+
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|passwordfile|The path to a .htpasswd file to use for authenticating requests. Passwords should be hashed with bcrypt.|`string`|`<nil>`
+
+## monitoring.tls
 
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|

--- a/internal/apiserver/metrics_server.go
+++ b/internal/apiserver/metrics_server.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -21,11 +21,17 @@ import (
 )
 
 const (
-	MetricsEnabled = "enabled"
-	MetricsPath    = "path"
+	Enabled               = "enabled"
+	DeprecatedMetricsPath = "path"
+	MetricsPath           = "metricsPath"
 )
 
-func initMetricsConfig(config config.Section) {
-	config.AddKnownKey(MetricsEnabled, true)
+func initDeprecatedMetricsConfig(config config.Section) {
+	config.AddKnownKey(Enabled, true)
+	config.AddKnownKey(DeprecatedMetricsPath, "/metrics")
+}
+
+func initMonitoringConfig(config config.Section) {
+	config.AddKnownKey(Enabled, true)
 	config.AddKnownKey(MetricsPath, "/metrics")
 }

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -42,10 +42,11 @@ import (
 )
 
 var (
-	spiConfig     = config.RootSection("spi")
-	apiConfig     = config.RootSection("http")
-	metricsConfig = config.RootSection("metrics")
-	corsConfig    = config.RootSection("cors")
+	spiConfig               = config.RootSection("spi")
+	apiConfig               = config.RootSection("http")
+	deprecatedMetricsConfig = config.RootSection("metrics")
+	monitoringConfig        = config.RootSection("monitoring")
+	corsConfig              = config.RootSection("cors")
 )
 
 // Server is the external interface for the API Server
@@ -55,31 +56,35 @@ type Server interface {
 
 type apiServer struct {
 	// Defaults set with config
-	apiTimeout             time.Duration
-	apiMaxTimeout          time.Duration
-	metricsEnabled         bool
-	ffiSwaggerGen          FFISwaggerGen
-	apiPublicURL           string
-	dynamicPublicURLHeader string
-	defaultNamespace       string
+	apiTimeout               time.Duration
+	apiMaxTimeout            time.Duration
+	deprecatedMetricsEnabled bool
+	monitoringEnabled        bool
+	ffiSwaggerGen            FFISwaggerGen
+	apiPublicURL             string
+	dynamicPublicURLHeader   string
+	defaultNamespace         string
 }
 
 func InitConfig() {
 	httpserver.InitHTTPConfig(apiConfig, 5000)
 	httpserver.InitHTTPConfig(spiConfig, 5001)
-	httpserver.InitHTTPConfig(metricsConfig, 6000)
+	httpserver.InitHTTPConfig(deprecatedMetricsConfig, 6000)
+	httpserver.InitHTTPConfig(monitoringConfig, 6000)
 	httpserver.InitCORSConfig(corsConfig)
-	initMetricsConfig(metricsConfig)
+	initDeprecatedMetricsConfig(deprecatedMetricsConfig)
+	initMonitoringConfig(monitoringConfig)
 }
 
 func NewAPIServer() Server {
 	as := &apiServer{
-		apiTimeout:             config.GetDuration(coreconfig.APIRequestTimeout),
-		apiMaxTimeout:          config.GetDuration(coreconfig.APIRequestMaxTimeout),
-		dynamicPublicURLHeader: config.GetString(coreconfig.APIDynamicPublicURLHeader),
-		defaultNamespace:       config.GetString(coreconfig.NamespacesDefault),
-		metricsEnabled:         config.GetBool(coreconfig.MetricsEnabled),
-		ffiSwaggerGen:          &ffiSwaggerGen{},
+		apiTimeout:               config.GetDuration(coreconfig.APIRequestTimeout),
+		apiMaxTimeout:            config.GetDuration(coreconfig.APIRequestMaxTimeout),
+		dynamicPublicURLHeader:   config.GetString(coreconfig.APIDynamicPublicURLHeader),
+		defaultNamespace:         config.GetString(coreconfig.NamespacesDefault),
+		deprecatedMetricsEnabled: config.GetBool(coreconfig.DeprecatedMetricsEnabled),
+		monitoringEnabled:        config.GetBool(coreconfig.MonitoringEnabled),
+		ffiSwaggerGen:            &ffiSwaggerGen{},
 	}
 	as.apiPublicURL = as.getPublicURL(apiConfig, "")
 	return as
@@ -110,16 +115,23 @@ func (as *apiServer) Serve(ctx context.Context, mgr namespace.Manager) (err erro
 	} else if config.GetBool(coreconfig.LegacyAdminEnabled) {
 		log.L(ctx).Warnf("Your config includes an 'admin' section, which should be renamed to 'spi' - SPI server will not be enabled until this is corrected")
 	}
+	var monitoringServer httpserver.HTTPServer
+	serverName := "metrics"
+	mConfig := deprecatedMetricsConfig
+	if as.monitoringEnabled {
+		serverName = "monitoring"
+		mConfig = monitoringConfig
+	}
 
-	if as.metricsEnabled {
-		metricsHTTPServer, err := httpserver.NewHTTPServer(ctx, "metrics", as.createMetricsMuxRouter(), metricsErrChan, metricsConfig, corsConfig, &httpserver.ServerOptions{
+	if as.deprecatedMetricsEnabled || as.monitoringEnabled {
+		monitoringServer, err = httpserver.NewHTTPServer(ctx, serverName, as.createMonitoringMuxRouter(), metricsErrChan, mConfig, corsConfig, &httpserver.ServerOptions{
 			MaximumRequestTimeout: as.apiMaxTimeout,
 		})
-		if err != nil {
-			return err
-		}
-		go metricsHTTPServer.ServeHTTP(ctx)
 	}
+	if err != nil {
+		return err
+	}
+	go monitoringServer.ServeHTTP(ctx)
 
 	return as.waitForServerStop(httpErrChan, spiErrChan, metricsErrChan)
 }
@@ -345,7 +357,7 @@ func (as *apiServer) createMuxRouter(ctx context.Context, mgr namespace.Manager)
 	r := mux.NewRouter()
 	hf := as.handlerFactory()
 
-	if as.metricsEnabled {
+	if as.deprecatedMetricsEnabled || as.monitoringEnabled {
 		r.Use(metrics.GetRestServerInstrumentation().Middleware)
 	}
 
@@ -433,7 +445,7 @@ func (as *apiServer) spiWSHandler(mgr namespace.Manager) http.HandlerFunc {
 
 func (as *apiServer) createAdminMuxRouter(mgr namespace.Manager) *mux.Router {
 	r := mux.NewRouter()
-	if as.metricsEnabled {
+	if as.deprecatedMetricsEnabled || as.monitoringEnabled {
 		r.Use(metrics.GetAdminServerInstrumentation().Middleware)
 	}
 	hf := as.handlerFactory()
@@ -468,12 +480,20 @@ func (as *apiServer) createAdminMuxRouter(mgr namespace.Manager) *mux.Router {
 	return r
 }
 
-func (as *apiServer) createMetricsMuxRouter() *mux.Router {
+func (as *apiServer) createMonitoringMuxRouter() *mux.Router {
 	r := mux.NewRouter()
-
-	r.Path(config.GetString(coreconfig.MetricsPath)).Handler(promhttp.InstrumentMetricHandler(metrics.Registry(),
+	metricsPath := config.GetString(coreconfig.DeprecatedMetricsPath)
+	if as.monitoringEnabled {
+		metricsPath = config.GetString(coreconfig.MonitoringMetricsPath)
+	}
+	r.Path(metricsPath).Handler(promhttp.InstrumentMetricHandler(metrics.Registry(),
 		promhttp.HandlerFor(metrics.Registry(), promhttp.HandlerOpts{})))
-
+	hf := ffapi.HandlerFactory{}
+	r.HandleFunc("/livez", hf.APIWrapper(func(res http.ResponseWriter, req *http.Request) (status int, err error) {
+		// a simple liveness check
+		return http.StatusOK, nil
+	}))
+	r.NotFoundHandler = hf.APIWrapper(as.notFoundHandler)
 	return r
 }
 

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -182,20 +182,6 @@ func TestStartMetricsFail(t *testing.T) {
 	assert.Regexp(t, "FF00151", err)
 }
 
-func TestMonitoringServerRoutes(t *testing.T) {
-	_, _, as := newTestServer()
-	s := httptest.NewServer(as.createMonitoringMuxRouter())
-	defer s.Close()
-
-	res, err := http.Get(fmt.Sprintf("http://%s/livez", s.Listener.Addr()))
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	res, err = http.Get(fmt.Sprintf("http://%s/metrics", s.Listener.Addr()))
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
-
 func TestNotFound(t *testing.T) {
 	_, _, as := newTestServer()
 	handler := as.handlerFactory().APIWrapper(as.notFoundHandler)
@@ -588,4 +574,18 @@ func TestContractAPIDefaultNS(t *testing.T) {
 		Get(fmt.Sprintf("http://%s/api/v1/apis", s.Listener.Addr()))
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode())
+}
+
+func TestMonitoringServerRoutes(t *testing.T) {
+	_, _, as := newTestServer()
+	s := httptest.NewServer(as.createMonitoringMuxRouter())
+	defer s.Close()
+
+	res, err := http.Get(fmt.Sprintf("http://%s/livez", s.Listener.Addr()))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	res, err = http.Get(fmt.Sprintf("http://%s/metrics", s.Listener.Addr()))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
 }

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -86,7 +86,7 @@ func TestStartStopServer(t *testing.T) {
 	InitConfig()
 	apiConfig.Set(httpserver.HTTPConfPort, 0)
 	spiConfig.Set(httpserver.HTTPConfPort, 0)
-	metricsConfig.Set(httpserver.HTTPConfPort, 0)
+	monitoringConfig.Set(httpserver.HTTPConfPort, 0)
 	config.Set(coreconfig.UIPath, "test")
 	config.Set(coreconfig.SPIEnabled, true)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -105,7 +105,7 @@ func TestStartLegacyAdminConfig(t *testing.T) {
 	InitConfig()
 	apiConfig.Set(httpserver.HTTPConfPort, 0)
 	spiConfig.Set(httpserver.HTTPConfPort, 0)
-	metricsConfig.Set(httpserver.HTTPConfPort, 0)
+	monitoringConfig.Set(httpserver.HTTPConfPort, 0)
 	config.Set(coreconfig.UIPath, "test")
 	config.Set(coreconfig.LegacyAdminEnabled, true)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -170,8 +170,8 @@ func TestStartMetricsFail(t *testing.T) {
 	coreconfig.Reset()
 	metrics.Clear()
 	InitConfig()
-	metricsConfig.Set(httpserver.HTTPConfAddress, "...://")
-	config.Set(coreconfig.MetricsEnabled, true)
+	monitoringConfig.Set(httpserver.HTTPConfAddress, "...://")
+	config.Set(coreconfig.MonitoringEnabled, true)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // server will immediately shut down
 	as := NewAPIServer()
@@ -180,6 +180,20 @@ func TestStartMetricsFail(t *testing.T) {
 	mgr.On("SPIEvents").Return(mae)
 	err := as.Serve(ctx, mgr)
 	assert.Regexp(t, "FF00151", err)
+}
+
+func TestMonitoringServerRoutes(t *testing.T) {
+	_, _, as := newTestServer()
+	s := httptest.NewServer(as.createMonitoringMuxRouter())
+	defer s.Close()
+
+	res, err := http.Get(fmt.Sprintf("http://%s/livez", s.Listener.Addr()))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	res, err = http.Get(fmt.Sprintf("http://%s/metrics", s.Listener.Addr()))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
 }
 
 func TestNotFound(t *testing.T) {

--- a/internal/coreconfig/coreconfig.go
+++ b/internal/coreconfig/coreconfig.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -287,10 +287,14 @@ var (
 	MessageWriterBatchTimeout = ffc("message.writer.batchTimeout")
 	// MessageWriterBatchMaxInserts
 	MessageWriterBatchMaxInserts = ffc("message.writer.batchMaxInserts")
-	// MetricsEnabled determines whether metrics will be instrumented and if the metrics server will be enabled or not
-	MetricsEnabled = ffc("metrics.enabled")
+	// MetricsEnabled - deprecated, use monitoring.enabled
+	DeprecatedMetricsEnabled = ffc("metrics.enabled")
+	// MetricsPath - deprecated, use monitoring.metricsPath
+	DeprecatedMetricsPath = ffc("metrics.path")
+	// Monitoring determines whether monitoring routes will be enabled, which contains metrics instruments
+	MonitoringEnabled = ffc("monitoring.enabled")
 	// MetricsPath determines what path to serve the Prometheus metrics from
-	MetricsPath = ffc("metrics.path")
+	MonitoringMetricsPath = ffc("monitoring.metricsPath")
 	// NamespacesDefault is the default namespace - must be in the predefines list
 	NamespacesDefault = ffc("namespaces.default")
 	// NamespacesPredefined is a list of namespaces to ensure exists, without requiring a broadcast from the network

--- a/internal/coremsgs/en_config_descriptions.go
+++ b/internal/coremsgs/en_config_descriptions.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -320,13 +320,21 @@ var (
 	ConfigTransactionWriterBatchTimeout         = ffc("config.transaction.writer.batchTimeout", "How long to wait for more transactions to arrive before flushing the batch", i18n.TimeDurationType)
 	ConfigTransactionWriterCount                = ffc("config.transaction.writer.count", "The number of message writer workers", i18n.IntType)
 
-	ConfigMetricsAddress      = ffc("config.metrics.address", "The IP address on which the metrics HTTP API should listen", i18n.IntType)
-	ConfigMetricsEnabled      = ffc("config.metrics.enabled", "Enables the metrics API", i18n.BooleanType)
-	ConfigMetricsPath         = ffc("config.metrics.path", "The path from which to serve the Prometheus metrics", i18n.StringType)
-	ConfigMetricsPort         = ffc("config.metrics.port", "The port on which the metrics HTTP API should listen", i18n.IntType)
-	ConfigMetricsPublicURL    = ffc("config.metrics.publicURL", "The fully qualified public URL for the metrics API. This is used for building URLs in HTTP responses and in OpenAPI Spec generation", urlStringType)
-	ConfigMetricsReadTimeout  = ffc("config.metrics.readTimeout", "The maximum time to wait when reading from an HTTP connection", i18n.TimeDurationType)
-	ConfigMetricsWriteTimeout = ffc("config.metrics.writeTimeout", "The maximum time to wait when writing to an HTTP connection", i18n.TimeDurationType)
+	DeprecatedConfigMetricsAddress      = ffc("config.metrics.address", "Deprecated - use monitoring.address instead", i18n.IntType)
+	DeprecatedConfigMetricsEnabled      = ffc("config.metrics.enabled", "Deprecated - use monitoring.enabled instead", i18n.BooleanType)
+	DeprecatedConfigMetricsPath         = ffc("config.metrics.path", "Deprecated - use monitoring.metricsPath instead", i18n.StringType)
+	DeprecatedConfigMetricsPort         = ffc("config.metrics.port", "Deprecated - use monitoring.port instead", i18n.IntType)
+	DeprecatedConfigMetricsPublicURL    = ffc("config.metrics.publicURL", "Deprecated - use monitoring.publicURL instead", urlStringType)
+	DeprecatedConfigMetricsReadTimeout  = ffc("config.metrics.readTimeout", "Deprecated - use monitoring.readTimeout instead", i18n.TimeDurationType)
+	DeprecatedConfigMetricsWriteTimeout = ffc("config.metrics.writeTimeout", "Deprecated - use monitoring.writeTimeout instead", i18n.TimeDurationType)
+
+	ConfigMetricsAddress      = ffc("config.monitoring.address", "The IP address on which the metrics HTTP API should listen", i18n.IntType)
+	ConfigMetricsEnabled      = ffc("config.monitoring.enabled", "Enables the metrics API", i18n.BooleanType)
+	ConfigMetricsPath         = ffc("config.monitoring.metricsPath", "The path from which to serve the Prometheus metrics", i18n.StringType)
+	ConfigMetricsPort         = ffc("config.monitoring.port", "The port on which the metrics HTTP API should listen", i18n.IntType)
+	ConfigMetricsPublicURL    = ffc("config.monitoring.publicURL", "The fully qualified public URL for the metrics API. This is used for building URLs in HTTP responses and in OpenAPI Spec generation", urlStringType)
+	ConfigMetricsReadTimeout  = ffc("config.monitoring.readTimeout", "The maximum time to wait when reading from an HTTP connection", i18n.TimeDurationType)
+	ConfigMetricsWriteTimeout = ffc("config.monitoring.writeTimeout", "The maximum time to wait when writing to an HTTP connection", i18n.TimeDurationType)
 
 	ConfigNamespacesDefault                    = ffc("config.namespaces.default", "The default namespace - must be in the predefined list", i18n.StringType)
 	ConfigNamespacesPredefined                 = ffc("config.namespaces.predefined", "A list of namespaces to ensure exists, without requiring a broadcast from the network", "List "+i18n.StringType)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -54,7 +54,7 @@ type metricsManager struct {
 func NewMetricsManager(ctx context.Context) Manager {
 	mm := &metricsManager{
 		ctx:            ctx,
-		metricsEnabled: config.GetBool(coreconfig.MetricsEnabled),
+		metricsEnabled: config.GetBool(coreconfig.DeprecatedMetricsEnabled) || config.GetBool(coreconfig.MonitoringEnabled),
 		timeMap:        make(map[string]time.Time),
 	}
 

--- a/internal/namespace/manager.go
+++ b/internal/namespace/manager.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -161,7 +161,7 @@ func stringSlicesEqual(a, b []string) bool {
 func NewNamespaceManager() Manager {
 	nm := &namespaceManager{
 		namespaces:          make(map[string]*namespace),
-		metricsEnabled:      config.GetBool(coreconfig.MetricsEnabled),
+		metricsEnabled:      config.GetBool(coreconfig.DeprecatedMetricsEnabled) || config.GetBool(coreconfig.MonitoringEnabled),
 		tokenBroadcastNames: make(map[string]string),
 		watchConfig:         viper.WatchConfig,
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

As elaborated in https://github.com/hyperledger/firefly-common/pull/167, there is a need to expose more endpoints for operational checks. 


This PR propose a new `monitoring` sections in the configuration file for configurations of the monitoring server:
- whether to enable the monitoring server
- a `metricsPath`

The new monitoring server itself is a replacement for the existing metrics server.
- Expose a liveness check route
- Expose the metrics routes


As a result the existing `metrics` section is marked as deprecated.

Adding monitoring routes for the latest best practices. The existing `metrics` config is marked as deprecated.

The FireFly API path has been split into `api` and `spi` and then namespaced `api`. So adopting the common utils will need some dedicated time, which I didn't manage to do.

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix 
- [x] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [?] My Pull Request title is in format <code>< issue name ></code> eg <code>Added links in the documentation</code>.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
