### PR TITLE
docs: fix typo in FireFly badge and broken docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/hyperledger/firefly/branch/main/graph/badge.svg?token=QdEnpMqB1G)](https://codecov.io/gh/hyperledger/firefly)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger/firefly)](https://goreportcard.com/report/github.com/hyperledger/firefly)
-[![FireFy Documentation](https://img.shields.io/static/v1?label=FireFly&message=documentation&color=informational)](https://hyperledger.github.io/firefly//)
+[![lFireFy Documentation](https://img.shields.io/static/v1?label=FireFly&message=documentation&color=informational)](https://hyperledger.github.io/firefly/)
 ![build](https://github.com/hyperledger/firefly/actions/workflows/docker_main.yml/badge.svg?branch=main)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7826/badge)](https://www.bestpractices.dev/projects/7826)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyperledger/firefly/badge)](https://scorecard.dev/viewer/?uri=github.com/hyperledger/firefly)


### PR DESCRIPTION
Fixed two small issues I noticed while browsing the README:

1. The FireFly documentation badge was displaying as "FireFy" instead of "FireFly" in the label text and URL parameter.
2. The documentation link had a double slash (firefly//) which is a minor URL formatting issue.

These are low-risk changes that should make the badges and links render correctly for new users checking out the project.

<!--  Thanks for sending a pull request! -->

## Proposed changes

Please include a summary of the changes here and why we need those changes. And also let us know which issue is fixed. 

Fixes # <issue_number_here>

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] I have read the contributing guidelines.
- [ ] I have performed a self-review of my own code or work.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generates no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
