### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/internal/reference/reference.go
+++ b/internal/reference/reference.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
@@ -892,17 +893,11 @@ func writeStructFields(ctx context.Context, t reflect.Type, rootPageNames, simpl
 
 		fieldInRootPages := false
 		fieldInSimpleTypes := false
-		for _, rootPageName := range rootPageNames {
-			if strings.ToLower(fieldType.Name()) == rootPageName {
-				fieldInRootPages = true
-				break
-			}
+		if slices.Contains(rootPageNames, strings.ToLower(fieldType.Name())) {
+			fieldInRootPages = true
 		}
-		for _, simpleTypeName := range simpleTypeNames {
-			if strings.ToLower(fieldType.Name()) == simpleTypeName {
-				fieldInSimpleTypes = true
-				break
-			}
+		if slices.Contains(simpleTypeNames, strings.ToLower(fieldType.Name())) {
+			fieldInSimpleTypes = true
 		}
 
 		link := ""
@@ -920,13 +915,7 @@ func writeStructFields(ctx context.Context, t reflect.Type, rootPageNames, simpl
 			fireflyType = fmt.Sprintf("[%s](%s)", fireflyType, link)
 
 			// Generate the table for the sub type
-			tableAlreadyGenerated := false
-			for _, tableName := range generatedTableNames {
-				if strings.ToLower(fieldType.Name()) == tableName {
-					tableAlreadyGenerated = true
-					break
-				}
-			}
+			tableAlreadyGenerated := slices.Contains(generatedTableNames, strings.ToLower(fieldType.Name()))
 			if isStruct && !tableAlreadyGenerated && !fieldInRootPages && !fieldInSimpleTypes {
 				subFieldBuff.WriteString(fmt.Sprintf("## %s\n\n", fieldType.Name()))
 				subFieldMarkdown, newTableNames, _ := generateObjectReferenceMarkdown(ctx, false, nil, fieldType, rootPageNames, simpleTypeNames, generatedTableNames, outputPath)

--- a/internal/spievents/websockets.go
+++ b/internal/spievents/websockets.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"slices"
 	"sync"
 	"time"
 
@@ -66,36 +67,18 @@ func newWebSocket(ae *adminEventManager, wsConn *websocket.Conn) *webSocket {
 }
 
 func (wc *webSocket) eventMatches(changeEvent *core.ChangeEvent) bool {
-	collectionMatches := false
-	for _, c := range wc.collections {
-		if c == changeEvent.Collection {
-			collectionMatches = true
-			break
-		}
-	}
+	collectionMatches := slices.Contains(wc.collections, changeEvent.Collection)
 	if !collectionMatches {
 		return false
 	}
 	if len(wc.filter.Namespaces) > 0 {
-		namespaceMatches := false
-		for _, ns := range wc.filter.Namespaces {
-			if ns == changeEvent.Namespace {
-				namespaceMatches = true
-				break
-			}
-		}
+		namespaceMatches := slices.Contains(wc.filter.Namespaces, changeEvent.Namespace)
 		if !namespaceMatches {
 			return false
 		}
 	}
 	if len(wc.filter.Types) > 0 {
-		typeMatches := false
-		for _, t := range wc.filter.Types {
-			if t == changeEvent.Type {
-				typeMatches = true
-				break
-			}
-		}
+		typeMatches := slices.Contains(wc.filter.Types, changeEvent.Type)
 		if !typeMatches {
 			return false
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generates no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
