### PR TITLE
Add manifest.json to release artifacts

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -107,3 +107,21 @@ jobs:
             UI_RELEASE=${{ steps.manifest.outputs.UI_RELEASE }}
             BUILD_VERSION=${{ steps.build_tag_generator.outputs.RELEASE_TAG }}
             GIT_REF=${{ github.ref }}
+
+      - name: Ensure manifest.json exists
+        run: |
+          if [ ! -f manifest.json ]; then
+            echo "manifest.json not found in repo root - generating via manifestgen.sh"
+            ./manifestgen.sh || true
+          fi
+
+      - name: Upload manifest.json to GitHub Release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./manifest.json
+          asset_name: manifest.json
+          asset_content_type: application/json


### PR DESCRIPTION
Ensure the `manifest.json` file is generated if it does not exist and upload it as part of the GitHub release process.

It fixes #1706