### PR TITLE
Make new monitoring config to be disabled by default

### DIFF
--- a/doc-site/docs/reference/config.md
+++ b/doc-site/docs/reference/config.md
@@ -450,7 +450,7 @@ title: Configuration Reference
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
 |address|The IP address on which the metrics HTTP API should listen|`int`|`127.0.0.1`
-|enabled|Enables the metrics API|`boolean`|`true`
+|enabled|Enables the metrics API|`boolean`|`false`
 |metricsPath|The path from which to serve the Prometheus metrics|`string`|`/metrics`
 |port|The port on which the metrics HTTP API should listen|`int`|`6000`
 |publicURL|The fully qualified public URL for the metrics API. This is used for building URLs in HTTP responses and in OpenAPI Spec generation|URL `string`|`<nil>`

--- a/internal/apiserver/metrics_server.go
+++ b/internal/apiserver/metrics_server.go
@@ -32,6 +32,6 @@ func initDeprecatedMetricsConfig(config config.Section) {
 }
 
 func initMonitoringConfig(config config.Section) {
-	config.AddKnownKey(Enabled, true)
+	config.AddKnownKey(Enabled, false)
 	config.AddKnownKey(MetricsPath, "/metrics")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes


Fixes issue discussed in https://discord.com/channels/905194001349627914/1351566571050504222/1351611062910451742

~Switch logic to direct access to the config.Sections to ensure access to the loaded configuration data are not lost~

We later found that's not the case^^

So the bug is the logic was unable to determine whether the YAML has opted into the new `monitoring` configuration or not because it's enabled by default. Therefore, the logic ignored the old `metrics` configuration altogether. 

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [na] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
