### PR TITLE
Update postgresql16-client to fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ ARG UI_TAG
 ARG UI_RELEASE
 RUN apk add --update --no-cache \
   sqlite=3.44.2-r0 \
-  postgresql16-client=16.6-r0 \
+  postgresql16-client=16.8-r0 \
   curl=8.12.1-r0 \
   jq=1.7.1-r0
 WORKDIR /firefly


### PR DESCRIPTION
## Proposed changes

Bump the `postgresql16-client` version used in the dockerfile, to one which doesn't conflict with the base image.

<hr>

## Types of changes

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] My Pull Request title is in format <code>< issue name ></code> eg <code>Added links in the documentation</code>.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

It might be a good idea to "pin" the manifest's base image: https://github.com/hyperledger/firefly/blob/d87917df2c67960b36fbfdbec4efad93a0732e6b/manifest.json#L53-L55 to `alpine:3.19.7`. It's not pinned to a specific patch right now, and this is the second time a patch update has broken the pinned dependency versions in the dockerfile.
