### PR TITLE
[dataexchange] Fixing Deadlock on Reconnect

### DIFF
--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -305,11 +305,12 @@ func (h *FFDX) beforeConnect(ctx context.Context, w wsclient.WSClient) error {
 		}
 	}
 
+	h.initialized = true
+
 	for _, cb := range h.callbacks.handlers {
 		cb.DXConnect(h)
 	}
 
-	h.initialized = true
 	return nil
 }
 
@@ -463,10 +464,6 @@ func (h *FFDX) TransferBlob(ctx context.Context, nsOpID string, peer, sender fft
 }
 
 func (h *FFDX) CheckNodeIdentityStatus(ctx context.Context, node *core.Identity) error {
-	if err := h.checkInitialized(ctx); err != nil {
-		return err
-	}
-
 	if node == nil {
 		return i18n.NewError(ctx, coremsgs.MsgNodeNotProvidedForCheck)
 	}

--- a/internal/dataexchange/ffdx/ffdx_test.go
+++ b/internal/dataexchange/ffdx/ffdx_test.go
@@ -1102,17 +1102,9 @@ BAYTAkFVMRMwEQYDVQQIDApxdWVlbnNsYW5kMREwDwYDVQQHDAhCcm9va2ZpZWxk
 	assert.ErrorContains(t, err, "failed to parse non-certificate within bundle")
 }
 
-func TestCheckNodeIdentityStatusReturnsErrorWhenNotInitialized(t *testing.T) {
-	h := &FFDX{initialized: false}
-	err := h.CheckNodeIdentityStatus(context.Background(), &core.Identity{})
-	assert.Regexp(t, "FF10342", err)
-}
-
 func TestCheckNodeIdentityStatusNodeNil(t *testing.T) {
 	mmm := metricsmocks.NewManager(t)
-
-	h := &FFDX{initialized: true, metrics: mmm}
-
+	h := &FFDX{metrics: mmm}
 	err := h.CheckNodeIdentityStatus(context.Background(), nil)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

If you restart a DX FF is connected to, it will cause FF to initialize and reconnect to it.

But with the recent https://github.com/hyperledger/firefly/pull/1652, we want to check the node's identity status relative to the DX config, but we wrongfully checked if the DX plugin was initialized - causing a deadlock since during reconnect we are holding the lock that re-initializes the plugin 🔁 .

It's safe to check the node identity status when we are not initialized since it is the same thing as GetEndpointInfo with some extra work.

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] My Pull Request title is in format <code>< issue name ></code> eg <code>Added links in the documentation</code>.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

See https://github.com/kaleido-io/firefly/pull/125 for original downstream fix.
