### PR TITLE
fix: test has race condition on ws before connect with DX callbacks

### DIFF
--- a/internal/dataexchange/ffdx/ffdx_test.go
+++ b/internal/dataexchange/ffdx/ffdx_test.go
@@ -22,13 +22,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hyperledger/firefly/internal/metrics"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hyperledger/firefly/internal/metrics"
 
 	"github.com/hyperledger/firefly/mocks/metricsmocks"
 
@@ -780,6 +781,12 @@ func TestEventsWithManifest(t *testing.T) {
 	h, toServer, fromServer, _, done := newTestFFDX(t, true)
 	defer done()
 
+	mcb := &dataexchangemocks.Callbacks{}
+	mcb.On("DXConnect", h).Return(nil)
+	h.SetHandler("ns1", "node1", mcb)
+	ocb := &coremocks.OperationCallbacks{}
+	h.SetOperationHandler("ns1", ocb)
+
 	err := h.Start()
 	assert.NoError(t, err)
 
@@ -787,11 +794,6 @@ func TestEventsWithManifest(t *testing.T) {
 	fromServer <- `{"id":"0"}` // ignored with ack
 	msg := <-toServer
 	assert.Equal(t, `{"action":"ack","id":"0"}`, string(msg))
-
-	mcb := &dataexchangemocks.Callbacks{}
-	h.SetHandler("ns1", "node1", mcb)
-	ocb := &coremocks.OperationCallbacks{}
-	h.SetOperationHandler("ns1", ocb)
 
 	namespacedID1 := fmt.Sprintf("ns1:%s", fftypes.NewUUID())
 	ocb.On("OperationUpdate", mock.MatchedBy(func(ev *core.OperationUpdateAsync) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

Fixes https://github.com/hyperledger/firefly/pull/1636#issuecomment-2717572967

`h.Start()` create the WS connection and in the before connect we added a callback handler `DXConnect()`. The test used to connect then add the handlers so sometimes the test might take longer so on reconnect the handler would be there but not the DXConnect mock. 

Actually the test should add all the handlers before staring the FFDX plugin, this is the fix.

FYI @onelapahead 

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>
