### PR TITLE
remove version from trivy install as version no longer supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ FROM alpine:3.21 AS sbom
 WORKDIR /
 ADD . /SBOM
 RUN apk add --no-cache curl
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.68.1
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
 RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --db-repository public.ecr.aws/aquasecurity/trivy-db --exit-code 1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

updste Dcokerfile to remove specific version in trivy install.
Trivy version was no longer supported. 
no version will install latest and works

Fixes # <issue_number_here>

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.


<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
