### PR TITLE
Add eyecatcher log lines at info-level for transaction lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ FROM alpine:3.21 AS sbom
 WORKDIR /
 ADD . /SBOM
 RUN apk add --no-cache curl
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.48.3
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.68.1
 RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
 RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --db-repository public.ecr.aws/aquasecurity/trivy-db --exit-code 1
 

--- a/internal/operations/operation_updater.go
+++ b/internal/operations/operation_updater.go
@@ -270,7 +270,9 @@ func (ou *operationUpdater) doBatchUpdate(ctx context.Context, updates []*core.O
 			if err != nil {
 				return err
 			}
-			transactions = append(transactions, transaction)
+			if transaction != nil {
+				transactions = append(transactions, transaction)
+			}
 		}
 	}
 

--- a/internal/operations/operation_updater.go
+++ b/internal/operations/operation_updater.go
@@ -335,7 +335,7 @@ func (ou *operationUpdater) doUpdate(ctx context.Context, update *core.Operation
 	// - The idempotencyKey
 	// - The FF Transaction ID
 	// - The Operation ID
-	log.L(ctx).Infof("FF_OPERATION_UPDATE: plugin=%s type=%s status=%s operationId=%s transactionId=%s idempotencyKey='%s'", op.Plugin, op.Type, update.Status, op.ID, txnIDStr, idempotencyKeyStr)
+	log.L(ctx).Infof("FF_OPERATION_UPDATE: namespace=%s plugin=%s type=%s status=%s operationId=%s transactionId=%s idempotencyKey='%s'", op.Namespace, op.Plugin, op.Type, update.Status, op.ID, txnIDStr, idempotencyKeyStr)
 
 	if handler, ok := ou.manager.handlers[op.Type]; ok {
 		if err := handler.OnOperationUpdate(ctx, op, update); err != nil {

--- a/internal/txwriter/txwriter.go
+++ b/internal/txwriter/txwriter.go
@@ -212,6 +212,14 @@ func (tw *txWriter) processBatch(ctx context.Context, batch *txWriterBatch) erro
 			for _, op := range req.operations {
 				op.Transaction = txn.ID
 				operations = append(operations, op)
+
+				// This is a key log line, where we can provide all pieces of correlation data a user needs:
+				// - The type of the operation
+				// - The plugin/connector
+				// - The idempotencyKey
+				// - The FF Transaction ID
+				// - The Operation ID
+				log.L(ctx).Infof("FF_NEW_TRANSACTION_OPERATION: plugin=%s type=%s operationId=%s transactionId=%s idempotencyKey='%s'", op.Plugin, op.Type, op.ID, txn.ID, txn.IdempotencyKey)
 			}
 		}
 	}

--- a/internal/txwriter/txwriter.go
+++ b/internal/txwriter/txwriter.go
@@ -219,7 +219,7 @@ func (tw *txWriter) processBatch(ctx context.Context, batch *txWriterBatch) erro
 				// - The idempotencyKey
 				// - The FF Transaction ID
 				// - The Operation ID
-				log.L(ctx).Infof("FF_NEW_TRANSACTION_OPERATION: plugin=%s type=%s operationId=%s transactionId=%s idempotencyKey='%s'", op.Plugin, op.Type, op.ID, txn.ID, txn.IdempotencyKey)
+				log.L(ctx).Infof("FF_NEW_TRANSACTION_OPERATION: namespace=%s plugin=%s type=%s operationId=%s transactionId=%s idempotencyKey='%s'", op.Namespace, op.Plugin, op.Type, op.ID, txn.ID, txn.IdempotencyKey)
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Add eyecatcher logs such as the following, that can be used as anchors for diagnosing transaction paths.
Particularly for `blockchain_invoke` transactions, it is important to see when the transaction came in, and correlate that with the connector for the plugin. This means correlating the `idempotencyKey` (app identifier), `transactionId` (overall FireFly transaction ID) and `operationId` (unique ID used with the blockchain connector).

```
[2025-12-11T17:26:24.742Z]  INFO FF_NEW_TRANSACTION_OPERATION: namespace=default plugin=ethereum type=blockchain_invoke operationId=02cc00a1-ad7f-4b53-b6cd-cbe22614bd4d transactionId=82061ac0-2364-4f03-8d1b-dbe9a0e4b865 idempotencyKey='' batch= dbtx=BnBpmsR1 httpreq=szeEliLI pid=1 req=DAkLlQnQ
[2025-12-11T17:26:24.750Z]  INFO FF_OPERATION_UPDATE: namespace=default plugin=ethereum type=blockchain_invoke status=Pending operationId=02cc00a1-ad7f-4b53-b6cd-cbe22614bd4d transactionId=82061ac0-2364-4f03-8d1b-dbe9a0e4b865 idempotencyKey='' dbtx=jsMMbdLq ns=default pid=1
[2025-12-11T17:26:24.881Z]  INFO FF_OPERATION_UPDATE: namespace=default plugin=ethereum type=blockchain_invoke status=Succeeded operationId=02cc00a1-ad7f-4b53-b6cd-cbe22614bd4d transactionId=82061ac0-2364-4f03-8d1b-dbe9a0e4b865 idempotencyKey='' dbtx=rITEYeqS ns=default pid=1
```

- [ ] Bug fix 
- [x] New feature added
- [ ] Documentation Update 

<hr>

- [x] I have read the contributing guidelines.
- [ x I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

